### PR TITLE
[Win32] savefile.c

### DIFF
--- a/savefile.c
+++ b/savefile.c
@@ -75,8 +75,10 @@
  * a HANDLE (which is OS-defined, not CRT-defined, and is part of the Win32
  * and Win64 ABIs).
  */
-static pcap_t *pcap_fopen_offline_with_tstamp_precision(FILE *, u_int, char *);
-static pcap_t *pcap_fopen_offline(FILE *, char *);
+#if defined(LIBPCAP_EXPORTS)
+  static pcap_t *pcap_fopen_offline_with_tstamp_precision(FILE *, u_int, char *);
+  static pcap_t *pcap_fopen_offline(FILE *, char *);
+#endif
 #endif
 
 /*
@@ -338,6 +340,8 @@ static pcap_t *(*check_headers[])(bpf_u_int32, FILE *, u_int, char *, int *) = {
 
 #define	N_FILE_TYPES	(sizeof check_headers / sizeof check_headers[0])
 
+#if defined(LIBPCAP_EXPORTS)
+
 #ifdef _WIN32
 static
 #endif
@@ -461,6 +465,7 @@ pcap_fopen_offline(FILE *fp, char *errbuf)
 	return (pcap_fopen_offline_with_tstamp_precision(fp,
 	    PCAP_TSTAMP_PRECISION_MICRO, errbuf));
 }
+#endif /* LIBPCAP_EXPORTS */
 
 /*
  * Read packets from a capture file, and call the callback for each


### PR DESCRIPTION
As comment on elsewhere (I lost that reference), the functions:
`pcap_fopen_offline_with_tstamp_precision()` and `pcap_fopen_offline()` must only be coded when `LIBPCAP_EXPORTS` is defined. They are macros in `pcap/pcap.h`otherwise.