### PR TITLE
.travis.yml: install libusb1.0 lib devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ compiler:
   - clang
 
 before_script:
-  - sudo apt-get install libusb-1.0-0-dev
+  - sudo apt-get install libusb-1.0-0-dev libdbus-1-dev
 
 script:
   - ./configure


### PR DESCRIPTION
before:
<code>
checking libusb-1.0/libusb.h usability... no
checking libusb-1.0/libusb.h presence... no
checking for libusb-1.0/libusb.h... no
configure: canusb sniffing is not supported; install libusb1.0 lib devel to enable it
</code>
after:
<code>
checking libusb-1.0/libusb.h usability... yes
checking libusb-1.0/libusb.h presence... yes
checking for libusb-1.0/libusb.h... yes
configure: canusb sniffing is supported
</code>
