### PR TITLE
Add the pcap_file_type() function and the file_type member in pcap_t

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -195,6 +195,8 @@ struct pcap {
 	int version_major;
 	int version_minor;
 
+	int file_type;		/* pcap or pcap-ng (for now) */
+
 	int snapshot;
 	int linktype;		/* Network linktype */
 	int linktype_ext;       /* Extended information stored in the linktype field of a file */

--- a/pcap.c
+++ b/pcap.c
@@ -1385,6 +1385,14 @@ pcap_is_swapped(pcap_t *p)
 }
 
 int
+pcap_file_type(pcap_t *p)
+{
+	if (!p->activated)
+		return (PCAP_ERROR_NOT_ACTIVATED);
+	return (p->file_type);
+}
+
+int
 pcap_major_version(pcap_t *p)
 {
 	if (!p->activated)

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -56,6 +56,13 @@ extern "C" {
 #endif
 
 /*
+ * File types supported
+ * now pcap-ng is only supported for reading.
+ */
+#define PCAP_FILE_TYPE    0
+#define PCAP_NG_FILE_TYPE 1
+
+/*
  * Version number of the current version of the pcap file format.
  *
  * NOTE: this is *NOT* the version number of the libpcap library.
@@ -64,6 +71,12 @@ extern "C" {
  */
 #define PCAP_VERSION_MAJOR 2
 #define PCAP_VERSION_MINOR 4
+
+/*
+ * Version number of the current version of the pcap-ng file format.
+ * We only use major for now.
+*/
+#define PCAP_NG_VERSION_MAJOR 1
 
 #define PCAP_ERRBUF_SIZE 256
 
@@ -407,6 +420,7 @@ int	pcap_snapshot(pcap_t *);
 int	pcap_is_swapped(pcap_t *);
 int	pcap_major_version(pcap_t *);
 int	pcap_minor_version(pcap_t *);
+int	pcap_file_type(pcap_t *);
 
 /* XXX */
 FILE	*pcap_file(pcap_t *);

--- a/savefile.c
+++ b/savefile.c
@@ -382,6 +382,12 @@ pcap_fopen_offline_with_tstamp_precision(FILE *fp, u_int precision,
 found:
 	p->rfile = fp;
 
+	/* pcap or pcap-ng ? */
+	if (i == 0)
+		p->file_type = PCAP_FILE_TYPE;
+	else
+		p->file_type = PCAP_NG_FILE_TYPE;
+
 	/* Padding only needed for live capture fcode */
 	p->fddipad = 0;
 

--- a/sf-pcap-ng.c
+++ b/sf-pcap-ng.c
@@ -119,8 +119,8 @@ struct section_header_block {
 /*
  * Current version number.  If major_version isn't PCAP_NG_VERSION_MAJOR,
  * that means that this code can't read the file.
+ * PCAP_NG_VERSION_MAJOR is now defined in pcap/pcap.h.
  */
-#define PCAP_NG_VERSION_MAJOR	1
 
 /*
  * Interface Description Block.


### PR DESCRIPTION
[FOR COMMENTS ONLY; no man pages updates currently]

This function is used to get the pcap file type when reading a pcap file.
The types are currently pcap and pcap-ng (PCAP_FILE_TYPE and
PCAP_NG_FILE_TYPE).

The first use of this function is to allow tcpdump to know the file type
and to do relevant version checks based on these types.

For that purpose, we need to move PCAP_NG_VERSION_MAJOR from sf-pcap-ng.c
to pcap/pcap.h.