### PR TITLE
Correct return value documentation in manpages.

### DIFF
--- a/pcap_datalink_name_to_val.3pcap
+++ b/pcap_datalink_name_to_val.3pcap
@@ -41,6 +41,6 @@ removed, to the corresponding link-layer header type value.  The
 translation is case-insensitive.
 .SH RETURN VALUE
 .B pcap_datalink_name_to_val()
-returns 0 on success and \-1 on failure.
+returns type value on success and \-1 on failure.
 .SH SEE ALSO
 pcap(3PCAP)

--- a/pcap_set_tstamp_type.3pcap.in
+++ b/pcap_set_tstamp_type.3pcap.in
@@ -52,7 +52,7 @@ for a list of all the time stamp types.
 returns 0 on success if the specified time stamp type is expected to be
 supported by the capture device,
 .B PCAP_WARNING_TSTAMP_TYPE_NOTSUP
-on success if the specified time stamp type is not supported by the
+if the specified time stamp type is not supported by the
 capture device,
 .B PCAP_ERROR_ACTIVATED
 if called on a capture handle that has been activated, and

--- a/pcap_tstamp_type_name_to_val.3pcap
+++ b/pcap_tstamp_type_name_to_val.3pcap
@@ -38,7 +38,7 @@ translates a time stamp type name to the corresponding time stamp type
 value.  The translation is case-insensitive.
 .SH RETURN VALUE
 .B pcap_tstamp_type_name_to_val()
-returns 0 on success and
+returns time stamp type value on success and
 .B PCAP_ERROR
 on failure.
 .SH SEE ALSO


### PR DESCRIPTION
Manpages:
- pcap_datalink_name_to_val
- pcap_set_tstamp_type
- pcap_tstamp_type_name_to_val
