### PR TITLE
Move the inclusion of config.h to the top of scanner.l.

### DIFF
--- a/scanner.l
+++ b/scanner.l
@@ -1,3 +1,10 @@
+%top{
+/* Must come first for _LARGE_FILE_API on AIX. */
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+}
+
 %{
 /*
  * Copyright (c) 1988, 1989, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
@@ -19,10 +26,6 @@
  * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
-
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
 
 #ifdef WIN32
 #include <pcap-stdinc.h>


### PR DESCRIPTION
This works around _LARGE_FILES difficulties on AIX. See
http://seclists.org/nmap-dev/2012/q1/459 for example.

Original patch credit David Fifield of the Nmap project
(https://svn.nmap.org/nmap/libpcap/NMAP_MODIFICATIONS/pre-configure.patch)