### PR TITLE
Remove BlueZ dependence

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -256,9 +256,6 @@
 /* target host supports Bluetooth sniffing */
 #undef PCAP_SUPPORT_BT
 
-/* target host supports Bluetooth Monitor */
-#undef PCAP_SUPPORT_BT_MONITOR
-
 /* target host supports CAN sniffing */
 #undef PCAP_SUPPORT_CAN
 
@@ -276,9 +273,6 @@
 
 /* include ACN support */
 #undef SITA
-
-/* if struct sockaddr_hci has hci_channel member */
-#undef SOCKADDR_HCI_HAS_HCI_CHANNEL
 
 /* Define to 1 if you have the ANSI C header files. */
 #undef STDC_HEADERS

--- a/configure
+++ b/configure
@@ -8005,109 +8005,21 @@ fi
 
 
 if test "x$enable_bluetooth" != "xno" ; then
-		case "$host_os" in
-	linux*)
-		ac_fn_c_check_header_mongrel "$LINENO" "bluetooth/bluetooth.h" "ac_cv_header_bluetooth_bluetooth_h" "$ac_includes_default"
-if test "x$ac_cv_header_bluetooth_bluetooth_h" = xyes; then :
-
+        case "$host_os" in
+    linux*)
 
 $as_echo "#define PCAP_SUPPORT_BT 1" >>confdefs.h
 
