### PR TITLE
Add 2 new TCP flags per RFC 3168.

### DIFF
--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -876,7 +876,8 @@ The following ICMP type field values are available: \fBicmp-echoreply\fP,
 
 The following TCP flags field values are available: \fBtcp-fin\fP,
 \fBtcp-syn\fP, \fBtcp-rst\fP, \fBtcp-push\fP,
-\fBtcp-ack\fP, \fBtcp-urg\fP.
+\fBtcp-ack\fP, \fBtcp-urg\fP, \fBtcp-ece\fP,
+\fBtcp-cwr\fP.
 .LP
 Primitives may be combined using:
 .IP

--- a/scanner.l
+++ b/scanner.l
@@ -435,6 +435,8 @@ tcp-rst			{ yylval->i = 0x04; return NUM; }
 tcp-push		{ yylval->i = 0x08; return NUM; }
 tcp-ack			{ yylval->i = 0x10; return NUM; }
 tcp-urg			{ yylval->i = 0x20; return NUM; }
+tcp-ece			{ yylval->i = 0x40; return NUM; }
+tcp-cwr			{ yylval->i = 0x80; return NUM; }
 [A-Za-z0-9]([-_.A-Za-z0-9]*[.A-Za-z0-9])? {
 			 yylval->s = sdup(yyextra, (char *)yytext); return ID; }
 "\\"[^ !()\n\t]+	{ yylval->s = sdup(yyextra, (char *)yytext + 1); return ID; }


### PR DESCRIPTION
Add ECE, CWR and NS bits for TCP header, defined in RFC 3168 and RFC 3540.
