### PR TITLE
Use size_t for buffer sizes instead of int

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -161,7 +161,7 @@ struct pcap {
 	/*
 	 * Read buffer.
 	 */
-	int bufsize;
+	size_t bufsize;
 	u_char *buffer;
 	u_char *bp;
 	int cc;

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -298,7 +298,7 @@ struct pcap_linux {
 	size_t	mmapbuflen;	/* size of region */
 	int	vlan_offset;	/* offset at which to insert vlan tags; if -1, don't insert */
 	u_int	tp_version;	/* version of tpacket_hdr for mmaped ring */
-	u_int	tp_hdrlen;	/* hdrlen of tpacket_hdr for mmaped ring */
+	size_t	tp_hdrlen;	/* hdrlen of tpacket_hdr for mmaped ring */
 	u_char	*oneshot_buffer; /* buffer for copy of packet */
 #ifdef HAVE_TPACKET3
 	unsigned char *current_packet; /* Current packet within the TPACKET_V3 block. Move to next block if NULL. */
@@ -4220,7 +4220,7 @@ static int pcap_handle_packet_mmap(
 	if (tp_mac + tp_snaplen > handle->bufsize) {
 		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
 			"corrupted frame on kernel ring mac "
-			"offset %d + caplen %d > frame len %d",
+			"offset %d + caplen %d > frame len %zd",
 			tp_mac, tp_snaplen, handle->bufsize);
 		return -1;
 	}

--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -149,7 +149,7 @@ pcap_stats_win32(pcap_t *p, struct pcap_stat *ps)
 
 /* Set the dimension of the kernel-level capture buffer */
 static int
-pcap_setbuff_win32(pcap_t *p, int dim)
+pcap_setbuff_win32(pcap_t *p, size_t dim)
 {
 	if(PacketSetBuff(p->adapter,dim)==FALSE)
 	{

--- a/pcap.c
+++ b/pcap.c
@@ -659,7 +659,7 @@ pcap_set_immediate_mode(pcap_t *p, int immediate)
 }
 
 int
-pcap_set_buffer_size(pcap_t *p, int buffer_size)
+pcap_set_buffer_size(pcap_t *p, size_t buffer_size)
 {
 	if (pcap_check_activated(p))
 		return (PCAP_ERROR_ACTIVATED);
@@ -1656,7 +1656,7 @@ pcap_setmode_dead(pcap_t *p, int mode)
 }
 
 int
-pcap_setmintocopy(pcap_t *p, int size)
+pcap_setmintocopy(pcap_t *p, size_t size)
 {
 	return (p->setmintocopy_op(p, size));
 }
@@ -1668,7 +1668,7 @@ pcap_get_adapter(pcap_t *p)
 }
 
 static int
-pcap_setmintocopy_dead(pcap_t *p, int size)
+pcap_setmintocopy_dead(pcap_t *p, size_t size)
 {
 	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 	    "The mintocopy parameter cannot be set on a pcap_open_dead pcap_t");
@@ -1849,7 +1849,7 @@ pcap_open_dead(int linktype, int snaplen)
  * XXX - what if we get a short write?
  */
 int
-pcap_sendpacket(pcap_t *p, const u_char *buf, int size)
+pcap_sendpacket(pcap_t *p, const u_char *buf, size_t size)
 {
 	if (p->inject_op(p, buf, size) == -1)
 		return (-1);

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -282,7 +282,7 @@ int	pcap_set_rfmon(pcap_t *, int);
 int	pcap_set_timeout(pcap_t *, int);
 int	pcap_set_tstamp_type(pcap_t *, int);
 int	pcap_set_immediate_mode(pcap_t *, int);
-int	pcap_set_buffer_size(pcap_t *, int);
+int	pcap_set_buffer_size(pcap_t *, size_t);
 int	pcap_set_tstamp_precision(pcap_t *, int);
 int	pcap_get_tstamp_precision(pcap_t *);
 int	pcap_activate(pcap_t *);
@@ -381,7 +381,7 @@ int 	pcap_setdirection(pcap_t *, pcap_direction_t);
 int	pcap_getnonblock(pcap_t *, char *);
 int	pcap_setnonblock(pcap_t *, int, char *);
 int	pcap_inject(pcap_t *, const void *, size_t);
-int	pcap_sendpacket(pcap_t *, const u_char *, int);
+int	pcap_sendpacket(pcap_t *, const u_char *, size_t);
 const char *pcap_statustostr(int);
 const char *pcap_strerror(int);
 char	*pcap_geterr(pcap_t *);
@@ -443,9 +443,9 @@ void	bpf_dump(const struct bpf_program *, int);
  * Win32 definitions
  */
 
-int pcap_setbuff(pcap_t *p, int dim);
+int pcap_setbuff(pcap_t *p, size_t dim);
 int pcap_setmode(pcap_t *p, int mode);
-int pcap_setmintocopy(pcap_t *p, int size);
+int pcap_setmintocopy(pcap_t *p, size_t size);
 Adapter *pcap_get_adapter(pcap_t *p);
 
 #ifdef WPCAP

--- a/pcap_set_buffer_size.3pcap
+++ b/pcap_set_buffer_size.3pcap
@@ -27,7 +27,7 @@ capture handle
 #include <pcap/pcap.h>
 .LP
 .ft B
-int pcap_set_buffer_size(pcap_t *p, int buffer_size);
+int pcap_set_buffer_size(pcap_t *p, size_t buffer_size);
 .ft
 .fi
 .SH DESCRIPTION


### PR DESCRIPTION
I'm seeing all kinds of problems on a PARISC system and I'm not here to solve all of them. Running tcpdump crashes the system (a kernel problem not fixed here, of course) on a 64-bit system with a 32-bit userland and with more than 4 gigabytes RAM. The kernel does not crash with only 2 gigabytes of RAM, but does give a clue as pcap prints:
corrupted frame on kernel ring mac offset 23712 + caplen -1163995555 > frame len 262144

Obviously caplen should not be negative.

Oh, did I mention that Linux on PARISC64 doesn't merely use a 32-bit userland (which very likely complicates talking to the kernel and interpreting what it returns) but that it's also big-endian (along with HP-UX) and that its stack direction is up, not down (as with HP-UX)?

With these changes, what it at least gets right is caplen:
corrupted frame on kernel ring mac offset 9562 + caplen 839049610 > frame len 262144

even if caplen is still way off the chart.

That aside, tcpdump just keeps thrashing it until the kernel dies a sorry death. wireshark neatly stops capturing when this happens. I haven't looked into the actual problem much yet, the one where caplen gets mangled beyond recognition, and I suspect that's hidden in pcap-linux.c somewhere.