-		  BT_SRC=pcap-bt-linux.c
-		  { $as_echo "$as_me:${as_lineno-$LINENO}: Bluetooth sniffing is supported" >&5
+        BT_SRC=pcap-bt-linux.c
+        BT_MONITOR_SRC=pcap-bt-monitor-linux.c
+        { $as_echo "$as_me:${as_lineno-$LINENO}: Bluetooth sniffing is supported" >&5
 $as_echo "$as_me: Bluetooth sniffing is supported" >&6;}
-
-		  #
-		  # OK, does struct sockaddr_hci have an hci_channel
-		  # member?
-		  #
-		  { $as_echo "$as_me:${as_lineno-$LINENO}: checking if struct sockaddr_hci has hci_channel member" >&5
-$as_echo_n "checking if struct sockaddr_hci has hci_channel member... " >&6; }
-		  if ${ac_cv_lbl_sockaddr_hci_has_hci_channel+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-
-int
-main ()
-{
-u_int i = sizeof(((struct sockaddr_hci *)0)->hci_channel)
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_lbl_sockaddr_hci_has_hci_channel=yes
-else
-  ac_cv_lbl_sockaddr_hci_has_hci_channel=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-		    { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lbl_sockaddr_hci_has_hci_channel" >&5
-$as_echo "$ac_cv_lbl_sockaddr_hci_has_hci_channel" >&6; }
-		    if test $ac_cv_lbl_sockaddr_hci_has_hci_channel = yes ; then
-
-$as_echo "#define SOCKADDR_HCI_HAS_HCI_CHANNEL /**/" >>confdefs.h
-
-
-		      #
-		      # OK, is HCI_CHANNEL_MONITOR defined?
-		      #
-		      { $as_echo "$as_me:${as_lineno-$LINENO}: checking if HCI_CHANNEL_MONITOR is defined" >&5
-$as_echo_n "checking if HCI_CHANNEL_MONITOR is defined... " >&6; }
-		      if ${ac_cv_lbl_hci_channel_monitor_is_defined+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
-/* end confdefs.h.  */
-
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-
-int
-main ()
-{
-u_int i = HCI_CHANNEL_MONITOR
-  ;
-  return 0;
-}
-_ACEOF
-if ac_fn_c_try_compile "$LINENO"; then :
-  ac_cv_lbl_hci_channel_monitor_is_defined=yes
-else
-  ac_cv_lbl_hci_channel_monitor_is_defined=no
-fi
-rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
-fi
-
-		      { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lbl_hci_channel_monitor_is_defined" >&5
-$as_echo "$ac_cv_lbl_hci_channel_monitor_is_defined" >&6; }
-		      if test $ac_cv_lbl_hci_channel_monitor_is_defined = yes ; then
-
-$as_echo "#define PCAP_SUPPORT_BT_MONITOR /**/" >>confdefs.h
-
-			BT_MONITOR_SRC=pcap-bt-monitor-linux.c
-		      fi
-		    fi
-
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: Bluetooth sniffing is not supported; install bluez-lib devel to enable it" >&5
-$as_echo "$as_me: Bluetooth sniffing is not supported; install bluez-lib devel to enable it" >&6;}
-
-fi
-
-
-		;;
-	*)
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: no Bluetooth sniffing support implemented for $host_os" >&5
+        ;;
+    *)
+        { $as_echo "$as_me:${as_lineno-$LINENO}: no Bluetooth sniffing support implemented for $host_os" >&5
 $as_echo "$as_me: no Bluetooth sniffing support implemented for $host_os" >&6;}
-		;;
-	esac
+        ;;
+    esac
 
 
 

--- a/configure.in
+++ b/configure.in
@@ -1458,65 +1458,21 @@ AC_ARG_ENABLE([bluetooth],
     [enable_bluetooth=yes])
 
 if test "x$enable_bluetooth" != "xno" ; then
-	dnl check for Bluetooth sniffing support
-	case "$host_os" in
-	linux*)
-		AC_CHECK_HEADER(bluetooth/bluetooth.h,
-		[
-		  AC_DEFINE(PCAP_SUPPORT_BT, 1, [target host supports Bluetooth sniffing])
-		  BT_SRC=pcap-bt-linux.c
-		  AC_MSG_NOTICE(Bluetooth sniffing is supported)
-
-		  #
-		  # OK, does struct sockaddr_hci have an hci_channel
-		  # member?
-		  #
-		  AC_MSG_CHECKING(if struct sockaddr_hci has hci_channel member)
-		  AC_CACHE_VAL(ac_cv_lbl_sockaddr_hci_has_hci_channel,
-		    AC_TRY_COMPILE(
-[
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-],
-		      [u_int i = sizeof(((struct sockaddr_hci *)0)->hci_channel)],
-		      ac_cv_lbl_sockaddr_hci_has_hci_channel=yes,
-		      ac_cv_lbl_sockaddr_hci_has_hci_channel=no))
-		    AC_MSG_RESULT($ac_cv_lbl_sockaddr_hci_has_hci_channel)
-		    if test $ac_cv_lbl_sockaddr_hci_has_hci_channel = yes ; then
-		      AC_DEFINE(SOCKADDR_HCI_HAS_HCI_CHANNEL,,
-			[if struct sockaddr_hci has hci_channel member])
-
-		      #
-		      # OK, is HCI_CHANNEL_MONITOR defined?
-		      #
-		      AC_MSG_CHECKING(if HCI_CHANNEL_MONITOR is defined)
-		      AC_CACHE_VAL(ac_cv_lbl_hci_channel_monitor_is_defined,
-		      AC_TRY_COMPILE(
-[
-#include <bluetooth/bluetooth.h>
-#include <bluetooth/hci.h>
-],
-			[u_int i = HCI_CHANNEL_MONITOR],
-			ac_cv_lbl_hci_channel_monitor_is_defined=yes,
-			ac_cv_lbl_hci_channel_monitor_is_defined=no))
-		      AC_MSG_RESULT($ac_cv_lbl_hci_channel_monitor_is_defined)
-		      if test $ac_cv_lbl_hci_channel_monitor_is_defined = yes ; then
-			AC_DEFINE(PCAP_SUPPORT_BT_MONITOR,,
-			  [target host supports Bluetooth Monitor])
-			BT_MONITOR_SRC=pcap-bt-monitor-linux.c
-		      fi
-		    fi
-		],
-		AC_MSG_NOTICE(Bluetooth sniffing is not supported; install bluez-lib devel to enable it)
-		)
-		;;
-	*)
-		AC_MSG_NOTICE(no Bluetooth sniffing support implemented for $host_os)
-		;;
-	esac
-	AC_SUBST(PCAP_SUPPORT_BT)
-	AC_SUBST(BT_SRC)
-	AC_SUBST(BT_MONITOR_SRC)
+    dnl check for Bluetooth sniffing support
+    case "$host_os" in
+    linux*)
+        AC_DEFINE(PCAP_SUPPORT_BT, 1, [target host supports Bluetooth sniffing])
+        BT_SRC=pcap-bt-linux.c
+        BT_MONITOR_SRC=pcap-bt-monitor-linux.c
+        AC_MSG_NOTICE(Bluetooth sniffing is supported)
+        ;;
+    *)
+        AC_MSG_NOTICE(no Bluetooth sniffing support implemented for $host_os)
+        ;;
+    esac
+    AC_SUBST(PCAP_SUPPORT_BT)
+    AC_SUBST(BT_SRC)
+    AC_SUBST(BT_MONITOR_SRC)
 fi
 
 AC_ARG_ENABLE([canusb],

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -39,6 +39,11 @@
 #include <stdint.h>
 #include <sys/socket.h>
 #include <sys/utsname.h>
+#include <netinet/in.h>
+
+#include "pcap-int.h"
+#include "pcap/bluetooth.h"
+#include "pcap-bt-monitor-linux.h"
 
 /* Start of copy of unexported Linux Kernel headers */
 
@@ -67,9 +72,6 @@ struct mgmt_hdr {
 #define MGMT_HDR_SIZE   sizeof(struct mgmt_hdr)
 /* End of copy of unexported Linux Kernel headers */
 
-#include "pcap/bluetooth.h"
-#include "pcap-int.h"
-
 #define BT_CONTROL_SIZE 32
 #define INTERFACE_NAME "bluetooth-monitor"
 
@@ -86,7 +88,7 @@ bt_monitor_findalldevs(pcap_if_t **alldevsp, char *err_str)
             sscanf(uname_data.release, "%u.%u.%u", &version_major, &version_minor, &version_release) == 3))
         return 0;
 
