### PR TITLE
Fix memory leak in pcap_compile.

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -548,6 +548,7 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 	program->bf_len = len;
 
 	lex_cleanup();
+	pcap_lex_destroy();
 	freechunks();
 
 	rc = 0;  /* We're all okay */


### PR DESCRIPTION
Fixes a memory leak in pcap_compile.

Testcase:

```C
#include <stdio.h>
#include <pcap/pcap.h>

int main()
{
    int ret;
    const char *bpf = "port 80";
    struct bpf_program filter;

    if (pcap_compile_nopcap(1524, DLT_EN10MB, &filter, bpf, 0, 0) == -1) {
        fprintf(stderr, "Failed to compile bpf filter %s\n", bpf);
        return -1;
    }

    pcap_freecode(&filter);

    return 0;
}

```

Valgrind output:

```
$ valgrind --leak-check=full --show-leak-kinds=all ./pcap_test                                      
==13324== Memcheck, a memory error detector                                                                            
==13324== Copyright (C) 2002-2013, and GNU GPL'd, by Julian Seward et al.                                              
==13324== Using Valgrind-3.10.1 and LibVEX; rerun with -h for copyright info                                           
==13324== Command: ./pcap_test                                                                                         
==13324==                                                                                                              
==13324==                                                                                                              
==13324== HEAP SUMMARY:                                                                                                
==13324==     in use at exit: 8 bytes in 1 blocks                                                                      
==13324==   total heap usage: 31 allocs, 30 frees, 15,713 bytes allocated                                              
==13324==                                                                                                              
==13324== 8 bytes in 1 blocks are still reachable in loss record 1 of 1                                                
==13324==    at 0x4C2BBA0: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)                             
==13324==    by 0x4E5C8B7: pcap_ensure_buffer_stack (scanner.c:4532)                                                   
==13324==    by 0x4E5C988: pcap__switch_to_buffer (scanner.c:4331)                                                     
==13324==    by 0x4E5CA86: pcap__scan_buffer (scanner.c:4594)                                                          
==13324==    by 0x4E5CAFC: pcap__scan_bytes (scanner.c:4638)                                                           
==13324==    by 0x4E5CDB8: lex_init (scanner.l:424)                                                                    
==13324==    by 0x4E4BFBC: pcap_compile (gencode.c:531)                                                                
==13324==    by 0x4E4CB4A: pcap_compile_nopcap (gencode.c:579)                                                         
==13324==    by 0x40083D: main (in /home/theodor/test/pcap_test)                                                       
==13324==                                                                                                              
==13324== LEAK SUMMARY:                                                                                                
==13324==    definitely lost: 0 bytes in 0 blocks                                                                      
==13324==    indirectly lost: 0 bytes in 0 blocks                                                                      
==13324==      possibly lost: 0 bytes in 0 blocks                                                                      
==13324==    still reachable: 8 bytes in 1 blocks                                                                      
==13324==         suppressed: 0 bytes in 0 blocks                                                                      
==13324==                                                                                                              
==13324== For counts of detected and suppressed errors, rerun with: -v                                                 
==13324== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)  
```

This happens because pcap_lex_destroy()  is not called when it should.