### PR TITLE
Add support for Geneve (Generic Network Virtualization Encapsulation).

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+Thursday Feb. 12, 2015 guy@alum.mit.edu/mcr@sandelman.ca
+  Summary for 1.8.0 libpcap release
+	Support for filtering Geneve encapsulated packets.
+
 Wednesday Nov. 12, 2014 guy@alum.mit.edu/mcr@sandelman.ca
   Summary for 1.7.0 libpcap release
 	Fix handling of zones for BPF on Solaris

--- a/gencode.c
+++ b/gencode.c
@@ -1107,10 +1107,14 @@ init_linktype(p)
 		off_nl_nosnap = 3;	/* 802.2 */
 		break;
 
-	case DLT_IEEE802_11:
 	case DLT_PRISM_HEADER:
 	case DLT_IEEE802_11_RADIO_AVS:
 	case DLT_IEEE802_11_RADIO:
+		off_linkhdr.is_variable = 1;
+		/* Fall through, 802.11 doesn't have a variable link
+		 * prefix but is otherwise the same. */
+
+	case DLT_IEEE802_11:
 		/*
 		 * 802.11 doesn't really have a link-level type field.
 		 * We set "off_linktype" to the offset of the LLC header.
@@ -1148,6 +1152,7 @@ init_linktype(p)
 		off_linktype = 24;
 		off_linkpl.constant_part = 0;	/* link-layer header is variable-length */
 		off_linkpl.is_variable = 1;
+		off_linkhdr.is_variable = 1;
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
 		break;

--- a/gencode.c
+++ b/gencode.c
@@ -1630,7 +1630,7 @@ gen_loadx_iphdrlen()
 		 * the value from the X register.
 		 */
 		s2 = new_stmt(BPF_LD|BPF_IND|BPF_B);
-		s2->s.k = off_nl;
+		s2->s.k = off_linkpl.constant_part + off_nl;
 		sappend(s, s2);
 		s2 = new_stmt(BPF_ALU|BPF_AND|BPF_K);
 		s2->s.k = 0xf;

--- a/gencode.c
+++ b/gencode.c
@@ -5557,15 +5557,8 @@ gen_protochain(v, proto, dir)
 	 * branches, and backward branch support is unlikely to appear
 	 * in kernel BPF engines.)
 	 */
-	switch (linktype) {
-
-	case DLT_IEEE802_11:
-	case DLT_PRISM_HEADER:
-	case DLT_IEEE802_11_RADIO_AVS:
-	case DLT_IEEE802_11_RADIO:
-	case DLT_PPI:
-		bpf_error("'protochain' not supported with 802.11");
-	}
+	if (off_linkpl.is_variable)
+		bpf_error("'protochain' not supported with variable length headers");
 
 	no_optimize = 1; /*this code is not compatible with optimzer yet */
 

--- a/gencode.c
+++ b/gencode.c
@@ -7955,7 +7955,11 @@ gen_vlan(vlan_num)
 	case DLT_NETANALYZER:
 	case DLT_NETANALYZER_TRANSPARENT:
 #if defined(SKF_AD_VLAN_TAG) && defined(SKF_AD_VLAN_TAG_PRESENT)