-    if (!(version_major >= 3 && version_minor >= 4 && version_release >= 0)) return 0;
+    if (!(version_major >= 3 && version_minor >= 4)) return 0;
 
     if (pcap_add_if(alldevsp, INTERFACE_NAME, 0,
                "Bluetooth Linux Monitor", err_str) < 0)
@@ -107,7 +109,6 @@ bt_monitor_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_ch
     struct pcap_pkthdr pkth;
     pcap_bluetooth_linux_monitor_header *bthdr;
     struct mgmt_hdr hdr;
-    int in = 0;
 
     bthdr = (pcap_bluetooth_linux_monitor_header*) &handle->buffer[handle->offset];
 

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -25,10 +25,10 @@
  *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  *
  *  Modifications:     Added PACKET_MMAP support
- *                     Paolo Abeni <paolo.abeni@email.it> 
+ *                     Paolo Abeni <paolo.abeni@email.it>
  *                     Added TPACKET_V3 support
  *                     Gabor Tatarka <gabor.tatarka@ericsson.com>
- *                     
+ *
  *                     based on previous works of:
  *                     Simon Patarin <patarin@cs.unibo.it>
  *                     Phil Wood <cpw@lanl.gov>
@@ -47,7 +47,7 @@
  * modification, are permitted provided that the following conditions
  * are met:
  * 1. Redistributions of source code must retain the above copyright
- *    notice, this list of conditions and the following disclaimer. 
+ *    notice, this list of conditions and the following disclaimer.
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
@@ -56,12 +56,12 @@
  *
  * THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
  * IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
- * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  
+ * OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
  * IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
  * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
  * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
  * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
- * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, 
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
@@ -188,7 +188,7 @@
 # endif /* PACKET_HOST */
 
 
- /* check for memory mapped access avaibility. We assume every needed 
+ /* check for memory mapped access avaibility. We assume every needed
   * struct is defined if the macro TPACKET_HDRLEN is defined, because it
   * uses many ring related structs and macros */
 # ifdef TPACKET_HDRLEN
@@ -1009,7 +1009,7 @@ linux_if_drops(const char * if_name)
 	FILE * file;
 	int field_to_convert = 3, if_name_sz = strlen(if_name);
 	long int dropped_pkts = 0;
-	
+
 	file = fopen("/proc/net/dev", "r");
 	if (!file)
 		return 0;
@@ -1024,7 +1024,7 @@ linux_if_drops(const char * if_name)
 			field_to_convert = 4;
 			continue;
 		}
-	
+
 		/* find iface and make sure it actually matches -- space before the name and : after it */
 		if ((bufptr = strstr(buffer, if_name)) &&
 			(bufptr == buffer || *(bufptr-1) == ' ') &&
@@ -1038,20 +1038,20 @@ linux_if_drops(const char * if_name)
 				while (*bufptr != '\0' && *(bufptr++) == ' ');
 				while (*bufptr != '\0' && *(bufptr++) != ' ');
 			}
-			
+
 			/* get rid of any final spaces */
 			while (*bufptr != '\0' && *bufptr == ' ') bufptr++;
-			
+
 			if (*bufptr != '\0')
 				dropped_pkts = strtol(bufptr, NULL, 10);
 
 			break;
 		}
 	}
-	
+
 	fclose(file);
 	return dropped_pkts;
