### PR TITLE
Set nonblock for fd with mmap'ed read

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -4042,7 +4042,7 @@ pcap_setnonblock_mmap(pcap_t *p, int nonblock, char *errbuf)
 			handlep->timeout = ~handlep->timeout;
 		}
 	}
-	return 0;
+	return pcap_setnonblock_fd(p, nonblock, errbuf);
 }
 
 static inline union thdr *


### PR DESCRIPTION
With libpcap mmap'ed read on LInux, which would be the very common case, even if we set pcap_setnonblock for that handle, pcap_sendpacket will block. pcap_setnonblock_fd makes pcap_sendpacket nonblock.
