### PR TITLE
configure.in cross compile and noMMU fixes

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -459,7 +459,6 @@ linux)
 			AC_DEFINE(HAVE_LIBNL_3_x,1,[if libnl exists and is version 3.x])
 			AC_DEFINE(HAVE_LIBNL_NLE,1,[libnl has NLE_FAILURE])
 			AC_DEFINE(HAVE_LIBNL_SOCKETS,1,[libnl has new-style socket api])
-			V_INCLS="$V_INCLS -I/usr/include/libnl3"
 			have_any_nl="yes"
 		])
 

--- a/configure.in
+++ b/configure.in
@@ -1538,7 +1538,7 @@ AC_ARG_ENABLE([canusb],
 if test "x$enable_canusb" != "xno" ; then
 	dnl check for canusb support
 	case "$host_os" in
-	linux*)
+	linux*|uclinux*)
 		AC_CHECK_HEADER(libusb-1.0/libusb.h,
 		[
 		    AC_CHECK_LIB(usb-1.0, libusb_init,
@@ -1548,7 +1548,8 @@ if test "x$enable_canusb" != "xno" ; then
 			LIBS="-lusb-1.0 -lpthread $LIBS"
 			ac_lbl_has_libusb=yes
 		    ],
-		    ac_lbl_has_libusb=no
+		    ac_lbl_has_libusb=no,
+		    -lpthread
 		    )
 		],
 		ac_lbl_has_libusb=no


### PR DESCRIPTION
These fixes for libpcap accumulated in the Buildroot filesystem builder at http://git.buildroot.org/buildroot/tree/package/libpcap.