### PR TITLE
bpf: increase snaplen if doing cooked mode userspace filtering

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -4471,6 +4471,7 @@ static int pcap_handle_packet_mmap(
 	unsigned char *bp;
 	struct sockaddr_ll *sll;
 	struct pcap_pkthdr pcaphdr;
+	unsigned int snaplen = tp_snaplen;
 
 	/* perform sanity check on internal offset. */
 	if (tp_mac + tp_snaplen > handle->bufsize) {
@@ -4531,6 +4532,8 @@ static int pcap_handle_packet_mmap(
 		hdrp->sll_halen = htons(sll->sll_halen);
 		memcpy(hdrp->sll_addr, sll->sll_addr, SLL_ADDRLEN);
 		hdrp->sll_protocol = sll->sll_protocol;
+
+		snaplen += sizeof(struct sll_header);
 	}
 
 	if (handlep->filter_in_userland && handle->fcode.bf_insns) {
@@ -4539,8 +4542,11 @@ static int pcap_handle_packet_mmap(
 		aux_data.vlan_tag = tp_vlan_tci & 0x0fff;
 		aux_data.vlan_tag_present = tp_vlan_tci_valid;
 
-		if (bpf_filter_with_aux_data(handle->fcode.bf_insns, bp,
-		    tp_len, tp_snaplen, &aux_data) == 0)
+		if (bpf_filter_with_aux_data(handle->fcode.bf_insns,
+					     bp,
+					     tp_len,
+					     snaplen,
+					     &aux_data) == 0)
 			return 0;
 	}
 


### PR DESCRIPTION
This commit should address the issue when bpf_filter_with_auxdata returned 0 for valid
packets because offset in filter exceeded tp_snaplen as returned by kernel. If
we filter in cooked mode filter offsets are adjusted because sll_header, we
should do the same for snaplen.
