### PR TITLE
Corrective: pcap-linux.c

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -3758,6 +3758,12 @@ create_ring(pcap_t *handle, int *status)
 		req.tp_frame_nr = handle->opt.buffer_size/req.tp_frame_size;
 		break;
 #endif
+	default:
+		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+		    "Internal error: unknown TPACKET_value %d",
+		    handlep->tp_version);
+		*status = PCAP_ERROR;
+		return -1;
 	}
 
 	/* compute the minumum block size that will handle this frame. 

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -3017,7 +3017,7 @@ activate_new(pcap_t *handle)
 	struct packet_mreq	mr;
 #ifdef SO_BPF_EXTENSIONS
 	int			bpf_extensions;
-	socklen_t		len;
+	socklen_t		len = sizeof(bpf_extensions);
 #endif
 
 	/*


### PR DESCRIPTION
If tp version is not valid, then we don't enter in the switch condition and we access to an uninitialized variable (req.tp_frame_size).