### PR TITLE
Bluetooth devices not available for capture

### DIFF
--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -80,7 +80,6 @@ struct pcap_bt {
 int 
 bt_findalldevs(pcap_if_t **alldevsp, char *err_str)
 {
-	pcap_if_t *found_dev = *alldevsp;
 	struct hci_dev_list_req *dev_list;
 	struct hci_dev_req *dev_req;
 	int i, sock;
@@ -124,7 +123,7 @@ bt_findalldevs(pcap_if_t **alldevsp, char *err_str)
 		snprintf(dev_name, 20, BT_IFACE"%d", dev_req->dev_id);
 		snprintf(dev_descr, 30, "Bluetooth adapter number %d", i);
 			
-		if (pcap_add_if(&found_dev, dev_name, 0, 
+		if (pcap_add_if(alldevsp, dev_name, 0, 
 		       dev_descr, err_str) < 0)
 		{
 			ret = -1;


### PR DESCRIPTION
Trying to capture from my bluetooth with wireshark, I couldn't find my adapter. Here is what I got when running `dumpcap -D` under root user:

```
1. usbmon1
2. usbmon2
3. usbmon3
4. usbmon4
5. p5p1
6. p6p1
7. any
8. lo (Loopback)
```

Digged in and turns out that `add_or_find_if()` in `inet.c` adds my bluetooth adapter to top of the list based on its rules. But `bt_findalldevs()` in `pcap-bt-linux.c` doesn't update `alldevsp` so the caller cannot see the added item. The only way `bt_findalldevs()` would work is if the bluetooth adapters are added to the list somewhere below the first item. And I assume in tests, this has been the case to date (as the source code seem to have been the same for past 7 years).

I have done a smoke test of running `dumpcap` and the wireshark GUI with this patch to capture HCI packets and it works fine.
