### PR TITLE
Add support for MPTCP filtering

### DIFF
--- a/gencode.h
+++ b/gencode.h
@@ -126,6 +126,8 @@
 
 #define Q_CARP		41
 
+#define Q_MPTCP		42
+
 /* Directional qualifiers. */
 
 #define Q_SRC		1

--- a/grammar.y
+++ b/grammar.y
@@ -285,7 +285,7 @@ pfaction_to_num(const char *action)
 
 
 %token  DST SRC HOST GATEWAY
-%token  NET NETMASK PORT PORTRANGE LESS GREATER PROTO PROTOCHAIN CBYTE
+%token  NET NETMASK PORT PORTRANGE LESS GREATER PROTO PROTOCHAIN CBYTE MPTCP
 %token  ARP RARP IP SCTP TCP UDP ICMP IGMP IGRP PIM VRRP CARP
 %token  ATALK AARP DECNET LAT SCA MOPRC MOPDL
 %token  TK_BROADCAST TK_MULTICAST
@@ -508,6 +508,7 @@ pname:	  LINK			{ $$ = Q_LINK; }
 	| IPX			{ $$ = Q_IPX; }
 	| NETBEUI		{ $$ = Q_NETBEUI; }
 	| RADIO			{ $$ = Q_RADIO; }
+	| MPTCP			{ $$ = Q_MPTCP; }
 	;
 other:	  pqual TK_BROADCAST	{ $$ = gen_broadcast($1); }
 	| pqual TK_MULTICAST	{ $$ = gen_multicast($1); }

--- a/scanner.l
+++ b/scanner.l
@@ -200,6 +200,7 @@ pim		return PIM;
 vrrp		return VRRP;
 carp		return CARP;
 radio		return RADIO;
+mptcp		return MPTCP;
 
 ip6		return IPV6;
 icmp6		return ICMPV6;


### PR DESCRIPTION
Multipath TCP (MPTCP) is a standardized extension to TCP (see http://tools.ietf.org/html/rfc6824).This pull request add the support for filtering on packets containing at least one MPTCP option.

The BPF code generated is complex and large due to the limitations of BPF (i.e. no loop) so any feedback on how to reduce the code is welcome !