### PR TITLE
configure.in: Use PKG_PROG_PKG_CONFIG for getting the right pkg-config

### DIFF
--- a/configure
+++ b/configure
@@ -626,7 +626,6 @@ INSTALL_PROGRAM
 PCAP_SUPPORT_PACKET_RING
 DBUS_SRC
 PCAP_SUPPORT_DBUS
-PKGCONFIG
 CAN_SRC
 PCAP_SUPPORT_CAN
 CANUSB_SRC
@@ -8766,66 +8765,30 @@ if test "x$enable_dbus" != "xno"; then
 fi
 
 if test "x$enable_dbus" != "xno"; then
-	# Extract the first word of "pkg-config", so it can be a program name with args.
-set dummy pkg-config; ac_word=$2
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
-$as_echo_n "checking for $ac_word... " >&6; }
-if ${ac_cv_prog_PKGCONFIG+:} false; then :
-  $as_echo_n "(cached) " >&6
-else
-  if test -n "$PKGCONFIG"; then
-  ac_cv_prog_PKGCONFIG="$PKGCONFIG" # Let the user override the test.
-else
-as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
-for as_dir in $PATH
-do
-  IFS=$as_save_IFS
-  test -z "$as_dir" && as_dir=.
-    for ac_exec_ext in '' $ac_executable_extensions; do
-  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
-    ac_cv_prog_PKGCONFIG="pkg-config"
-    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
-    break 2
-  fi
-done
-  done
-IFS=$as_save_IFS
-
-  test -z "$ac_cv_prog_PKGCONFIG" && ac_cv_prog_PKGCONFIG="no"
-fi
-fi
-PKGCONFIG=$ac_cv_prog_PKGCONFIG
-if test -n "$PKGCONFIG"; then
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $PKGCONFIG" >&5
-$as_echo "$PKGCONFIG" >&6; }
-else
-  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
-$as_echo "no" >&6; }
-fi
-
-
-	if test "x$PKGCONFIG" != "xno"; then
-		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for D-Bus" >&5
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for pkg-config" >&5
+$as_echo_n "checking for pkg-config... " >&6; }
+    PKG_PROG_PKG_CONFIG()
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for D-Bus" >&5
 $as_echo_n "checking for D-Bus... " >&6; }
-		if "$PKGCONFIG" dbus-1; then
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+	if "$PKG_CONFIG" dbus-1; then
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
-			DBUS_CFLAGS=`"$PKGCONFIG" --cflags dbus-1`
-			DBUS_LIBS=`"$PKGCONFIG" --libs dbus-1`
-			save_CFLAGS="$CFLAGS"
-			save_LIBS="$LIBS"
-			CFLAGS="$CFLAGS $DBUS_CFLAGS"
-			LIBS="$LIBS $DBUS_LIBS"
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the D-Bus library defines dbus_connection_read_write" >&5
+		DBUS_CFLAGS=`"$PKG_CONFIG" --cflags dbus-1`
+		DBUS_LIBS=`"$PKG_CONFIG" --libs dbus-1`
+		save_CFLAGS="$CFLAGS"
+		save_LIBS="$LIBS"
+		CFLAGS="$CFLAGS $DBUS_CFLAGS"
+		LIBS="$LIBS $DBUS_LIBS"
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the D-Bus library defines dbus_connection_read_write" >&5
 $as_echo_n "checking whether the D-Bus library defines dbus_connection_read_write... " >&6; }
-			cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+		cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 #include <string.h>
 
-			     #include <time.h>
-			     #include <sys/time.h>
+		     #include <time.h>
+		     #include <sys/time.h>
 
-			     #include <dbus/dbus.h>
+		     #include <dbus/dbus.h>
 int
 main ()
 {
@@ -8836,33 +8799,32 @@ return dbus_connection_read_write(NULL, 0);
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
 
-				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
 $as_echo "yes" >&6; }
 
 $as_echo "#define PCAP_SUPPORT_DBUS 1" >>confdefs.h
 
-				DBUS_SRC=pcap-dbus.c
-				V_INCLS="$V_INCLS $DBUS_CFLAGS"
+			DBUS_SRC=pcap-dbus.c
+			V_INCLS="$V_INCLS $DBUS_CFLAGS"
 
 else
 
