### PR TITLE
[API] add functions to be able to get packet's savefile offset

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -200,6 +200,9 @@ struct pcap {
 	int activated;		/* true if the capture is really started */
 	int oldstyle;		/* if we're opening with pcap_open_live() */
 
+    long lastpkt_offset;    /* last packet offset in save file */
+    long current_offset;    /* current offset in save file */
+
 	struct pcap_opt opt;
 
 	/*

--- a/pcap.c
+++ b/pcap.c
@@ -303,6 +303,26 @@ pcap_next_ex(pcap_t *p, struct pcap_pkthdr **pkt_header,
 	return (p->read_op(p, 1, p->oneshot_callback, (u_char *)&s));
 }
 
+const u_char *
+pcap_next_with_file_offset(pcap_t *p, struct pcap_pkthdr *pkt_header,
+        long *file_offset)
+{
+    const u_char *ret = pcap_next(p, pkt_header);
+
+    *file_offset = p->lastpkt_offset;
+    return ret;
+}
+
+int
+pcap_next_ex_with_file_offset(pcap_t *p, struct pcap_pkthdr **pkt_header,
+                         const u_char **pkt_data, long *file_offset)
+{
+    int ret = pcap_next_ex(p, pkt_header, pkt_data);
+
+    *file_offset = p->lastpkt_offset;
+    return ret;
+}
+
 #if defined(DAG_ONLY)
 int
 pcap_findalldevs(pcap_if_t **alldevsp, char *errbuf)

--- a/pcap.c
+++ b/pcap.c
@@ -304,22 +304,24 @@ pcap_next_ex(pcap_t *p, struct pcap_pkthdr **pkt_header,
 }
 
 const u_char *
-pcap_next_with_file_offset(pcap_t *p, struct pcap_pkthdr *pkt_header,
-        long *file_offset)
+pcap_next_with_sf_offset(pcap_t *p, struct pcap_pkthdr *pkt_header,
+        long *sf_offset)
 {
     const u_char *ret = pcap_next(p, pkt_header);
 
-    *file_offset = p->lastpkt_offset;
+    // sf_offset is set to -1 if live capture
+    *sf_offset = (p->rfile != NULL ? p->lastpkt_offset : -1);
     return ret;
 }
 
 int
-pcap_next_ex_with_file_offset(pcap_t *p, struct pcap_pkthdr **pkt_header,
-                         const u_char **pkt_data, long *file_offset)
+pcap_next_ex_with_sf_offset(pcap_t *p, struct pcap_pkthdr **pkt_header,
+                         const u_char **pkt_data, long *sf_offset)
 {
     int ret = pcap_next_ex(p, pkt_header, pkt_data);
 
-    *file_offset = p->lastpkt_offset;
+    // sf_offset is set to -1 if live capture
+    *sf_offset = (p->rfile != NULL ? p->lastpkt_offset : -1);
     return ret;
 }
 

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -378,6 +378,10 @@ PCAP_API int	pcap_loop(pcap_t *, int, pcap_handler, u_char *);
 PCAP_API int	pcap_dispatch(pcap_t *, int, pcap_handler, u_char *);
 PCAP_API const u_char *pcap_next(pcap_t *, struct pcap_pkthdr *);
 PCAP_API int 	pcap_next_ex(pcap_t *, struct pcap_pkthdr **, const u_char **);
+PCAP_API const u_char *pcap_next_with_file_offset(pcap_t *, struct pcap_pkthdr *,
+        long *);
+PCAP_API int 	pcap_next_ex_with_file_offset(pcap_t *, struct pcap_pkthdr **,
+        const u_char **, long *);
 PCAP_API void	pcap_breakloop(pcap_t *);
 PCAP_API int	pcap_stats(pcap_t *, struct pcap_stat *);
 PCAP_API int	pcap_setfilter(pcap_t *, struct bpf_program *);

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -378,9 +378,9 @@ PCAP_API int	pcap_loop(pcap_t *, int, pcap_handler, u_char *);
 PCAP_API int	pcap_dispatch(pcap_t *, int, pcap_handler, u_char *);
 PCAP_API const u_char *pcap_next(pcap_t *, struct pcap_pkthdr *);
 PCAP_API int 	pcap_next_ex(pcap_t *, struct pcap_pkthdr **, const u_char **);
-PCAP_API const u_char *pcap_next_with_file_offset(pcap_t *, struct pcap_pkthdr *,
+PCAP_API const u_char *pcap_next_with_sf_offset(pcap_t *, struct pcap_pkthdr *,
         long *);
-PCAP_API int 	pcap_next_ex_with_file_offset(pcap_t *, struct pcap_pkthdr **,
+PCAP_API int 	pcap_next_ex_with_sf_offset(pcap_t *, struct pcap_pkthdr **,
         const u_char **, long *);
 PCAP_API void	pcap_breakloop(pcap_t *);
 PCAP_API int	pcap_stats(pcap_t *, struct pcap_stat *);

--- a/pcap_next_ex.3pcap
+++ b/pcap_next_ex.3pcap
@@ -19,7 +19,7 @@
 .\"
 .TH PCAP_NEXT_EX 3PCAP "17 April 2016"
 .SH NAME
-pcap_next_ex, pcap_next_ex_with_sf_offset, pcap_next_with_sf_offset
+pcap_next_ex, pcap_next, pcap_next_ex_with_sf_offset, pcap_next_with_sf_offset
 \- read the next packet from a pcap_t
 .SH SYNOPSIS
 .nf

--- a/pcap_next_ex.3pcap
+++ b/pcap_next_ex.3pcap
@@ -17,9 +17,10 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_NEXT_EX 3PCAP "7 April 2014"
+.TH PCAP_NEXT_EX 3PCAP "17 April 2016"
 .SH NAME
-pcap_next_ex, pcap_next \- read the next packet from a pcap_t
+pcap_next_ex, pcap_next_ex_with_sf_offset, pcap_next_with_sf_offset
+\- read the next packet from a pcap_t
 .SH SYNOPSIS
 .nf
 .ft B
@@ -31,6 +32,14 @@ int pcap_next_ex(pcap_t *p, struct pcap_pkthdr **pkt_header,
 .ti +8
 const u_char **pkt_data);
 const u_char *pcap_next(pcap_t *p, struct pcap_pkthdr *h);
+.LP
+.ft B
+int pcap_next_ex_with_sf_offset(pcap_t *p, struct pcap_pkthdr **pkt_header,
+.ti +8
+const u_char **pkt_data, long *sf_offset);
+const u_char *pcap_next_with_sf_offset(pcap_t *p, struct pcap_pkthdr *h,
+.ti +8
+long *sf_offset);
 .ft
 .fi
 .SH DESCRIPTION
@@ -49,6 +58,8 @@ and the packet data are not to be freed by the caller, and are not
 guaranteed to be valid after the next call to
 .BR pcap_next_ex() ,
 .BR pcap_next() ,
+.BR pcap_next_ex_with_sf_offset() ,
+.BR pcap_next_with_sf_offset() ,
 .BR pcap_loop() ,
 or
 .BR pcap_dispatch() ;
@@ -66,6 +77,8 @@ packet data is not to be freed by the caller, and is not
 guaranteed to be valid after the next call to
 .BR pcap_next_ex() ,
 .BR pcap_next() ,
+.BR pcap_next_ex_with_sf_offset() ,
+.BR pcap_next_with_sf_offset() ,
 .BR pcap_loop() ,
 or
 .BR pcap_dispatch() ;
@@ -75,6 +88,19 @@ The
 structure pointed to by
 .I h
 is filled in with the appropriate values for the packet.
+.PP
+.B pcap_next_with_sf_offset()
+and
+.B pcap_next_ex_with_sf_offset()
+are the same as
+.B pcap_next()
+and
+.B pcap_next_ex()
+except that they take an additional
+.I sf_offset
+pointer argument. The pointed variable will be set to the extracted
+packet's ``savefile`` offset. If the packets are being read from a live capture, the
+pointed variable will be set to -1.
 .PP
 The bytes of data from the packet begin with a link-layer header.  The
 format of the link-layer header is indicated by the return value of the
@@ -112,7 +138,9 @@ have some other data link type, such as
 for Ethernet.
 .SH RETURN VALUE
 .B pcap_next_ex()
-returns 1 if the packet was read without problems, 0
+and
+.B pcap_next_ex_with_sf_offset()
+both return 1 if the packet was read without problems, 0
 if packets are being read from a live capture and the timeout expired,
 \-1 if an error occurred while reading the packet, and \-2 if
 packets are being read from a ``savefile'' and there are no more
@@ -126,7 +154,9 @@ may be called with
 as an argument to fetch or display the error text.
 .PP
 .B pcap_next()
-returns a pointer to the packet data on success, and returns
+and
+.B pcap_next_with_sf_offset()
+both return a pointer to the packet data on success, and returns
 .B NULL
 if an error occurred, or if no packets were read from a live
 capture (if, for example, they were discarded because they didn't pass

--- a/sf-pcap-ng.c
+++ b/sf-pcap-ng.c
@@ -875,7 +875,11 @@ pcap_ng_check_header(bpf_u_int32 magic, FILE *fp, u_int precision, char *errbuf,
 	bhdrp->block_type = magic;
 	bhdrp->total_length = total_length;
 	shbp->byte_order_magic = byte_order_magic;
-    p->lastpkt_offset = bhdrp->total_length;
+
+    /*
+     * We initialize current_offset to the end of the SHB
+     */
+    p->current_offset = bhdrp->total_length;
 
 	if (read_bytes(fp,
 	    (u_char *)p->buffer + (sizeof(magic) + sizeof(total_length) + sizeof(byte_order_magic)),
@@ -926,7 +930,11 @@ pcap_ng_check_header(bpf_u_int32 magic, FILE *fp, u_int precision, char *errbuf,
 		}
 		if (status == -1)
 			goto fail;	/* error */
-        p->lastpkt_offset += cursor.data_remaining + sizeof(struct block_header)
+
+        /*
+         * Add to current_offset the length of the section we just read
+         */
+        p->current_offset += cursor.data_remaining + sizeof(struct block_header)
                              + sizeof(struct block_trailer);
 		switch (cursor.block_type) {
 
@@ -995,9 +1003,6 @@ done:
 
 	p->next_packet_op = pcap_ng_next_packet;
 	p->cleanup_op = pcap_ng_cleanup;
-
-    p->current_offset = p->lastpkt_offset;
-
 	return (p);
 
 fail:
@@ -1051,10 +1056,23 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			return (1);	/* EOF */
 		if (status == -1)
 			return (-1);	/* error */
-        p->lastpkt_offset = p->current_offset;
-        p->current_offset += cursor.data_remaining
-            + sizeof(struct block_header)
-            + sizeof(struct block_trailer);
+        if (p->rfile != NULL) {
+            /*
+             * We set lastpkt_offset to current offset and we add the length of
+             * the section we just read to the current_offset
+             *
+             * When we will read a packet block (from any kind), we will add to
+             * lastpkt_offset the length of a block header and the length of our
+             * packet block's header
+             * This way, the lastpkt_offset variable will be set to the
+             * packet savefile's offset
+             * offset in his original savefile.
+             */
+            p->lastpkt_offset = p->current_offset;
+            p->current_offset += cursor.data_remaining
+                                 + sizeof(struct block_header)
+                                 + sizeof(struct block_trailer);
+        }
 		switch (cursor.block_type) {
 
 		case BT_EPB:
@@ -1084,8 +1102,10 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 				t = ((u_int64_t)epbp->timestamp_high) << 32 |
 				    epbp->timestamp_low;
 			}
-            p->lastpkt_offset += sizeof(struct block_header)
-                                 + sizeof(struct enhanced_packet_block);
+            if (p->rfile != NULL) {
+                p->lastpkt_offset += sizeof(struct block_header)
+                                     + sizeof(struct enhanced_packet_block);
+            }
 			goto found;
 
 		case BT_SPB:
@@ -1123,8 +1143,10 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 				hdr->caplen = p->snapshot;
 			t = 0;	/* no time stamps */
 
-            p->lastpkt_offset += sizeof(struct block_header)
-                                 + sizeof(struct simple_packet_block);
+            if (p->rfile != NULL) {
+                p->lastpkt_offset += sizeof(struct block_header)
+                                     + sizeof(struct simple_packet_block);
+            }
 			goto found;
 
 		case BT_PB:
@@ -1154,8 +1176,10 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 				t = ((u_int64_t)pbp->timestamp_high) << 32 |
 				    pbp->timestamp_low;
 			}
-            p->lastpkt_offset += sizeof(struct block_header)
-                                 + sizeof(struct packet_block);
+            if (p->rfile != NULL) {
+                p->lastpkt_offset += sizeof(struct block_header)
+                                     + sizeof(struct packet_block);
+            }
 			goto found;
 
 		case BT_IDB:

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -257,7 +257,6 @@ pcap_check_header(bpf_u_int32 magic, FILE *fp, u_int precision, char *errbuf,
 	p->snapshot = hdr.snaplen;
 	p->linktype = linktype_to_dlt(LT_LINKTYPE(hdr.linktype));
 	p->linktype_ext = LT_LINKTYPE_EXT(hdr.linktype);
-
 	p->next_packet_op = pcap_next_packet;
 
 	ps = p->priv;
@@ -407,7 +406,7 @@ pcap_check_header(bpf_u_int32 magic, FILE *fp, u_int precision, char *errbuf,
 	}
 
 	p->cleanup_op = sf_cleanup;
-
+    p->current_offset = sizeof(struct pcap_file_header);
 	return (p);
 }
 
@@ -615,6 +614,9 @@ pcap_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 	if (p->swapped)
 		swap_pseudo_headers(p->linktype, hdr, *data);
 
+    p->current_offset += ps->hdrsize;
+    p->lastpkt_offset = p->current_offset;
+    p->current_offset += hdr->caplen;
 	return (0);
 }
 

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -406,6 +406,9 @@ pcap_check_header(bpf_u_int32 magic, FILE *fp, u_int precision, char *errbuf,
 	}
 
 	p->cleanup_op = sf_cleanup;
+    /*
+     * If savefile, initialize current_offset to pcap file's body
+     */
     p->current_offset = sizeof(struct pcap_file_header);
 	return (p);
 }
@@ -614,9 +617,16 @@ pcap_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 	if (p->swapped)
 		swap_pseudo_headers(p->linktype, hdr, *data);
 
-    p->current_offset += ps->hdrsize;
-    p->lastpkt_offset = p->current_offset;
-    p->current_offset += hdr->caplen;
+    if (p->rfile != NULL) {
+        /*
+         * If savefile:
+         * - we set lastpkt_offset to the offset of the packet we just read
+         * - we set the current_offset to the end of this packet
+         */
+        p->current_offset += ps->hdrsize;
+        p->lastpkt_offset = p->current_offset;
+        p->current_offset += hdr->caplen;
+    }
 	return (0);
 }
 


### PR DESCRIPTION
I noticed there was no way through the API to get a packet's savefile offset, so I added those functions in order to resolve this problem :
`pcap_next_with_sf_offset()` and `pcap_next_ex_with_sf_offset()`

They work the same as `pcap_next()` and `pcap_next_ex()` but takes an additional pointer on a long, which will be set to the packet's savefile offset. If the packets are read from a live capture, then this long will be set to -1.

This feature would be useful for a project I work on, which aim is to retrieve packets from pcap[-ng] files and then process them. I need to keep their savefile offsets to be able to retrieve their raw format at any time, after the processing.
It may also be useful for others :)