### PR TITLE
Program received signal SIGBUS, Bus error.

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -4537,7 +4537,7 @@ again:
 				handlep->current_packet = NULL;
 				return ret;
 			}
-            while (tp3_hdr->tp_status & TP_STATUS_USER) == 0) {
+            while ((tp3_hdr->tp_status & TP_STATUS_USER) == 0) {
                 printf(".");
                 fflush(stdout);
             }


### PR DESCRIPTION
After a random amount of packets the pcap_loop() function returns. 

Setup
- ath9k wireless interface in monitor mode
- libpcap 1.5.3 and yesterdays master.

```
Program received signal SIGBUS, Bus error.
0x77fac976 in pcap_read_linux_mmap_v3 ()
   from staging_dir/target-mips_34kc_uClibc-0.9.33.2/usr/lib/libpcap.so.1.3
```

Function calls:

```
pcap_open_live(iface, 256, 1, 1000, errbuf)
pcap_loop(handle, -1, callback, NULL)
```

pcap_geterr(handle) after pcap_loop() returns:

```
pcap_loop() exited: corrupted frame on kernel ring mac offset 0 + caplen -1777593832 > frame len 131072
```

What is the best approach to handle this?
