### PR TITLE
Add back WinPcap specific functions to libpcap, no compile errors now.

### DIFF
--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -317,7 +317,7 @@ struct eproto {
  * don't officially export it by declaring it in a header file.
  * (Programs *should* do this themselves, as tcpdump now does.)
  */
-PCAP_API_DEF struct eproto eproto_db[] = {
+struct eproto eproto_db[] = {
 	{ "pup", ETHERTYPE_PUP },
 	{ "xns", ETHERTYPE_NS },
 	{ "ip", ETHERTYPE_IP },


### PR DESCRIPTION
Wireshark x64 can capture packets normally under this version ``wpcap.dll`` built from libpcap source. I didn't test other use cases.

For now, only 4 functions are still missing compared to WinPcap:
1. endservent()
2. getservent()
3. wsockinit()
4. pcap_read()

I think 1. and 2. are needed to be added back later. 3. and 4. are some functions maybe we can ignore.