-				{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-				if test "x$enable_dbus" = "xyes"; then
-				    as_fn_error $? "--enable-dbus was given, but the D-Bus library doesn't define dbus_connection_read_write()" "$LINENO" 5
-				fi
-				LIBS="$save_LIBS"
+			if test "x$enable_dbus" = "xyes"; then
+			    as_fn_error $? "--enable-dbus was given, but the D-Bus library doesn't define dbus_connection_read_write()" "$LINENO" 5
+			fi
+			LIBS="$save_LIBS"
 
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
-			CFLAGS="$save_CFLAGS"
-		else
-			{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+		CFLAGS="$save_CFLAGS"
+	else
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
-			if test "x$enable_dbus" = "xyes"; then
-				as_fn_error $? "--enable-dbus was given, but the dbus-1 package is not installed" "$LINENO" 5
-			fi
+		if test "x$enable_dbus" = "xyes"; then
+			as_fn_error $? "--enable-dbus was given, but the dbus-1 package is not installed" "$LINENO" 5
 		fi
 	fi
 

--- a/configure.in
+++ b/configure.in
@@ -1765,45 +1765,44 @@ if test "x$enable_dbus" != "xno"; then
 fi
 
 if test "x$enable_dbus" != "xno"; then
-	AC_CHECK_PROG([PKGCONFIG], [pkg-config], [pkg-config], [no])
-	if test "x$PKGCONFIG" != "xno"; then
-		AC_MSG_CHECKING([for D-Bus])
-		if "$PKGCONFIG" dbus-1; then
+	AC_MSG_CHECKING([for pkg-config])
+    PKG_PROG_PKG_CONFIG()
+	AC_MSG_CHECKING([for D-Bus])
+	if "$PKG_CONFIG" dbus-1; then
+		AC_MSG_RESULT([yes])
+		DBUS_CFLAGS=`"$PKG_CONFIG" --cflags dbus-1`
+		DBUS_LIBS=`"$PKG_CONFIG" --libs dbus-1`
+		save_CFLAGS="$CFLAGS"
+		save_LIBS="$LIBS"
+		CFLAGS="$CFLAGS $DBUS_CFLAGS"
+		LIBS="$LIBS $DBUS_LIBS"
+		AC_MSG_CHECKING(whether the D-Bus library defines dbus_connection_read_write)
+		AC_TRY_LINK(
+		    [#include <string.h>
+
+		     #include <time.h>
+		     #include <sys/time.h>
+
+		     #include <dbus/dbus.h>],
+		    [return dbus_connection_read_write(NULL, 0);],
+		    [
 			AC_MSG_RESULT([yes])
-			DBUS_CFLAGS=`"$PKGCONFIG" --cflags dbus-1`
-			DBUS_LIBS=`"$PKGCONFIG" --libs dbus-1`
-			save_CFLAGS="$CFLAGS"
-			save_LIBS="$LIBS"
-			CFLAGS="$CFLAGS $DBUS_CFLAGS"
-			LIBS="$LIBS $DBUS_LIBS"
-			AC_MSG_CHECKING(whether the D-Bus library defines dbus_connection_read_write)
-			AC_TRY_LINK(
-			    [#include <string.h>
-
-			     #include <time.h>
-			     #include <sys/time.h>
-
-			     #include <dbus/dbus.h>],
-			    [return dbus_connection_read_write(NULL, 0);],
-			    [
-				AC_MSG_RESULT([yes])
-				AC_DEFINE(PCAP_SUPPORT_DBUS, 1, [support D-Bus sniffing])
-				DBUS_SRC=pcap-dbus.c
-				V_INCLS="$V_INCLS $DBUS_CFLAGS"
-			    ],
-			    [
-				AC_MSG_RESULT([no])
-				if test "x$enable_dbus" = "xyes"; then
-				    AC_MSG_ERROR([--enable-dbus was given, but the D-Bus library doesn't define dbus_connection_read_write()])
-				fi
-				LIBS="$save_LIBS"
-			     ])
-			CFLAGS="$save_CFLAGS"
-		else
+			AC_DEFINE(PCAP_SUPPORT_DBUS, 1, [support D-Bus sniffing])
+			DBUS_SRC=pcap-dbus.c
+			V_INCLS="$V_INCLS $DBUS_CFLAGS"
+		    ],
+		    [
 			AC_MSG_RESULT([no])
 			if test "x$enable_dbus" = "xyes"; then
-				AC_MSG_ERROR([--enable-dbus was given, but the dbus-1 package is not installed])
+			    AC_MSG_ERROR([--enable-dbus was given, but the D-Bus library doesn't define dbus_connection_read_write()])
 			fi
+			LIBS="$save_LIBS"
+		     ])
+		CFLAGS="$save_CFLAGS"
+	else
+		AC_MSG_RESULT([no])
+		if test "x$enable_dbus" = "xyes"; then
+			AC_MSG_ERROR([--enable-dbus was given, but the dbus-1 package is not installed])
 		fi
 	fi
 	AC_SUBST(PCAP_SUPPORT_DBUS)


### PR DESCRIPTION
pkg-config provides a macro that comes with the distribution, and it provides PKG_PROG_PKG_CONFIG, which should be preferred to using custom code for detecting it; this can aid in building with cross-compilation, where target-prefixed pkg-config binaries may be preferred to just `pkg-config`.
