### PR TITLE
add pkg-config support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ valgrindtest
 grammar.c
 libpcap.a
 libpcap.*.dylib
+libpcap.pc
 libpcap.sl
 libpcap.so.*
 libpcap-*.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -40,7 +40,7 @@ pcap_open_dead.3pcap
 pcap_open_offline.3pcap
 pcap_set_tstamp_precision.3pcap
 pcap_set_tstamp_type.3pcap
-scanner.c
+scanner.c*
 scanner.h
 selpolltest
 tokdefs.h

--- a/Makefile.in
+++ b/Makefile.in
@@ -61,6 +61,10 @@ V_RPATH_OPT = @V_RPATH_OPT@
 DEPENDENCY_CFLAG = @DEPENDENCY_CFLAG@
 PROG=libpcap
 
+# pkgconfig support
+pkgconfigdir = $(libdir)/pkgconfig
+pkgconfig_DATA = libpcap.pc
+
 # Standard CFLAGS
 FULL_CFLAGS = $(CCOPT) $(INCLS) $(DEFS) $(CFLAGS)
 
@@ -276,6 +280,7 @@ EXTRA_DIST = \
 	lbl/os-solaris2.h \
 	lbl/os-sunos4.h \
 	lbl/os-ultrix4.h \
+	libpcap.pc \
 	missing/snprintf.c \
 	mkdep \
 	msdos/bin2c.c \

--- a/configure
+++ b/configure
@@ -3791,6 +3791,12 @@ $as_echo "$ac_cv___attribute___format" >&6; }
 
 fi
 
+if test "x$PACKAGE_VERSION" = "x"; then
+      if test -f "VERSION"; then
+      PACKAGE_VERSION=`head -1 VERSION`
+   fi
+fi
+
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
@@ -8569,6 +8575,8 @@ test -z "$INSTALL_DATA" && INSTALL_DATA='${INSTALL} -m 644'
 
 ac_config_headers="$ac_config_headers config.h"
 
+ac_config_files="$ac_config_files libpcap.pc"
+
 
 ac_config_commands="$ac_config_commands default-1"
 
@@ -9274,6 +9282,7 @@ for ac_config_target in $ac_config_targets
 do
   case $ac_config_target in
     "config.h") CONFIG_HEADERS="$CONFIG_HEADERS config.h" ;;
+    "libpcap.pc") CONFIG_FILES="$CONFIG_FILES libpcap.pc" ;;
     "default-1") CONFIG_COMMANDS="$CONFIG_COMMANDS default-1" ;;
     "Makefile") CONFIG_FILES="$CONFIG_FILES Makefile" ;;
     "pcap-filter.manmisc") CONFIG_FILES="$CONFIG_FILES pcap-filter.manmisc" ;;

--- a/configure.in
+++ b/configure.in
@@ -30,6 +30,13 @@ if test "$ac_cv___attribute__" = "yes"; then
 	AC_C___ATTRIBUTE___FORMAT
 fi
 
+if test "x$PACKAGE_VERSION" = "x"; then
+   dnl PACKAGE_VERSION was not specified above, check the VERSION file
+   if test -f "VERSION"; then
+      PACKAGE_VERSION=`head -1 VERSION`
+   fi
+fi
+
 AC_CHECK_HEADERS(sys/bitypes.h)
 
 AC_CHECK_TYPE([int8_t], ,
@@ -1742,6 +1749,7 @@ fi
 AC_PROG_INSTALL
 
 AC_CONFIG_HEADER(config.h)
+AC_CONFIG_FILES([libpcap.pc])
 
 AC_OUTPUT_COMMANDS([if test -f .devel; then
 	echo timestamp > stamp-h

--- a/libpcap.pc.in
+++ b/libpcap.pc.in
@@ -1,0 +1,10 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: libpcap
+Description: System-independent interface for user-level packet capture.
+Version: @PACKAGE_VERSION@
+Libs: -L${libdir} -lpcap
+Cflags: -I${includedir}


### PR DESCRIPTION
The intent here is to have no impact on the existing libpcap development or deployment method, but for systems where pkg-config is available, libpcap can provide accurate information to it.