-		if (vlan_stack_depth == 0) {
+		/* Verify that this is the outer part of the packet and
+		 * not encapsulated somehow. */
+		if (vlan_stack_depth == 0 && !off_linkhdr.is_variable &&
+		    off_linkhdr.constant_part ==
+		    off_outermostlinkhdr.constant_part) {
 			/*
 			 * Do we need special VLAN handling?
 			 */

--- a/gencode.c
+++ b/gencode.c
@@ -2574,6 +2574,15 @@ insert_compute_vloffsets(b)
 {
 	struct slist *s;
 
+	/* There is an implicit dependency between the link
+	 * payload and link header since the payload computation
+	 * includes the variable part of the header. Therefore,
+	 * if nobody else has allocated a register for the link
+	 * header and we need it, do it now. */
+	if (off_linkpl.reg != -1 && off_linkhdr.is_variable &&
+	    off_linkhdr.reg == -1)
+		off_linkhdr.reg = alloc_reg();
+
 	/*
 	 * For link-layer types that have a variable-length header
 	 * preceding the link-layer header, generate code to load

--- a/gencode.c
+++ b/gencode.c
@@ -981,21 +981,21 @@ init_linktype(p)
 		off_linkpl.constant_part = 6;
 		off_nl = 0;		/* XXX in reality, variable! */
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_ARCNET_LINUX:
 		off_linktype = 4;
 		off_linkpl.constant_part = 8;
 		off_nl = 0;		/* XXX in reality, variable! */
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_EN10MB:
 		off_linktype = 12;
 		off_linkpl.constant_part = 14;	/* Ethernet header length */
 		off_nl = 0;		/* Ethernet II */
 		off_nl_nosnap = 3;	/* 802.3+802.2 */
-		return;
+		break;
 
 	case DLT_SLIP:
 		/*
@@ -1006,7 +1006,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 16;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_SLIP_BSDOS:
 		/* XXX this may be the same as the DLT_PPP_BSDOS case */
@@ -1015,7 +1015,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 24;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_NULL:
 	case DLT_LOOP:
@@ -1023,14 +1023,14 @@ init_linktype(p)
 		off_linkpl.constant_part = 4;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_ENC:
 		off_linktype = 0;
 		off_linkpl.constant_part = 12;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_PPP:
 	case DLT_PPP_PPPD:
@@ -1040,7 +1040,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 4;	/* skip HDLC-like framing and protocol field */
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_PPP_ETHER:
 		/*
@@ -1051,14 +1051,14 @@ init_linktype(p)
 		off_linkpl.constant_part = 8;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_PPP_BSDOS:
 		off_linktype = 5;
 		off_linkpl.constant_part = 24;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_FDDI:
 		/*
@@ -1075,7 +1075,7 @@ init_linktype(p)
 		off_linkpl.constant_part += pcap_fddipad;
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_IEEE802:
 		/*
@@ -1105,7 +1105,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 14;	/* Token Ring MAC header length */
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_IEEE802_11:
 	case DLT_PRISM_HEADER:
@@ -1133,7 +1133,7 @@ init_linktype(p)
 		off_linkpl.is_variable = 1;
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_PPI:
 		/*
@@ -1150,7 +1150,7 @@ init_linktype(p)
 		off_linkpl.is_variable = 1;
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_ATM_RFC1483:
 	case DLT_ATM_CLIP:	/* Linux ATM defines this */
@@ -1169,7 +1169,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 0;	/* packet begins with LLC header */
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_SUNATM:
 		/*
@@ -1185,7 +1185,7 @@ init_linktype(p)
 		off_linkpl.constant_part = off_payload;	/* if LLC-encapsulated */
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_RAW:
 	case DLT_IPV4:
@@ -1194,14 +1194,14 @@ init_linktype(p)
 		off_linkpl.constant_part = 0;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_LINUX_SLL:	/* fake header for Linux cooked socket */
 		off_linktype = 14;
 		off_linkpl.constant_part = 16;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_LTALK:
 		/*
@@ -1213,7 +1213,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 0;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_IP_OVER_FC:
 		/*
@@ -1230,7 +1230,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 16;
 		off_nl = 8;		/* 802.2+SNAP */
 		off_nl_nosnap = 3;	/* 802.2 */
-		return;
+		break;
 
 	case DLT_FRELAY:
 		/*
@@ -1241,7 +1241,7 @@ init_linktype(p)
 		off_linkpl.constant_part = 0;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
                 /*
                  * the only BPF-interesting FRF.16 frames are non-control frames;
@@ -1253,21 +1253,21 @@ init_linktype(p)
 		off_linkpl.constant_part = 0;
 		off_nl = 4;
 		off_nl_nosnap = 0;	/* XXX - for now -> no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_APPLE_IP_OVER_IEEE1394:
 		off_linktype = 16;
 		off_linkpl.constant_part = 18;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_SYMANTEC_FIREWALL:
 		off_linktype = 6;
 		off_linkpl.constant_part = 44;
 		off_nl = 0;		/* Ethernet II */
 		off_nl_nosnap = 0;	/* XXX - what does it do with 802.3 packets? */
-		return;
+		break;
 
 #ifdef HAVE_NET_PFVAR_H
 	case DLT_PFLOG:
@@ -1275,7 +1275,7 @@ init_linktype(p)
 		off_linkpl.constant_part = PFLOG_HDRLEN;
 		off_nl = 0;
 		off_nl_nosnap = 0;	/* no 802.2 LLC */
-		return;
+		break;
 #endif
 
         case DLT_JUNIPER_MFR:
@@ -1288,21 +1288,21 @@ init_linktype(p)
 		off_linkpl.constant_part = 4;
 		off_nl = 0;
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-                return;
+                break;
 
 	case DLT_JUNIPER_ATM1:
 		off_linktype = 4;		/* in reality variable between 4-8 */
 		off_linkpl.constant_part = 4;	/* in reality variable between 4-8 */
 		off_nl = 0;
 		off_nl_nosnap = 10;
-		return;
+		break;
 
 	case DLT_JUNIPER_ATM2:
 		off_linktype = 8;		/* in reality variable between 8-12 */
 		off_linkpl.constant_part = 8;	/* in reality variable between 8-12 */
 		off_nl = 0;
 		off_nl_nosnap = 10;
-		return;
+		break;
 
 		/* frames captured on a Juniper PPPoE service PIC
 		 * contain raw ethernet frames */
@@ -1312,70 +1312,70 @@ init_linktype(p)
 		off_linktype = 16;
 		off_nl = 18;		/* Ethernet II */
 		off_nl_nosnap = 21;	/* 802.3+802.2 */
-		return;
+		break;
 
 	case DLT_JUNIPER_PPPOE_ATM:
 		off_linktype = 4;
 		off_linkpl.constant_part = 6;
 		off_nl = 0;
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_JUNIPER_GGSN:
 		off_linktype = 6;
 		off_linkpl.constant_part = 12;
 		off_nl = 0;
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_JUNIPER_ES:
 		off_linktype = 6;
 		off_linkpl.constant_part = -1;	/* not really a network layer but raw IP addresses */
 		off_nl = -1;		/* not really a network layer but raw IP addresses */
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_JUNIPER_MONITOR:
 		off_linktype = 12;
 		off_linkpl.constant_part = 12;
 		off_nl = 0;		/* raw IP/IP6 header */
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_BACNET_MS_TP:
 		off_linktype = -1;
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_JUNIPER_SERVICES:
 		off_linktype = 12;
 		off_linkpl.constant_part = -1;	/* L3 proto location dep. on cookie type */
 		off_nl = -1;		/* L3 proto location dep. on cookie type */
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_JUNIPER_VP:
 		off_linktype = 18;
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_JUNIPER_ST:
 		off_linktype = 18;
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_JUNIPER_ISM:
 		off_linktype = 8;
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_JUNIPER_VS:
 	case DLT_JUNIPER_SRX_E2E:
@@ -1385,7 +1385,7 @@ init_linktype(p)
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_MTP2:
 		off_li = 2;
@@ -1398,7 +1398,7 @@ init_linktype(p)
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_MTP2_WITH_PHDR:
 		off_li = 6;
@@ -1411,7 +1411,7 @@ init_linktype(p)
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_ERF:
 		off_li = 22;
@@ -1424,14 +1424,14 @@ init_linktype(p)
 		off_linkpl.constant_part = -1;
 		off_nl = -1;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_PFSYNC:
 		off_linktype = -1;
 		off_linkpl.constant_part = 4;
 		off_nl = 0;
 		off_nl_nosnap = 0;
-		return;
+		break;
 
 	case DLT_AX25_KISS:
 		/*
@@ -1441,14 +1441,14 @@ init_linktype(p)
 		off_linkpl.constant_part = -1;
 		off_nl = -1;		/* variable, min 16, max 71 steps of 7 */
 		off_nl_nosnap = -1;	/* no 802.2 LLC */
-		return;
+		break;
 
 	case DLT_IPNET:
 		off_linktype = 1;
 		off_linkpl.constant_part = 24;	/* ipnet header length */
 		off_nl = 0;
 		off_nl_nosnap = -1;
-		return;
+		break;
 
 	case DLT_NETANALYZER:
 		off_linkhdr.constant_part = 4;	/* Ethernet header is past 4-byte pseudo-header */
@@ -1456,7 +1456,7 @@ init_linktype(p)
 		off_linkpl.constant_part = off_linkhdr.constant_part + 14;	/* pseudo-header+Ethernet header length */
 		off_nl = 0;		/* Ethernet II */
 		off_nl_nosnap = 3;	/* 802.3+802.2 */
-		return;
+		break;
 
 	case DLT_NETANALYZER_TRANSPARENT:
 		off_linkhdr.constant_part = 12;	/* MAC header is past 4-byte pseudo-header, preamble, and SFD */
@@ -1464,7 +1464,7 @@ init_linktype(p)
 		off_linkpl.constant_part = off_linkhdr.constant_part + 14;	/* pseudo-header+preamble+SFD+Ethernet header length */
 		off_nl = 0;		/* Ethernet II */
 		off_nl_nosnap = 3;	/* 802.3+802.2 */
-		return;
+		break;
 
 	default:
 		/*
@@ -1477,12 +1477,13 @@ init_linktype(p)
 			off_linkpl.constant_part = -1;
 			off_nl = -1;
 			off_nl_nosnap = -1;
-			return;
+		} else {
+			bpf_error("unknown data link type %d", linktype);
 		}
-
+		break;
 	}
-	bpf_error("unknown data link type %d", linktype);
-	/* NOTREACHED */
+
+	off_outermostlinkhdr = off_prevlinkhdr = off_linkhdr;
 }
 
 /*

--- a/gencode.h
+++ b/gencode.h
@@ -321,6 +321,8 @@ struct block *gen_mpls(int);
 struct block *gen_pppoed(void);
 struct block *gen_pppoes(int);
 
+struct block *gen_geneve(int);
+
 struct block *gen_atmfield_code(int atmfield, bpf_int32 jvalue, bpf_u_int32 jtype, int reverse);
 struct block *gen_atmtype_abbrev(int type);
 struct block *gen_atmmulti_abbrev(int type);

--- a/grammar.y
+++ b/grammar.y
@@ -299,7 +299,7 @@ pfaction_to_num(const char *action)
 %token  LEN
 %token  IPV6 ICMPV6 AH ESP
 %token	VLAN MPLS
-%token	PPPOED PPPOES
+%token	PPPOED PPPOES GENEVE
 %token  ISO ESIS CLNP ISIS L1 L2 IIH LSP SNP CSNP PSNP 
 %token  STP
 %token  IPX
@@ -523,6 +523,8 @@ other:	  pqual TK_BROADCAST	{ $$ = gen_broadcast($1); }
 	| PPPOED		{ $$ = gen_pppoed(); }
 	| PPPOES pnum		{ $$ = gen_pppoes($2); }
 	| PPPOES		{ $$ = gen_pppoes(-1); }
+	| GENEVE pnum		{ $$ = gen_geneve($2); }
+	| GENEVE		{ $$ = gen_geneve(-1); }
 	| pfvar			{ $$ = $1; }
 	| pqual p80211		{ $$ = $2; }
 	| pllc			{ $$ = $1; }

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -733,6 +733,22 @@ For example:
 .fi
 .in -.5i
 filters IPv4 protocols encapsulated in PPPoE session id 0x27.
+.IP "\fBgeneve \fI[vni]\fR"
+True if the packet is a Geneve packet (UDP port 6081). If \fI[vni]\fR
+is specified, only true if the packet has the specified \fIvni\fR.
+Note that when the \fBgeneve\fR keyword is encountered in
+\fIexpression\fR, it changes the decoding offsets for the remainder of
+\fIexpression\fR on the assumption that the packet is a Geneve packet.
+.IP
+For example:
+.in +.5i
+.nf
+\fBgeneve 0xb && ip\fR
+.fi
+.in -.5i
+filters IPv4 protocols encapsulated in Geneve with VNI 0xb. This will
+match both IP directly encapsulated in Geneve as well as IP contained
+inside an Ethernet frame.
 .IP "\fBiso proto \fIprotocol\fR"
 True if the packet is an OSI packet of protocol type \fIprotocol\fP.
 \fIProtocol\fP can be a number or one of the names

--- a/scanner.l
+++ b/scanner.l
@@ -279,6 +279,7 @@ vlan		return VLAN;
 mpls		return MPLS;
 pppoed		return PPPOED;
 pppoes		return PPPOES;
+geneve		return GENEVE;
 
 lane		return LANE;
 llc		return LLC;


### PR DESCRIPTION
"geneve" can be used to filter on Geneve encapsulated packets. It
also allows later filters to look at frames inside the tunnel
headers.

The Geneve protocol is documented here:
http://tools.ietf.org/html/draft-gross-geneve-02