### PR TITLE
libpcap: added raw filters

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -57,6 +57,10 @@
 
 #endif /* WIN32 */
 
+#if defined(BSD) || (defined (__APPLE__) && defined(__MACH__))
+#include <net/bpf.h>
+#endif
+
 #include <stdlib.h>
 #include <string.h>
 #include <memory.h>
@@ -396,6 +400,97 @@ static int snaplen;
 int no_optimize;
 
 int
+pcap_is_raw(const char *bpf_string)
+{
+	char sp, separator1 = ',', separator2 = '\n';
+	unsigned short bpf_len;
+
+	if (sscanf(bpf_string, "%hu%c", &bpf_len, &sp) != 2 ||
+			(sp != separator1 && sp != separator2))
+		return 0;
+
+	return 1;
+}
+
+int
+pcap_compile_raw(pcap_t *p, struct bpf_program *program, const char *bpf_string)
+{
+	const char *token;
+	char sp, separator, separator1 = ',', separator2 = '\n';
+	unsigned short bpf_len, i = 0, line = 0;
+	size_t size;
+	struct bpf_insn tmp;
+
+	program->bf_len = 0;
+
+	if (sscanf(bpf_string, "%hu%c", &bpf_len, &sp) != 2 ||
+			(sp != separator1 && sp != separator2) ||
+			bpf_len > BPF_MAXINSNS || bpf_len == 0) {
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+				"syntax error in head length encoding!");
+		return (-1);
+	}
+	separator = sp;
+
+	/* allocate the fcode buffer */
+	program->bf_len = bpf_len;
+	size = sizeof(struct bpf_insn) * program->bf_len;
+	program->bf_insns = (struct bpf_insn *)malloc(size);
+	if (program->bf_insns == NULL)
+		bpf_error("malloc");
+	memset(program->bf_insns, 0, size);
+
+	/* fill it up */
+	token = bpf_string;
+	while ((token = strchr(token, separator)) && (++token)[0]) {
+		line++;
+		/* consume whitespaces */
+		while (*token == ' ' || *token == '\t')
+			++token;
+		/* skip empty lines and comments */
+		if (*token == separator || *token == '\n' || strlen(token) < 1 ||
+				token[0] == '#')
+			continue;
+
+		if (i >= bpf_len) {
+			program->bf_len = 0;
+			free(program->bf_insns);
+			snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+					"program exceeds encoded length!");
+			return (-1);
+		}
+
+		if (sscanf(token, "%hu %hhu %hhu %u%c",
+				&tmp.code, &tmp.jt, &tmp.jf, &tmp.k, &sp) != 5) {
+			program->bf_len = 0;
+			free(program->bf_insns);
+			snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+					"syntax error at line %d!", line);
+			return (-1);
+		}
+
+		program->bf_insns[i].code = tmp.code;
+		program->bf_insns[i].jt = tmp.jt;
+		program->bf_insns[i].jf = tmp.jf;
+		program->bf_insns[i].k = tmp.k;
+
+		i++;
+	}
+
+	if (i != bpf_len) {
+		program->bf_len = 0;
+		free(program->bf_insns);
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+				"syntax error exceeding encoded length!");
+		return (-1);
+	}
+
+	program->bf_len = bpf_len;
+  p->skip_validate = 1;
+	return 0;
+}
+
+int
 pcap_compile(pcap_t *p, struct bpf_program *program,
 	     const char *buf, int optimize, bpf_u_int32 mask)
 {
@@ -429,6 +524,14 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 		rc = -1;
 		goto quit;
 	}
+
+	/*
+	 * support for raw filters
+	 */
+	if (pcap_is_raw(buf))
+		return pcap_compile_raw(p, program, buf);
+
+  p->skip_validate = 0;
 	no_optimize = 0;
 	n_errors = 0;
 	root = NULL;

--- a/optimize.c
+++ b/optimize.c
@@ -2219,7 +2219,7 @@ install_bpf_program(pcap_t *p, struct bpf_program *fp)
 	/*
 	 * Validate the program.
 	 */
