### PR TITLE
Fencepost error in ERF extension header handling

### DIFF
--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -202,7 +202,7 @@ dag_erf_ext_header_count(uint8_t * erf, size_t len)
 	do {
 	
 		/* sanity check we have enough bytes */
-		if ( len <= (24 + (hdr_num * 8)) )
+		if ( len < (24 + (hdr_num * 8)) )
 			return hdr_num;
 
 		/* get the header type */


### PR DESCRIPTION
If an ERF record has 0 'payload' bytes the last extension header will not be counted and the header length will be calculated incorrectly.
