### PR TITLE
Add some error checking to pcap_dump().

### DIFF
--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -648,13 +648,39 @@ pcap_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	struct pcap_sf_pkthdr sf_hdr;
 
 	f = (FILE *)user;
+	/*
+	 * If the output file handle is in an error state, don't write
+	 * anything.
+	 *
+	 * While in principle a file handle can return from an error state
+	 * to a normal state (for example if a disk that is full has space
+	 * freed), we have possibly left a broken file already, and won't
+	 * be able to clean it up. The safest option is to do nothing.
+	 *
+	 * Note that if we could guarantee that fwrite() was atomic we
+	 * might be able to insure that we don't produce a corrupted file,
+	 * but the standard defines fwrite() as a series of fputc() calls,
+	 * so we really have no insurance that things are not fubared.
+	 *
+	 * http://pubs.opengroup.org/onlinepubs/009695399/functions/fwrite.html
+	 */
+	if (ferror(f))
+		return;
 	sf_hdr.ts.tv_sec  = h->ts.tv_sec;
 	sf_hdr.ts.tv_usec = h->ts.tv_usec;
 	sf_hdr.caplen     = h->caplen;
 	sf_hdr.len        = h->len;
-	/* XXX we should check the return status */
-	(void)fwrite(&sf_hdr, sizeof(sf_hdr), 1, f);
-	(void)fwrite(sp, h->caplen, 1, f);
+	/*
+	 * We only write the packet if we can write the header properly.
+	 *
+	 * This doesn't prevent us from having corrupted output, and if we
+	 * for some reason don't get a complete write we don't have any
+	 * way to set ferror() to prevent future writes from being
+	 * attempted, but it is better than nothing.
+	 */
+	if (fwrite(&sf_hdr, sizeof(sf_hdr), 1, f) == 1) {
+		(void)fwrite(sp, h->caplen, 1, f);
+	}
 }
 
 static pcap_dumper_t *


### PR DESCRIPTION
We noticed that pcap files were corrupted after a full disk event. This patch tries to help a bit.

Note that probably it would be better if `pcap_dump()` returned an error code, rather than being a void function. The best way to transition to that might be to add a new function that returned an error, and had `pcap_dump()` just call that and throw away the error code, then declare `pcap_dump()` deprecated in a future version of the ABI and ultimately removing it.

Who thought a function that doesn't return an error code was a good idea? :wink:
