### PR TITLE
Change the way NFLOG version is determined

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1338,7 +1338,7 @@ swap_nflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		return;
 	}
 
-	if (nfhdr->nflog_version != 0) {
+	if ((!nfhdr->nflog_version) == 0) {
 		/* Unknown NFLOG version */
 		return;
 	}


### PR DESCRIPTION
The NOT operation is inside the brackets because it only applies to the variable nfhdr->nflog_version, not to the expression.
This check is pretty straightforward but silences a compiler warning. The operator != is not the best usage here, so I replaced it with a solution that made his proof in Nmap project (I am currently working for Nmap organisation).