### PR TITLE
Revert "patch partialy fix building on QNX 6.5"

### DIFF
--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -70,7 +70,7 @@
  *
  * This also provides our own multiple-include protection.
  */
-#if !defined(_NET_BPF_H_) && !defined(_NET_BPF_H_INCLUDED) && !defined(_BPF_H_) && !defined(_H_BPF) && !defined(lib_pcap_bpf_h)
+#if !defined(_NET_BPF_H_) && !defined(_BPF_H_) && !defined(_H_BPF) && !defined(lib_pcap_bpf_h)
 #define lib_pcap_bpf_h
 
 #ifdef __cplusplus

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -409,7 +409,7 @@ const char *pcap_lib_version(void);
  * declared in <net/bpf.h>, so we *do* want to declare it here, so it's
  * declared when we build pcap-bpf.c.
  */
-#if !defined(__NetBSD__) && !defined(__QNX__)
+#ifndef __NetBSD__
 u_int	bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
 #endif
 int	bpf_validate(const struct bpf_insn *f, int len);


### PR DESCRIPTION
Reverts the-tcpdump-group/libpcap#394

We don't want to patch the ancient 1.2 branch, we want to patch the _trunk_.
