### PR TITLE
Add tstamp_type/precision support for DAG capture

### DIFF
--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -1,5 +1,5 @@
 /*
- * pcap-dag.c: Packet capture interface for Endace DAG card.
+ * pcap-dag.c: Packet capture interface for Emulex EndaceDAG cards.
  *
  * The functionality of this code attempts to mimic that of pcap-linux as much
  * as possible.  This code is compiled in several different ways depending on
@@ -10,9 +10,9 @@
  * called as required from their pcap-linux/bpf equivalents.
  *
  * Authors: Richard Littin, Sean Irvine ({richard,sean}@reeltwo.com)
- * Modifications: Jesper Peterson  <support@endace.com>
- *                Koryn Grant      <support@endace.com>
- *                Stephen Donnelly <support@endace.com>
+ * Modifications: Jesper Peterson
+ *                Koryn Grant
+ *                Stephen Donnelly <stephen.donnelly@emulex.com>
  */
 
 #ifdef HAVE_CONFIG_H

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -937,26 +937,6 @@ pcap_t *dag_create(const char *device, char *ebuf, int *is_ours)
 		return NULL;
 
 	p->activate_op = dag_activate;
-	/*
-	 * We claim that we support:
-	 *
-	 *	hardware time stamps, synced to the host time;
-	 *	hardware time stamps, not synced to the host time.
-	 *
-	 * XXX - we can't determine whether the user configured the clock to be
-	 * synchronisd to the host clock, a different clock, or is free running,
-	 * so we claim both. We don't support software (HOST) timestamps at all.
-	 */
-	p->tstamp_type_count = 2;
-	p->tstamp_type_list = malloc(2 * sizeof(u_int));
-	if (p->tstamp_type_list == NULL) {
-		snprintf(ebuf, PCAP_ERRBUF_SIZE, "malloc: %s",
-		    pcap_strerror(errno));
-		free(p);
-		return NULL;
-	}
-	p->tstamp_type_list[0] = PCAP_TSTAMP_ADAPTER;
-	p->tstamp_type_list[1] = PCAP_TSTAMP_ADAPTER_UNSYNCED;
 
 	/*
 	 * We claim that we support microsecond and nanosecond time

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -40,6 +40,7 @@ struct rtentry;		/* declarations in <net/if.h> */
 
 #include "dagnew.h"
 #include "dagapi.h"
+#include "dagpci.h"
 
 #include "pcap-dag.h"
 
@@ -1012,6 +1013,8 @@ dag_findalldevs(pcap_if_t **devlistp, char *errbuf)
 	char dagname[DAGNAME_BUFSIZE];
 	int dagstream;
 	int dagfd;
+	dag_card_inf_t *inf;
+	char *description;
 
 	/* Try all the DAGs 0-DAG_MAX_BOARDS */
 	for (c = 0; c < DAG_MAX_BOARDS; c++) {
@@ -1020,8 +1023,11 @@ dag_findalldevs(pcap_if_t **devlistp, char *errbuf)
 		{
 			return -1;
 		}
+		description = NULL;
 		if ( (dagfd = dag_open(dagname)) >= 0 ) {
-			if (pcap_add_if(devlistp, name, 0, NULL, errbuf) == -1) {
+			if ((inf = dag_pciinfo(dagfd)))
+				description = dag_device_name(inf->device_code, 1);
+			if (pcap_add_if(devlistp, name, 0, description, errbuf) == -1) {
 				/*
 				 * Failure.
 				 */
@@ -1036,7 +1042,7 @@ dag_findalldevs(pcap_if_t **devlistp, char *errbuf)
 						dag_detach_stream(dagfd, stream);
 
 						snprintf(name,  10, "dag%d:%d", c, stream);
-						if (pcap_add_if(devlistp, name, 0, NULL, errbuf) == -1) {
+						if (pcap_add_if(devlistp, name, 0, description, errbuf) == -1) {
 							/*
 							 * Failure.
 							 */

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -435,6 +435,9 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 					caplen = rlen - dag_record_size - 4;
 					dp+=4;
 				}
+				/* Skip over extension headers */
+				caplen -= (8 * num_ext_hdr);
+
 				if (header->type == TYPE_ATM) {
 					caplen = packet_len = ATM_CELL_SIZE;
 				}
@@ -466,6 +469,8 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 				packet_len = ntohs(header->wlen);
 				packet_len -= (pd->dag_fcs_bits >> 3);
 				caplen = rlen - dag_record_size - 2;
+				/* Skip over extension headers */
+				caplen -= (8 * num_ext_hdr);
 				if (caplen > packet_len) {
 					caplen = packet_len;
 				}
@@ -479,6 +484,8 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 				packet_len = ntohs(header->wlen);
 				packet_len -= (pd->dag_fcs_bits >> 3);
 				caplen = rlen - dag_record_size;
+				/* Skip over extension headers */
+				caplen -= (8 * num_ext_hdr);
 				if (caplen > packet_len) {
 					caplen = packet_len;
 				}
@@ -489,6 +496,8 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 				packet_len = ntohs(header->wlen);
 				packet_len -= (pd->dag_fcs_bits >> 3);
 				caplen = rlen - dag_record_size - 4;
+				/* Skip over extension headers */
+				caplen -= (8 * num_ext_hdr);
 				if (caplen > packet_len) {
 					caplen = packet_len;
 				}
@@ -514,6 +523,8 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			case TYPE_IPV6:
 				packet_len = ntohs(header->wlen);
 				caplen = rlen - dag_record_size;
+				/* Skip over extension headers */
+				caplen -= (8 * num_ext_hdr);
 				if (caplen > packet_len) {
 					caplen = packet_len;
 				}
@@ -533,9 +544,6 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 				 */
 				continue;
 			} /* switch type */
-
-			/* Skip over extension headers */
-			caplen -= (8 * num_ext_hdr);
 
 		} /* ERF encapsulation */
 		


### PR DESCRIPTION
Add tstamp_precision and tstamp_type support to pcap-dag.c.

Update contact details.

The DAG hardware clock may or may not be synchronsied to either the host clock or an external clock reference, so we can't determine which of PCAP_TSTAMP_ADAPTER or PCAP_TSTAMP_ADAPTER_UNSYNCED is accurate. Either will produce the same result.

The only potential concern is that we don't advertise PCAP_TSTAMP_HOST_* so anyone requesting those explicitly will not be able to capture. 
