### PR TITLE
BPF: add new DLT for WattStopper DLM bus protocol

### DIFF
--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -1318,7 +1318,13 @@ struct bpf_program {
 #define DLT_ZWAVE_R1_R2  261
 #define DLT_ZWAVE_R3     262
 
-#define DLT_MATCHING_MAX	262	/* highest value in the "matching" range */
+/*
+ * per Steve Karg <skarg@users.sourceforge.net>, formats for Wattstopper
+ * Digital Lighting Management room bus serial protocol captures.
+ */
+#define DLT_WATTSTOPPER_DLM     263
+
+#define DLT_MATCHING_MAX	263	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
For a few years I have been using DLT_USER0 147 (user defined) for capturing and saving a serial protocol used by Wattstopper Digital Lighting Management products (see wattstopper.com website) and dissecting via Wireshark and Lua. I'm planning on adding this pcap file logging to a product, and would like to have a DLT defined for this usage. This started with Issue #401.