-	if (!bpf_validate(fp->bf_insns, fp->bf_len)) {
+	if (!p->skip_validate && !bpf_validate(fp->bf_insns, fp->bf_len)) {
 		snprintf(p->errbuf, sizeof(p->errbuf),
 			"BPF program is not valid");
 		return (-1);

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -168,6 +168,7 @@ struct pcap {
 	int offset;		/* offset for proper alignment */
 	int activated;		/* true if the capture is really started */
 	int oldstyle;		/* if we're opening with pcap_open_live() */
+	int skip_validate;		/* let the kernel validate raw filters */
 
 	struct pcap_opt opt;
 

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -388,6 +388,8 @@ char	*pcap_geterr(pcap_t *);
 void	pcap_perror(pcap_t *, char *);
 int	pcap_compile(pcap_t *, struct bpf_program *, const char *, int,
 	    bpf_u_int32);
+int pcap_is_raw(const char *);
+int pcap_compile_raw(pcap_t *, struct bpf_program *, const char *);
 int	pcap_compile_nopcap(int, int, struct bpf_program *,
 	    const char *, int, bpf_u_int32);
 void	pcap_freecode(struct bpf_program *);

--- a/pcap1.h
+++ b/pcap1.h
@@ -235,6 +235,8 @@ char	*pcap_strerror(int);
 char	*pcap_geterr(pcap_t *);
 int	pcap_compile(pcap_t *, struct bpf_program *, char *, int,
 	    bpf_u_int32);
+int pcap_is_raw(const char *);
+int pcap_compile_raw(pcap_t *, struct bpf_program *, const char *);
 int	pcap_compile_nopcap(int, int, struct bpf_program *,
 	    char *, int, bpf_u_int32);
 void	pcap_freecode(struct bpf_program *);


### PR DESCRIPTION
The goal of supporting raw filters* is to provide libpcap/tcpdump support
for generic BPF insns, including those that are not-supported by libpcap
(e.g., the BPF_MOD/BPF_XOR ops in Linux, or any of the multiple ancillary
loads in linux). It also allows testing new kernel extensions to the
BPF ISA without having to modify libpcap/tcpdump.

We provide support by modifying pcap_compile() so that it first checks
for raw filters. This works for expressions appended in the command line,
and for expressions read from a file ("-F" option). Filters starting
with an integer and a valid separator (',' or '\n') are considered raw.
All other filters are considered (traditional) expressions.

We also make sure that filters compiled from raw filters are left for the
kernel to validate (added "skip_validate" to pcap_t).

*Raw filters are those generated by tcpdump -ddd. i.e.

$ ./tcpdump -ddd -i eth0 icmp
6
40 0 0 12
21 0 3 2048
48 0 0 23
21 0 1 1
6 0 0 65535
6 0 0 0

We also support replacing the new line characters with commas, as to
make possible to have inline filters.

$ ./tcpdump -ddd -i eth0 icmp |tr '\n' ','
6,40 0 0 12,21 0 3 2048,48 0 0 23,21 0 1 1,6 0 0 65535,6 0 0 0,

Tested:

$ cat icmp.bpf
ldh [12]
jne #0x800, drop
ldb [23]
jneq #1, drop
ret #-1
drop: ret #0
$ linux/net/tools/bpf_asm icmp.bpf > icmp.1.bpfraw
$ cat icmp.1.bpfraw
6,40 0 0 12,21 0 3 2048,48 0 0 23,21 0 1 1,6 0 0 4294967295,6 0 0 0,
$ linux/net/tools/bpf_asm icmp.bpf |tr ',' '\n' > icmp.2.bpfraw
$ cat icmp.2.bpfraw
6
40 0 0 12
21 0 3 2048
48 0 0 23
21 0 1 1
6 0 0 4294967295
6 0 0 0

-- start pinging at 8.8.8.8 from another xterm

$ echo 2 > /proc/sys/net/core/bpf_jit_enable

$ ./tcpdump -nn -i eth0 icmp
[000096.500054] device eth0 entered promiscuous mode
[000096.530154] flen=1 proglen=3 pass=3 image=ffffffffa000878c
[000096.531000] JIT code: 00000000: 31 c0 c3
[000096.531676] flen=6 proglen=70 pass=3 image=ffffffffa00049ad
[000096.532505] JIT code: 00000000: 55 48 89 e5 48 83 ec 60 48 89 5d f8 44 8b 4f 68
[000096.533567] JIT code: 00000010: 44 2b 4f 6c 4c 8b 87 d8 00 00 00 be 0c 00 00 00
[000096.534661] JIT code: 00000020: e8 cf 26 04 e1 3d 00 08 00 00 75 16 be 17 00 00
[000096.535707] JIT code: 00000030: 00 e8 da 26 04 e1 83 f8 01 75 07 b8 ff ff 00 00
[000096.536733] JIT code: 00000040: eb 02 31 c0 c9 c3
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 65535 bytes
16:35:09.097308 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10357, seq 1, length 64
16:35:09.118301 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10357, seq 1, length 64
16:35:10.098626 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10357, seq 2, length 64
16:35:10.119608 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10357, seq 2, length 64

$ ./tcpdump -nn -i eth0 -F ~/bpf/icmp.1.bpfraw
[000166.010055] device eth0 entered promiscuous mode
[000166.040163] flen=1 proglen=3 pass=3 image=ffffffffa0008e83
[000166.040689] JIT code: 00000000: 31 c0 c3
[000166.041138] flen=6 proglen=70 pass=3 image=ffffffffa0004161
[000166.041884] JIT code: 00000000: 55 48 89 e5 48 83 ec 60 48 89 5d f8 44 8b 4f 68
[000166.042809] JIT code: 00000010: 44 2b 4f 6c 4c 8b 87 d8 00 00 00 be 0c 00 00 00
[000166.043744] JIT code: 00000020: e8 1b 2f 04 e1 3d 00 08 00 00 75 16 be 17 00 00
[000166.044725] JIT code: 00000030: 00 e8 26 2f 04 e1 83 f8 01 75 07 b8 ff ff ff ff
[000166.045644] JIT code: 00000040: eb 02 31 c0 c9 c3
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 65535 bytes
16:36:00.089773 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10359, seq 1, length 64
16:36:00.110723 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10359, seq 1, length 64
16:36:01.091191 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10359, seq 2, length 64
16:36:01.112169 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10359, seq 2, length 64
16:36:02.092495 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10359, seq 3, length 64
16:36:02.113500 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10359, seq 3, length 64

$ ./tcpdump -nn -i eth0 "6,40 0 0 12,21 0 3 2048,48 0 0 23,21 0 1 1,6 0 0 65535,6 0 0 0,"
[000100.590119] device eth0 entered promiscuous mode
[000100.620140] flen=1 proglen=3 pass=3 image=ffffffffa00040cc
...

$ ./tcpdump -nn -i eth0 -F ~/bpf/icmp.2.bpfraw
[000199.950055] device eth0 entered promiscuous mode
[000199.980521] flen=1 proglen=3 pass=3 image=ffffffffa0008d82
[000199.981505] JIT code: 00000000: 31 c0 c3
[000199.982220] flen=6 proglen=70 pass=3 image=ffffffffa0004655
[000199.983214] JIT code: 00000000: 55 48 89 e5 48 83 ec 60 48 89 5d f8 44 8b 4f 68
[000199.984375] JIT code: 00000010: 44 2b 4f 6c 4c 8b 87 d8 00 00 00 be 0c 00 00 00
[000199.985498] JIT code: 00000020: e8 27 2a 04 e1 3d 00 08 00 00 75 16 be 17 00 00
[000199.986579] JIT code: 00000030: 00 e8 32 2a 04 e1 83 f8 01 75 07 b8 ff ff ff ff
[000199.987664] JIT code: 00000040: eb 02 31 c0 c9 c3
tcpdump: verbose output suppressed, use -v or -vv for full protocol decode
listening on eth0, link-type EN10MB (Ethernet), capture size 65535 bytes
16:36:33.402095 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10361, seq 1, length 64
16:36:33.423003 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10361, seq 1, length 64
16:36:34.403321 IP 192.168.100.1 > 8.8.8.8: ICMP echo request, id 10361, seq 2, length 64
16:36:34.424359 IP 8.8.8.8 > 192.168.100.1: ICMP echo reply, id 10361, seq 2, length 64

And this uses an extended Linux feature (random numbers):

$ ./tcpdump -nn -i eth0 "9,40 0 0 12,21 0 6 2048,48 0 0 23,21 0 4 1,32 0 0 4294963256,148 0 0 4,21 0 1 1,6 0 0 4294967295,6 0 0 0,"
...