### PR TITLE
Add the --disable-packet-ring configure option.

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1655,6 +1655,24 @@ linux*)
 	;;
 esac
 
+dnl The packet ring capture facility of Linux, described in
+dnl Documentation/networking/packet_mmap.txt, is not 32/64-bit compatible before
+dnl version 2.6.27. A 32-bit kernel requires a 32-bit userland, and likewise for
+dnl 64-bit. The effect of this is that a 32-bit libpcap binary will not run
+dnl correctly on a 64-bit kernel (the binary will use the wrong offsets into a
+dnl kernel struct). This problem was solved in Linux 2.6.27. Use
+dnl --disable-packet-ring whenever a 32-bit application must run on a 64-bit
+dnl target host, and either the build host or the target host run Linux 2.6.26
+dnl or earlier.
+AC_ARG_ENABLE([packet-ring],
+[AC_HELP_STRING([--enable-packet-ring],[enable Linux packet ring support @<:@default=yes@:>@])],
+,enable_packet_ring=yes)
+
+if test "x$enable_packet_ring" != "xno" ; then
+	AC_DEFINE(PCAP_SUPPORT_PACKET_RING, 1, [use Linux packet ring capture if available])
+	AC_SUBST(PCAP_SUPPORT_PACKET_RING)
+fi
+
 AC_PROG_INSTALL
 
 AC_CONFIG_HEADER(config.h)

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -191,6 +191,7 @@
  /* check for memory mapped access avaibility. We assume every needed 
   * struct is defined if the macro TPACKET_HDRLEN is defined, because it
   * uses many ring related structs and macros */
+# ifdef PCAP_SUPPORT_PACKET_RING
 # ifdef TPACKET_HDRLEN
 #  define HAVE_PACKET_RING
 #  ifdef TPACKET3_HDRLEN
@@ -202,6 +203,7 @@
 #   define TPACKET_V1	0    /* Old kernel with only V1, so no TPACKET_Vn defined */
 #  endif /* TPACKET2_HDRLEN */
 # endif /* TPACKET_HDRLEN */
+# endif /* PCAP_SUPPORT_PACKET_RING */
 #endif /* PF_PACKET */
 
 #ifdef SO_ATTACH_FILTER


### PR DESCRIPTION
This allows the creation of 32-bit binaries that are compatible with
64-bit Linux kernels before version 2.6.27.

Original patch credit: David Fifield of the Nmap project
(https://svn.nmap.org/nmap/libpcap/NMAP_MODIFICATIONS/0002-Add-the-disable-packet-ring-configure-option.patch)