### PR TITLE
Move the inclusion of config.h to the top of scanner.c

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -443,8 +443,9 @@ libpcap.shareda: $(OBJ)
 libpcap.none:
 
 scanner.c: $(srcdir)/scanner.l
-	@rm -f $@
-	$(srcdir)/runlex.sh $(LEX) -o$@ $<
+	@rm -f $@ $@.bottom
+	$(srcdir)/runlex.sh $(LEX) -o$@.bottom $<
+	cat $@.top $@.bottom > $@
 
 scanner.o: scanner.c tokdefs.h
 	$(CC) $(FULL_CFLAGS) -c scanner.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -444,7 +444,8 @@ libpcap.none:
 
 scanner.c: $(srcdir)/scanner.l
 	@rm -f $@ $@.bottom
-	$(srcdir)/runlex.sh $(LEX) -o$@.bottom $<
+	$(srcdir)/runlex.sh $(LEX) -o$@ $<
+	mv $@ $@.bottom
 	cat $@.top $@.bottom > $@
 
 scanner.o: scanner.c tokdefs.h

--- a/scanner.c.top
+++ b/scanner.c.top
@@ -1,0 +1,3 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif

--- a/scanner.l
+++ b/scanner.l
@@ -20,10 +20,6 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
-#include "config.h"
-#endif
-
 #ifdef WIN32
 #include <pcap-stdinc.h>
 #else /* WIN32 */


### PR DESCRIPTION
This works around _LARGE_FILES difficulties on AIX. See
http://seclists.org/nmap-dev/2012/q1/459 for example.

This is an alternative to the flex-only solution in #359