### PR TITLE
Fix all build errors on MSVC 2013 together with Npcap source code

### DIFF
--- a/Win32/Prj/libpcap.vcxproj
+++ b/Win32/Prj/libpcap.vcxproj
@@ -123,7 +123,6 @@
     <ClCompile Include="..\..\bpf_image.c" />
     <ClCompile Include="..\..\etherent.c" />
     <ClCompile Include="..\..\fad-helpers.c" />
-    <ClCompile Include="..\..\fad-win32.c" />
     <ClCompile Include="..\..\gencode.c" />
     <ClCompile Include="..\..\grammar.c" />
     <ClCompile Include="..\..\inet.c" />
@@ -140,6 +139,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\pcap-common.h" />
+    <ClInclude Include="..\..\pcap-int.h" />
     <ClInclude Include="..\..\pcap-stdinc.h" />
     <ClInclude Include="..\..\pcap-tc.h" />
     <ClInclude Include="..\..\pcap.h" />

--- a/Win32/Prj/libpcap.vcxproj.filters
+++ b/Win32/Prj/libpcap.vcxproj.filters
@@ -13,9 +13,6 @@
     <ClCompile Include="..\..\etherent.c">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="..\..\fad-win32.c">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="..\..\gencode.c">
       <Filter>Source Files</Filter>
     </ClCompile>
@@ -78,6 +75,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\pcap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\pcap-int.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -409,6 +409,11 @@ int	pcap_offline_read(pcap_t *, int, pcap_handler, u_char *);
  * #defining them to be snprintf or vsnprintf, respectively, or by
  * defining our own versions and exporting them.
  */
+
+#if defined(WIN32) && _MSC_VER < 1900
+#define snprintf _snprintf
+#endif
+
 #ifdef HAVE_SNPRINTF
 #define pcap_snprintf snprintf
 #else


### PR DESCRIPTION
libpcap repo needs to be placed into Npcap repo's "\wpcap" folder.