-} 
+}
 
 
 /*
@@ -1285,12 +1285,12 @@ pcap_activate_linux(pcap_t *handle)
 			 pcap_strerror(errno) );
 		return PCAP_ERROR;
 	}
-	
+
 	/* copy timeout value */
 	handlep->timeout = handle->opt.timeout;
 
 	/*
-	 * If we're in promiscuous mode, then we probably want 
+	 * If we're in promiscuous mode, then we probably want
 	 * to see when the interface drops packets too, so get an
 	 * initial count from /proc/net/dev
 	 */
@@ -1408,7 +1408,7 @@ fail:
  *  error occured.
  */
 static int
-pcap_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *user)
+pcap_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char *user)
 {
 	/*
 	 * Currently, on Linux only one packet is delivered per read,
@@ -1736,7 +1736,7 @@ pcap_read_packet(pcap_t *handle, pcap_handler callback, u_char *userdata)
 					"SIOCGSTAMPNS: %s", pcap_strerror(errno));
 			return PCAP_ERROR;
 		}
-        } else
+	} else
 #endif
 	{
 		if (ioctl(handle->fd, SIOCGSTAMP, &pcap_header.ts) == -1) {
@@ -1744,7 +1744,7 @@ pcap_read_packet(pcap_t *handle, pcap_handler callback, u_char *userdata)
 					"SIOCGSTAMP: %s", pcap_strerror(errno));
 			return PCAP_ERROR;
 		}
-        }
+	}
 
 	pcap_header.caplen	= caplen;
 	pcap_header.len		= packet_len;
@@ -1843,7 +1843,7 @@ pcap_inject_linux(pcap_t *handle, const void *buf, size_t size)
 		return (-1);
 	}
 	return (ret);
-}                           
+}
 
 /*
  *  Get the statistics for the given packet capture handle.
@@ -1881,8 +1881,8 @@ pcap_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 #endif /* HAVE_TPACKET_STATS */
 
 	long if_dropped = 0;
-	
-	/* 
+
+	/*
 	 *	To fill in ps_ifdrop, we parse /proc/net/dev for the number
 	 */
 	if (handle->opt.promisc)
@@ -1912,7 +1912,7 @@ pcap_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 		 *	dropped by the interface driver.  It counts only
 		 *	packets that passed the filter.
 		 *
-		 *	See above for ps_ifdrop. 
+		 *	See above for ps_ifdrop.
 		 *
 		 *	Both statistics include packets not yet read from
 		 *	the kernel by libpcap, and thus not yet seen by
@@ -1941,7 +1941,7 @@ pcap_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 		 * "tp_packets" as the count of packets and "tp_drops"
 		 * as the count of drops.
 		 *
-		 * Keep a running total because each call to 
+		 * Keep a running total because each call to
 		 *    getsockopt(handle->fd, SOL_PACKET, PACKET_STATISTICS, ....
 		 * resets the counters to zero.
 		 */
@@ -1987,10 +1987,10 @@ pcap_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 	 * We maintain the count of packets processed by libpcap in
 	 * "handlep->packets_read", for reasons described in the comment
 	 * at the end of pcap_read_packet().  We have no idea how many
-	 * packets were dropped by the kernel buffers -- but we know 
+	 * packets were dropped by the kernel buffers -- but we know
 	 * how many the interface dropped, so we can return that.
 	 */
-	 
+
 	stats->ps_recv = handlep->packets_read;
 	stats->ps_drop = 0;
 	stats->ps_ifdrop = handlep->stat.ps_ifdrop;
@@ -2598,7 +2598,7 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype, const char *device,
 			handle->linktype = DLT_RAW;
 			return;
 		}
-	
+
 		/*
 		 * This is (presumably) a real Ethernet capture; give it a
 		 * link-layer-type list with DLT_EN10MB and DLT_DOCSIS, so
@@ -2962,9 +2962,9 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype, const char *device,
 #ifndef ARPHRD_IEEE802154
 #define ARPHRD_IEEE802154      804
 #endif
-       case ARPHRD_IEEE802154:
-               handle->linktype =  DLT_IEEE802_15_4_NOFCS;
-               break;
+	case ARPHRD_IEEE802154:
+		handle->linktype =  DLT_IEEE802_15_4_NOFCS;
+		break;
 
 #ifndef ARPHRD_NETLINK
 #define ARPHRD_NETLINK	824
@@ -3361,7 +3361,7 @@ activate_new(pcap_t *handle)
  * On error, returns -1, and sets *status to the appropriate error code;
  * if that is PCAP_ERROR, sets handle->errbuf to the appropriate message.
  */
-static int 
+static int
 activate_mmap(pcap_t *handle, int *status)
 {
 	struct pcap_linux *handlep = handle->priv;
@@ -3442,7 +3442,7 @@ activate_mmap(pcap_t *handle, int *status)
 	return 1;
 }
 #else /* HAVE_PACKET_RING */
-static int 
+static int
 activate_mmap(pcap_t *handle _U_, int *status _U_)
 {
 	return 0;
@@ -3733,12 +3733,12 @@ create_ring(pcap_t *handle, int *status)
 #endif
 	}
 
-	/* compute the minumum block size that will handle this frame. 
-	 * The block has to be page size aligned. 
-	 * The max block size allowed by the kernel is arch-dependent and 
+	/* compute the minumum block size that will handle this frame.
+	 * The block has to be page size aligned.
+	 * The max block size allowed by the kernel is arch-dependent and
 	 * it's not explicitly checked here. */
 	req.tp_block_size = getpagesize();
-	while (req.tp_block_size < req.tp_frame_size) 
+	while (req.tp_block_size < req.tp_frame_size)
 		req.tp_block_size <<= 1;
 
 	frames_per_block = req.tp_block_size/req.tp_frame_size;
@@ -3836,8 +3836,8 @@ create_ring(pcap_t *handle, int *status)
 			}
 			if (setsockopt(handle->fd, SOL_PACKET, PACKET_TIMESTAMP,
 				(void *)&timesource, sizeof(timesource))) {
-				snprintf(handle->errbuf, PCAP_ERRBUF_SIZE, 
-					"can't set PACKET_TIMESTAMP: %s", 
+				snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+					"can't set PACKET_TIMESTAMP: %s",
 					pcap_strerror(errno));
 				*status = PCAP_ERROR;
 				return -1;
@@ -3852,7 +3852,7 @@ retry:
 
 	/* req.tp_frame_nr is requested to match frames_per_block*req.tp_block_nr */
 	req.tp_frame_nr = req.tp_block_nr * frames_per_block;
-	
+
 #ifdef HAVE_TPACKET3
 	/* timeout value to retire block - use the configured buffering timeout, or default if <0. */
 	req.tp_retire_blk_tov = (handlep->timeout>=0)?handlep->timeout:0;
@@ -3984,7 +3984,7 @@ pcap_oneshot_mmap(u_char *user, const struct pcap_pkthdr *h,
 	memcpy(handlep->oneshot_buffer, bytes, h->caplen);
 	*sp->pkt = handlep->oneshot_buffer;
 }
-    
+
 static void
 pcap_cleanup_linux_mmap( pcap_t *handle )
 {
@@ -4000,7 +4000,7 @@ pcap_cleanup_linux_mmap( pcap_t *handle )
 
 
 static int
-pcap_getnonblock_mmap(pcap_t *p, char *errbuf)
+pcap_getnonblock_mmap(pcap_t *p, char *errbuf _U_)
 {
 	struct pcap_linux *handlep = p->priv;
 
@@ -4009,7 +4009,7 @@ pcap_getnonblock_mmap(pcap_t *p, char *errbuf)
 }
 
 static int
-pcap_setnonblock_mmap(pcap_t *p, int nonblock, char *errbuf)
+pcap_setnonblock_mmap(pcap_t *p, int nonblock, char *errbuf _U_)
 {
 	struct pcap_linux *handlep = p->priv;
 
@@ -4578,7 +4578,7 @@ again:
 }
 #endif /* HAVE_TPACKET3 */
 
-static int 
+static int
 pcap_setfilter_linux_mmap(pcap_t *handle, struct bpf_program *filter)
 {
 	struct pcap_linux *handlep = handle->priv;
@@ -5475,7 +5475,7 @@ iface_ethtool_ioctl(pcap_t *handle, int cmd, const char *cmdname)
 		    cmdname, strerror(errno));
 		return -1;
 	}
-	return eval.data;	
+	return eval.data;
 }
 
 static int

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -11,8 +11,8 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  * notice, this list of conditions and the following disclaimer in the
  * documentation and/or other materials provided with the distribution.
