### PR TITLE
remove duplicate includes, align h1_64 with the other struct members

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -137,8 +137,6 @@
 #include <net/if_arp.h>
 #include <poll.h>
 #include <dirent.h>
-#include <sys/stat.h>
-#include <sys/utsname.h>
 
 #include "pcap-int.h"
 #include "pcap/sll.h"
@@ -352,7 +350,7 @@ struct tpacket_hdr_64 {
 
 union thdr {
 	struct tpacket_hdr		*h1;
-	struct tpacket_hdr_64	*h1_64;
+	struct tpacket_hdr_64		*h1_64;
 #ifdef HAVE_TPACKET2
 	struct tpacket2_hdr		*h2;
 #endif


### PR DESCRIPTION
This is a super-trivial patch, just a couple of things I noticed while reviewing #421 