- * 3. The name of the author may not be used to endorse or promote 
- * products derived from this software without specific prior written 
+ * 3. The name of the author may not be used to endorse or promote
+ * products derived from this software without specific prior written
  * permission.
  *
  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
@@ -32,7 +32,7 @@
  * Modifications: Kris Katterjohn <katterjohn@gmail.com>
  *
  */
- 
+
 #ifdef HAVE_CONFIG_H
 #include "config.h"
 #endif
@@ -139,21 +139,21 @@ static int usb_setdirection_linux(pcap_t *, pcap_direction_t);
 static void usb_cleanup_linux_mmap(pcap_t *);
 
 /* facility to add an USB device to the device list*/
-static int 
+static int
 usb_dev_add(pcap_if_t** alldevsp, int n, char *err_str)
 {
 	char dev_name[10];
-	char dev_descr[30]; 
+	char dev_descr[30];
 	snprintf(dev_name, 10, USB_IFACE"%d", n);
 	snprintf(dev_descr, 30, "USB bus number %d", n);
 
-	if (pcap_add_if(alldevsp, dev_name, 0, 
+	if (pcap_add_if(alldevsp, dev_name, 0,
 	    dev_descr, err_str) < 0)
 		return -1;
-	return 0; 
+	return 0;
 }
 
-int 
+int
 usb_findalldevs(pcap_if_t **alldevsp, char *err_str)
 {
 	struct dirent* data;
@@ -172,7 +172,7 @@ usb_findalldevs(pcap_if_t **alldevsp, char *err_str)
 			if (strncmp(name, "usb", 3) != 0)
 				continue;
 
-			if (sscanf(&name[3], "%d", &n) == 0) 
+			if (sscanf(&name[3], "%d", &n) == 0)
 				continue;
 
 			ret = usb_dev_add(alldevsp, n, err_str);
@@ -193,7 +193,7 @@ usb_findalldevs(pcap_if_t **alldevsp, char *err_str)
 			if ((len < 1) || !isdigit(name[--len]))
 				continue;
 			while (isdigit(name[--len]));
-			if (sscanf(&name[len+1], "%d", &n) != 1) 
+			if (sscanf(&name[len+1], "%d", &n) != 1)
 				continue;
 
 			ret = usb_dev_add(alldevsp, n, err_str);
@@ -207,12 +207,12 @@ usb_findalldevs(pcap_if_t **alldevsp, char *err_str)
 	return 0;
 }
 
-static 
+static
 int usb_mmap(pcap_t* handle)
 {
 	struct pcap_usb_linux *handlep = handle->priv;
 	int len = ioctl(handle->fd, MON_IOCQ_RING_SIZE);
-	if (len < 0) 
+	if (len < 0)
 		return 0;
 
 	handlep->mmapbuflen = len;
@@ -258,7 +258,7 @@ probe_devices(int bus)
 			continue;
 
 		snprintf(buf, sizeof(buf), "/dev/bus/usb/%03d/%s", bus, data->d_name);
-		
+
 		fd = open(buf, O_RDWR);
 		if (fd == -1)
 			continue;
@@ -360,7 +360,7 @@ usb_activate(pcap_t* handle)
 	}
 
 	/*now select the read method: try to open binary interface */
-	snprintf(full_path, USB_LINE_LEN, LINUX_USB_MON_DEV"%d", handlep->bus_index);  
+	snprintf(full_path, USB_LINE_LEN, LINUX_USB_MON_DEV"%d", handlep->bus_index);
 	handle->fd = open(full_path, O_RDONLY, 0);
 	if (handle->fd >= 0)
 	{
@@ -395,7 +395,7 @@ usb_activate(pcap_t* handle)
 	}
 	else {
 		/*Binary interface not available, try open text interface */
-		snprintf(full_path, USB_LINE_LEN, USB_TEXT_DIR"/%dt", handlep->bus_index);  
+		snprintf(full_path, USB_LINE_LEN, USB_TEXT_DIR"/%dt", handlep->bus_index);
 		handle->fd = open(full_path, O_RDONLY, 0);
 		if (handle->fd < 0)
 		{
@@ -405,7 +405,7 @@ usb_activate(pcap_t* handle)
 				 * Not found at the new location; try
 				 * the old location.
 				 */
-				snprintf(full_path, USB_LINE_LEN, USB_TEXT_DIR_OLD"/%dt", handlep->bus_index);  
+				snprintf(full_path, USB_LINE_LEN, USB_TEXT_DIR_OLD"/%dt", handlep->bus_index);
 				handle->fd = open(full_path, O_RDONLY, 0);
 			}
 			if (handle->fd < 0) {
@@ -446,27 +446,27 @@ usb_activate(pcap_t* handle)
 	return 0;
 }
 
-static inline int 
+static inline int
 ascii_to_int(char c)
 {
 	return c < 'A' ? c- '0': ((c<'a') ? c - 'A' + 10: c-'a'+10);
 }
 
 /*
- * see <linux-kernel-source>/Documentation/usb/usbmon.txt and 
- * <linux-kernel-source>/drivers/usb/mon/mon_text.c for urb string 
+ * see <linux-kernel-source>/Documentation/usb/usbmon.txt and
+ * <linux-kernel-source>/drivers/usb/mon/mon_text.c for urb string
  * format description
  */
 static int
-usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *user)
+usb_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char *user)
 {
 	/* see:
-	* /usr/src/linux/Documentation/usb/usbmon.txt 
+	* /usr/src/linux/Documentation/usb/usbmon.txt
 	* for message format
 	*/
 	struct pcap_usb_linux *handlep = handle->priv;
-	unsigned timestamp;
-	int tag, cnt, ep_num, dev_addr, dummy, ret, urb_len, data_len;
+	unsigned int tag, timestamp;
+	int cnt, ep_num, dev_addr, dummy, ret, urb_len, data_len;
 	char etype, pipeid1, pipeid2, status[16], urb_tag, line[USB_LINE_LEN];
 	char *string = line;
 	u_char * rawdata = handle->buffer;
@@ -494,11 +494,11 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 		return -1;
 	}
 
-	/* read urb header; %n argument may increment return value, but it's 
+	/* read urb header; %n argument may increment return value, but it's
 	* not mandatory, so does not count on it*/
 	string[ret] = 0;
-	ret = sscanf(string, "%x %d %c %c%c:%d:%d %s%n", &tag, &timestamp, &etype, 
-		&pipeid1, &pipeid2, &dev_addr, &ep_num, status, 
+	ret = sscanf(string, "%x %u %c %c%c:%d:%d %s%i", &tag, &timestamp, &etype,
+		&pipeid1, &pipeid2, &dev_addr, &ep_num, status,
 		&cnt);
 	if (ret < 8)
 	{
@@ -514,10 +514,10 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 	string += cnt;
 
 	/* don't use usbmon provided timestamp, since it have low precision*/
-	if (gettimeofday(&pkth.ts, NULL) < 0) 
+	if (gettimeofday(&pkth.ts, NULL) < 0)
 	{
 		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
-			"Can't get timestamp for message '%s' %d:%s", 
+			"Can't get timestamp for message '%s' %d:%s",
 			string, errno, strerror(errno));
 		return -1;
 	}
@@ -560,11 +560,11 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 	if (ret != 1)
 	{
 		/* this a setup packet, setup data can be filled with underscore if
-		* usbmon has not been able to read them, so we must parse this fields as 
+		* usbmon has not been able to read them, so we must parse this fields as
 		* strings */
 		pcap_usb_setup* shdr;
 		char str1[3], str2[3], str3[5], str4[5], str5[5];
-		ret = sscanf(string, "%s %s %s %s %s%n", str1, str2, str3, str4, 
+		ret = sscanf(string, "%s %s %s %s %s%n", str1, str2, str3, str4,
 		str5, &cnt);
 		if (ret < 5)
 		{
@@ -585,7 +585,7 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 
 		uhdr->setup_flag = 0;
 	}
-	else 
+	else
 		uhdr->setup_flag = 1;
 
 	/* read urb data */
@@ -598,7 +598,7 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 	}
 	string += cnt;
 
-	/* urb tag is not present if urb length is 0, so we can stop here 
+	/* urb tag is not present if urb length is 0, so we can stop here
 	 * text parsing */
 	pkth.len = urb_len+pkth.caplen;
 	uhdr->urb_len = urb_len;
@@ -615,7 +615,7 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 		return -1;
 	}
 
-	if (urb_tag != '=') 
+	if (urb_tag != '=')
 		goto got;
 
 	/* skip urb tag and following space */
@@ -624,7 +624,7 @@ usb_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 	/* if we reach this point we got some urb data*/
 	uhdr->data_flag = 0;
 
-	/* read all urb data; if urb length is greater then the usbmon internal 
+	/* read all urb data; if urb length is greater then the usbmon internal
 	 * buffer length used by the kernel to spool the URB, we get only
 	 * a partial information.
 	 * At least until linux 2.6.17 there is no way to set usbmon intenal buffer
@@ -656,14 +656,14 @@ got:
 }
 
 static int
-usb_inject_linux(pcap_t *handle, const void *buf, size_t size)
+usb_inject_linux(pcap_t *handle, const void *buf _U_, size_t size _U_)
 {
 	snprintf(handle->errbuf, PCAP_ERRBUF_SIZE, "inject not supported on "
 		"USB devices");
 	return (-1);
 }
 
-static int 
+static int
 usb_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 {
 	struct pcap_usb_linux *handlep = handle->priv;
@@ -688,7 +688,7 @@ usb_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 		}
 		if (fd < 0) {
 			snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
-				"Can't open USB stats file %s: %s", 
+				"Can't open USB stats file %s: %s",
 				string, strerror(errno));
 			return -1;
 		}
@@ -710,11 +710,11 @@ usb_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 
 	/* extract info on dropped urbs */
 	for (consumed=0; consumed < ret; ) {
-		/* from the sscanf man page: 
- 		 * The C standard says: "Execution of a %n directive does 
- 		 * not increment the assignment count returned at the completion
+		/* from the sscanf man page:
+		 * The C standard says: "Execution of a %n directive does
+		 * not increment the assignment count returned at the completion
 		 * of  execution" but the Corrigendum seems to contradict this.
-		 * Do not make any assumptions on the effect of %n conversions 
+		 * Do not make any assumptions on the effect of %n conversions
 		 * on the return value and explicitly check for cnt assignmet*/
 		int ntok;
 
@@ -725,8 +725,8 @@ usb_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 		consumed += cnt;
 		ptr += cnt;
 		if (strcmp(token, "nreaders") == 0)
-			ret = sscanf(ptr, "%d", &stats->ps_drop);
-		else 
+			ret = sscanf(ptr, "%u", &stats->ps_drop);
+		else
 			ret = sscanf(ptr, "%d", &dummy);
 		if (ntok != 1)
 			break;
@@ -739,7 +739,7 @@ usb_stats_linux(pcap_t *handle, struct pcap_stat *stats)
 	return 0;
 }
 
-static int 
+static int
 usb_setdirection_linux(pcap_t *p, pcap_direction_t d)
 {
 	p->direction = d;
@@ -747,7 +747,7 @@ usb_setdirection_linux(pcap_t *p, pcap_direction_t d)
 }
 
 
-static int 
+static int
 usb_stats_linux_bin(pcap_t *handle, struct pcap_stat *stats)
 {
 	struct pcap_usb_linux *handlep = handle->priv;
@@ -768,11 +768,11 @@ usb_stats_linux_bin(pcap_t *handle, struct pcap_stat *stats)
 }
 
 /*
- * see <linux-kernel-source>/Documentation/usb/usbmon.txt and 
+ * see <linux-kernel-source>/Documentation/usb/usbmon.txt and
  * <linux-kernel-source>/drivers/usb/mon/mon_bin.c binary ABI
  */
 static int
-usb_read_linux_bin(pcap_t *handle, int max_packets, pcap_handler callback, u_char *user)
+usb_read_linux_bin(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char *user)
 {
 	struct pcap_usb_linux *handlep = handle->priv;
 	struct mon_bin_get info;
@@ -826,7 +826,7 @@ usb_read_linux_bin(pcap_t *handle, int max_packets, pcap_handler callback, u_cha
 }
 
 /*
- * see <linux-kernel-source>/Documentation/usb/usbmon.txt and 
+ * see <linux-kernel-source>/Documentation/usb/usbmon.txt and
  * <linux-kernel-source>/drivers/usb/mon/mon_bin.c binary ABI
  */
 #define VEC_SIZE 32
@@ -880,7 +880,7 @@ usb_read_linux_mmap(pcap_t *handle, int max_packets, pcap_handler callback, u_ch
 		for (i=0; i<fetch.nfetch; ++i) {
 			/* discard filler */
 			hdr = (pcap_usb_header*) &handlep->mmapbuf[vec[i]];
-			if (hdr->event_type == '@') 
+			if (hdr->event_type == '@')
 				continue;
 
 			/* we can get less that than really captured from kernel, depending on

--- a/pcap.c
+++ b/pcap.c
@@ -86,9 +86,6 @@
 
 #ifdef PCAP_SUPPORT_BT
 #include "pcap-bt-linux.h"
-#endif
-
-#ifdef PCAP_SUPPORT_BT_MONITOR
 #include "pcap-bt-monitor-linux.h"
 #endif
 
@@ -322,8 +319,6 @@ struct capture_source_type {
 #endif
 #ifdef PCAP_SUPPORT_BT
 	{ bt_findalldevs, bt_create },
-#endif
-#ifdef PCAP_SUPPORT_BT_MONITOR
 	{ bt_monitor_findalldevs, bt_monitor_create },
 #endif
 #if PCAP_SUPPORT_CANUSB


### PR DESCRIPTION
Libpcap should not use BlueZ userspace headers, because it does not
use BlueZ at all. It used only Linux kernel, but it does not
provide userspace headers. For compatible reason we should use own copy
of headers and try to dynamically detect Linux kernel version and use
proper structures.

This fixes #343.
