### PR TITLE
Fix some compile warnings reported by MSVC.

### DIFF
--- a/inet.c
+++ b/inet.c
@@ -233,7 +233,10 @@ pcap_lookupdev(errbuf)
 	DWORD dwWindowsMajorVersion;
 	char our_errbuf[PCAP_ERRBUF_SIZE+1];
 
+#pragma warning (push)
+#pragma warning (disable: 4996) /* disable MSVC's GetVersion() deprecated warning here */
 	dwVersion = GetVersion();	/* get the OS version */
+#pragma warning (pop)
 	dwWindowsMajorVersion = (DWORD)(LOBYTE(LOWORD(dwVersion)));
 
 	if (dwVersion >= 0x80000000 && dwWindowsMajorVersion >= 4) {

--- a/missing/win_snprintf.c
+++ b/missing/win_snprintf.c
@@ -6,7 +6,7 @@ pcap_vsnprintf(char *str, size_t str_size, const char *format, va_list args)
 {
 	int ret;
 
-	ret = _vsnprintf(str, str_size, format, args);
+	ret = _vsnprintf_s(str, str_size, _TRUNCATE, format, args);
 
 	/*
 	 * XXX - _vsnprintf() and _snprintf() do *not* guarantee

--- a/pcap-new.c
+++ b/pcap-new.c
@@ -166,7 +166,7 @@ int pcap_findalldevs_ex(char *source, struct pcap_rmtauth *auth, pcap_if_t **all
 			}
 
 			/* Copy the new device identifier into the correct memory location */
-			strncpy(dev->name, tmpstring, strlen(tmpstring) + 1);
+			strlcpy(dev->name, tmpstring, strlen(tmpstring) + 1);
 
 
 			/* Create the new device description */
@@ -189,7 +189,7 @@ int pcap_findalldevs_ex(char *source, struct pcap_rmtauth *auth, pcap_if_t **all
 			}
 
 			/* Copy the new device description into the correct memory location */
-			strncpy(dev->description, tmpstring, strlen(tmpstring) + 1);
+			strlcpy(dev->description, tmpstring, strlen(tmpstring) + 1);
 
 			dev = dev->next;
 		}
@@ -312,7 +312,7 @@ int pcap_findalldevs_ex(char *source, struct pcap_rmtauth *auth, pcap_if_t **all
 					return -1;
 				}
 
-				strncpy(dev->name, tmpstring, stringlen);
+				strlcpy(dev->name, tmpstring, stringlen);
 
 				dev->name[stringlen] = 0;
 
@@ -331,7 +331,7 @@ int pcap_findalldevs_ex(char *source, struct pcap_rmtauth *auth, pcap_if_t **all
 				}
 
 				/* Copy the new device description into the correct memory location */
-				strncpy(dev->description, tmpstring, stringlen + 1);
+				strlcpy(dev->description, tmpstring, stringlen + 1);
 
 				pcap_close(fp);
 			}
@@ -514,7 +514,7 @@ int pcap_findalldevs_ex(char *source, struct pcap_rmtauth *auth, pcap_if_t **all
 			}
 
 			/* Copy the new device name into the correct memory location */
-			strncpy(dev->name, tmpstring2, stringlen + 1);
+			strlcpy(dev->name, tmpstring2, stringlen + 1);
 		}
 
 		if (findalldevs_if.desclen)
@@ -546,7 +546,7 @@ int pcap_findalldevs_ex(char *source, struct pcap_rmtauth *auth, pcap_if_t **all
 			}
 
 			/* Copy the new device description into the correct memory location */
-			strncpy(dev->description, tmpstring2, stringlen + 1);
+			strlcpy(dev->description, tmpstring2, stringlen + 1);
 		}
 
 		dev->flags = ntohl(findalldevs_if.flags);
@@ -668,10 +668,10 @@ int pcap_createsrcstr(char *source, int type, const char *host, const char *port
 	{
 	case PCAP_SRC_FILE:
 	{
-		strncpy(source, PCAP_SRC_FILE_STRING, PCAP_BUF_SIZE);
+		strlcpy(source, PCAP_SRC_FILE_STRING, PCAP_BUF_SIZE);
 		if ((name) && (*name))
 		{
-			strncat(source, name, PCAP_BUF_SIZE);
+			strlcat(source, name, PCAP_BUF_SIZE);
 			return 0;
 		}
 		else
@@ -683,27 +683,27 @@ int pcap_createsrcstr(char *source, int type, const char *host, const char *port
 
 	case PCAP_SRC_IFREMOTE:
 	{
-		strncpy(source, PCAP_SRC_IF_STRING, PCAP_BUF_SIZE);
+		strlcpy(source, PCAP_SRC_IF_STRING, PCAP_BUF_SIZE);
 		if ((host) && (*host))
 		{
 			if ((strcspn(host, "aAbBcCdDeEfFgGhHjJkKlLmMnNoOpPqQrRsStTuUvVwWxXyYzZ")) == strlen(host))
 			{
 				/* the host name does not contains alphabetic chars. So, it is a numeric address */
 				/* In this case we have to include it between square brackets */
-				strncat(source, "[", PCAP_BUF_SIZE);
-				strncat(source, host, PCAP_BUF_SIZE);
-				strncat(source, "]", PCAP_BUF_SIZE);
+				strlcat(source, "[", PCAP_BUF_SIZE);
+				strlcat(source, host, PCAP_BUF_SIZE);
+				strlcat(source, "]", PCAP_BUF_SIZE);
 			}
 			else
-				strncat(source, host, PCAP_BUF_SIZE);
+				strlcat(source, host, PCAP_BUF_SIZE);
 
 			if ((port) && (*port))
 			{
-				strncat(source, ":", PCAP_BUF_SIZE);
-				strncat(source, port, PCAP_BUF_SIZE);
+				strlcat(source, ":", PCAP_BUF_SIZE);
+				strlcat(source, port, PCAP_BUF_SIZE);
 			}
 
-			strncat(source, "/", PCAP_BUF_SIZE);
+			strlcat(source, "/", PCAP_BUF_SIZE);
 		}
 		else
 		{
@@ -712,17 +712,17 @@ int pcap_createsrcstr(char *source, int type, const char *host, const char *port
 		}
 
 		if ((name) && (*name))
-			strncat(source, name, PCAP_BUF_SIZE);
+			strlcat(source, name, PCAP_BUF_SIZE);
 
 		return 0;
 	}
 
 	case PCAP_SRC_IFLOCAL:
 	{
-		strncpy(source, PCAP_SRC_IF_STRING, PCAP_BUF_SIZE);
+		strlcpy(source, PCAP_SRC_IF_STRING, PCAP_BUF_SIZE);
 
 		if ((name) && (*name))
-			strncat(source, name, PCAP_BUF_SIZE);
+			strlcat(source, name, PCAP_BUF_SIZE);
 
 		return 0;
 	}
@@ -801,7 +801,7 @@ int pcap_parsesrcstr(const char *source, int *type, char *host, char *port, char
 				{
 					/* We're on a local capture */
 					if (*ptr)
-						strncpy(tmpname, ptr, PCAP_BUF_SIZE);
+						strlcpy(tmpname, ptr, PCAP_BUF_SIZE);
 
 					/* Clean the host name, since it is a remote capture */
 					/* NOTE: the host name has been assigned in the previous "ntoken= sscanf(...)" line */
@@ -815,9 +815,9 @@ int pcap_parsesrcstr(const char *source, int *type, char *host, char *port, char
 		}
 
 		if (host)
-			strcpy(host, tmphost);
+			strlcpy(host, tmphost, PCAP_BUF_SIZE);
 		if (port)
-			strcpy(port, tmpport);
+			strlcpy(port, tmpport, PCAP_BUF_SIZE);
 		if (type)
 			*type = tmptype;
 
@@ -830,7 +830,7 @@ int pcap_parsesrcstr(const char *source, int *type, char *host, char *port, char
 			 */
 			if (tmpname[0])
 			{
-				strcpy(name, tmpname);
+				strlcpy(name, tmpname, PCAP_BUF_SIZE);
 			}
 			else
 			{
@@ -851,7 +851,7 @@ int pcap_parsesrcstr(const char *source, int *type, char *host, char *port, char
 		if (*ptr)
 		{
 			if (name)
-				strncpy(name, ptr, PCAP_BUF_SIZE);
+				strlcpy(name, ptr, PCAP_BUF_SIZE);
 
 			if (type)
 				*type = PCAP_SRC_FILE;
@@ -872,7 +872,7 @@ int pcap_parsesrcstr(const char *source, int *type, char *host, char *port, char
 	if ((source) && (*source))
 	{
 		if (name)
-			strncpy(name, source, PCAP_BUF_SIZE);
+			strlcpy(name, source, PCAP_BUF_SIZE);
 
 		if (type)
 			*type = PCAP_SRC_IFLOCAL;
@@ -979,7 +979,7 @@ pcap_t *pcap_open(const char *source, int snaplen, int flags, int read_timeout, 
 		break;
 
 	default:
-		strcpy(errbuf, "Source type not supported");
+		strlcpy(errbuf, "Source type not supported", PCAP_ERRBUF_SIZE);
 		return NULL;
 	}
 	return fp;
@@ -1254,7 +1254,7 @@ int pcap_remoteact_list(char *hostlist, char sep, int size, char *errbuf)
 			return -1;
 		}
 
-		strcat(hostlist, hoststr);
+		strlcat(hostlist, hoststr, PCAP_ERRBUF_SIZE);
 		hostlist[len - 1] = sep;
 		hostlist[len] = 0;
 

--- a/pcap-remote.c
+++ b/pcap-remote.c
@@ -241,7 +241,7 @@ static int pcap_read_nocb_remote(pcap_t *p, struct pcap_pkthdr **pkt_header, u_c
 	 */
 	FD_SET(md->rmt_sockdata, &rfds);
 
-	retval = select(md->rmt_sockdata + 1, &rfds, NULL, NULL, &tv);
+	retval = select((int) md->rmt_sockdata + 1, &rfds, NULL, NULL, &tv);
 	if (retval == -1)
 	{
 		sock_geterror("select(): ", p->errbuf, PCAP_ERRBUF_SIZE);
@@ -794,9 +794,9 @@ int pcap_opensource_remote(pcap_t *fp, struct pcap_rmtauth *auth)
 		&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, fp->errbuf, PCAP_ERRBUF_SIZE))
 		goto error;
 
-	rpcap_createhdr((struct rpcap_header *) sendbuf, RPCAP_MSG_OPEN_REQ, 0, strlen(iface));
+	rpcap_createhdr((struct rpcap_header *) sendbuf, RPCAP_MSG_OPEN_REQ, 0, (uint32) strlen(iface));
 
-	if (sock_bufferize(iface, strlen(iface), sendbuf, &sendbufidx,
+	if (sock_bufferize(iface, (int) strlen(iface), sendbuf, &sendbufidx,
 		RPCAP_NETBUF_SIZE, SOCKBUF_BUFFERIZE, fp->errbuf, PCAP_ERRBUF_SIZE))
 		goto error;
 
@@ -1780,8 +1780,8 @@ int rpcap_sendauth(SOCKET sock, struct pcap_rmtauth *auth, char *errbuf)
 
 		case RPCAP_RMTAUTH_PWD:
 			length = sizeof(struct rpcap_auth);
-			if (auth->username) length += strlen(auth->username);
-			if (auth->password) length += strlen(auth->password);
+			if (auth->username) length += (uint16) strlen(auth->username);
+			if (auth->password) length += (uint16) strlen(auth->password);
 			break;
 
 		default:
@@ -1816,7 +1816,7 @@ int rpcap_sendauth(SOCKET sock, struct pcap_rmtauth *auth, char *errbuf)
 	{
 
 		if (auth->username)
-			rpauth->slen1 = strlen(auth->username);
+			rpauth->slen1 = (uint16) strlen(auth->username);
 		else
 			rpauth->slen1 = 0;
 
@@ -1825,7 +1825,7 @@ int rpcap_sendauth(SOCKET sock, struct pcap_rmtauth *auth, char *errbuf)
 			return -1;
 
 		if (auth->password)
-			rpauth->slen2 = strlen(auth->password);
+			rpauth->slen2 = (uint16) strlen(auth->password);
 		else
 			rpauth->slen2 = 0;
 
@@ -2107,7 +2107,7 @@ SOCKET rpcap_remoteact_getsock(const char *host, int *isactive, char *errbuf)
 {
 	struct activehosts *temp;					/* temp var needed to scan the host list chain */
 	struct addrinfo hints, *addrinfo, *ai_next;	/* temp var needed to translate between hostname to its address */
-	SOCKET retval;
+	int retval;
 
 	/* retrieve the network address corresponding to 'host' */
 	addrinfo = NULL;

--- a/pcap-remote.c
+++ b/pcap-remote.c
@@ -1194,11 +1194,11 @@ int pcap_startcapture_remote(pcap_t *fp)
 	 * So, here bufsize is the whole size of the user buffer.
 	 * In case the bufsize returned is too small, let's adjust it accordingly.
 	 */
-	if (fp->bufsize <= fp->snapshot)
+	if (fp->bufsize <= (u_int) fp->snapshot)
 		fp->bufsize += sizeof(struct pcap_pkthdr);
 
 	/* if the current socket buffer is smaller than the desired one */
-	if (sockbufsize < fp->bufsize)
+	if ((u_int) sockbufsize < fp->bufsize)
 	{
 		/* Loop until the buffer size is OK or the original socket buffer size is larger than this one */
 		while (1)
@@ -1214,7 +1214,7 @@ int pcap_startcapture_remote(pcap_t *fp)
 			 */
 			fp->bufsize /= 2;
 
-			if (sockbufsize >= fp->bufsize)
+			if ((u_int) sockbufsize >= fp->bufsize)
 			{
 				fp->bufsize = sockbufsize;
 				break;

--- a/pcap-remote.c
+++ b/pcap-remote.c
@@ -1136,7 +1136,7 @@ int pcap_startcapture_remote(pcap_t *fp)
 			memset(&hints, 0, sizeof(struct addrinfo));
 			hints.ai_family = ai_family;		/* Use the same address family of the control socket */
 			hints.ai_socktype = (md->rmt_flags & PCAP_OPENFLAG_DATATX_UDP) ? SOCK_DGRAM : SOCK_STREAM;
-			sprintf(portdata, "%d", ntohs(startcapreply.portdata));
+			pcap_snprintf(portdata, PCAP_BUF_SIZE, "%d", ntohs(startcapreply.portdata));
 
 			/* Let's the server pick up a free network port for us */
 			if (sock_initaddress(host, portdata, &hints, &addrinfo, fp->errbuf, PCAP_ERRBUF_SIZE) == -1)

--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -1225,7 +1225,7 @@ pcap_setfilter_win32_dag(pcap_t *p, struct bpf_program *fp) {
 
 	if(!fp)
 	{
-		strncpy(p->errbuf, "setfilter: No filter specified", sizeof(p->errbuf));
+		strlcpy(p->errbuf, "setfilter: No filter specified", sizeof(p->errbuf));
 		return (-1);
 	}
 

--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -556,7 +556,7 @@ pcap_read_win32_npf(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 				return (PCAP_ERROR_BREAK);
 			} else {
 				p->bp = bp;
-				p->cc = ep - bp;
+				p->cc = (int) (ep - bp);
 				return (n);
 			}
 		}
@@ -586,7 +586,7 @@ pcap_read_win32_npf(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			bp += Packet_WORDALIGN(caplen + hdrlen);
 			if (++n >= cnt && !PACKET_COUNT_IS_UNLIMITED(cnt)) {
 				p->bp = bp;
-				p->cc = ep - bp;
+				p->cc = (int) (ep - bp);
 				return (n);
 			}
 		} else {

--- a/pcap.c
+++ b/pcap.c
@@ -1624,7 +1624,16 @@ const char *
 pcap_strerror(int errnum)
 {
 #ifdef HAVE_STRERROR
+#ifdef _WIN32
+	static char errbuf[PCAP_BUF_SIZE];
+	errno_t errno;
+	errno = strerror_s(errbuf, PCAP_BUF_SIZE, errnum);
+	if (errno != 0) /* errno = 0 if successful */
+		strlcpy(errbuf, "strerror_s() error", PCAP_BUF_SIZE);
+	return errbuf;
+#else
 	return (strerror(errnum));
+#endif /* _WIN32 */
 #else
 	extern int sys_nerr;
 	extern const char *const sys_errlist[];

--- a/pcap.c
+++ b/pcap.c
@@ -2188,7 +2188,8 @@ pcap_lib_version(void)
 			    malloc(full_pcap_version_string_len);
 			if (full_pcap_version_string == NULL)
 				return (NULL);
-			sprintf(full_pcap_version_string,
+			pcap_snprintf(full_pcap_version_string,
+				full_pcap_version_string_len,
 			    pcap_version_string_fmt, wpcap_version_string,
 			    pcap_version_string);
 		} else {
@@ -2207,7 +2208,8 @@ pcap_lib_version(void)
 			full_pcap_version_string = malloc(full_pcap_version_string_len);
 			if (full_pcap_version_string == NULL)
 				return (NULL);
-			sprintf(full_pcap_version_string,
+			pcap_snprintf(full_pcap_version_string,
+				full_pcap_version_string_len,
 			    pcap_version_string_packet_dll_fmt,
 			    wpcap_version_string, packet_version_string,
 			    pcap_version_string);

--- a/portability.h
+++ b/portability.h
@@ -79,6 +79,14 @@ extern "C" {
 
 #ifdef _MSC_VER
   #define strdup    _strdup
+  #define sscanf	sscanf_s
+char *tokbuf;
+  #define strltok(x, y) \
+	strtok_s((x), (y), &tokbuf)
+  #define strlcat(x, y, z) \
+	strncat_s((x), (z), (y), _TRUNCATE)
+#else
+  #define strltok strtok
 #endif
 
 /*

--- a/portability.h
+++ b/portability.h
@@ -85,6 +85,8 @@ char *tokbuf;
 	strtok_s((x), (y), &tokbuf)
   #define strlcat(x, y, z) \
 	strncat_s((x), (z), (y), _TRUNCATE)
+  #define setbuf(x, y) \
+	setvbuf((x), (y), _IONBF, 0)
 #else
   #define strltok strtok
 #endif

--- a/portability.h
+++ b/portability.h
@@ -87,6 +87,9 @@ char *tokbuf;
 	strncat_s((x), (z), (y), _TRUNCATE)
   #define setbuf(x, y) \
 	setvbuf((x), (y), _IONBF, 0)
+  #define fopen(x, y) \
+	fopen_safe((x), (y))
+  FILE *fopen_safe(const char *filename, const char* mode);
 #else
   #define strltok strtok
 #endif

--- a/savefile.c
+++ b/savefile.c
@@ -254,6 +254,22 @@ sf_cleanup(pcap_t *p)
 	pcap_freecode(&p->fcode);
 }
 
+/*
+* fopen's safe version on Windows.
+*/
+#ifdef _MSC_VER
+FILE *fopen_safe(const char *filename, const char* mode)
+{
+	FILE *fp = NULL;
+	errno_t errno;
+	errno = fopen_s(&fp, filename, mode);
+	if (errno == 0)
+		return fp;
+	else
+		return NULL;
+}
+#endif
+
 pcap_t *
 pcap_open_offline_with_tstamp_precision(const char *fname, u_int precision,
     char *errbuf)

--- a/sockutils.c
+++ b/sockutils.c
@@ -714,7 +714,7 @@ ssize_t sock_recv(SOCKET sock, void *buffer, size_t size, int receiveall,
 	 * Win32.
 	 */
 	for (;;) {
-		nread = recv(sock, bufp, remaining, 0);
+		nread = recv(sock, bufp, (int) remaining, 0);
 
 		if (nread == -1) {
 #ifndef _WIN32
@@ -748,7 +748,7 @@ ssize_t sock_recv(SOCKET sock, void *buffer, size_t size, int receiveall,
 		remaining -= nread;
 
 		if (remaining == 0)
-			return size;
+			return (ssize_t) size;
 	}
 }
 

--- a/sockutils.c
+++ b/sockutils.c
@@ -862,7 +862,7 @@ int sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage
 			return -2;
 		}
 
-		token = strtok(temphostlist, sep);
+		token = strltok(temphostlist, sep);
 
 		/* it avoids a warning in the compilation ('addrinfo used but not initialized') */
 		addrinfo = NULL;
@@ -886,7 +886,7 @@ int sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage
 				SOCK_ASSERT(errbuf, 1);
 
 				/* Get next token */
-				token = strtok(NULL, sep);
+				token = strltok(NULL, sep);
 				continue;
 			}
 
@@ -911,7 +911,7 @@ int sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage
 			addrinfo = NULL;
 
 			/* Get next token */
-			token = strtok(NULL, sep);
+			token = strltok(NULL, sep);
 		}
 
 		if (addrinfo)
@@ -1105,7 +1105,7 @@ int sock_getascii_addrport(const struct sockaddr_storage *sockaddr, char *addres
 			(memcmp(&((struct sockaddr_in6 *) sockaddr)->sin6_addr, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", sizeof(struct in6_addr)) == 0))
 		{
 			if (address)
-				strncpy(address, SOCKET_NAME_NULL_DAD, addrlen);
+				strlcpy(address, SOCKET_NAME_NULL_DAD, addrlen);
 			return retval;
 		}
 	}
@@ -1121,13 +1121,13 @@ int sock_getascii_addrport(const struct sockaddr_storage *sockaddr, char *addres
 
 		if (address)
 		{
-			strncpy(address, SOCKET_NO_NAME_AVAILABLE, addrlen);
+			strlcpy(address, SOCKET_NO_NAME_AVAILABLE, addrlen);
 			address[addrlen - 1] = 0;
 		}
 
 		if (port)
 		{
-			strncpy(port, SOCKET_NO_PORT_AVAILABLE, portlen);
+			strlcpy(port, SOCKET_NO_PORT_AVAILABLE, portlen);
 			port[portlen - 1] = 0;
 		}
 


### PR DESCRIPTION
Mainly for Windows:
``strncpy, strcpy`` -> ``strlcpy`` -> ``strncpy_s``
``strncat, strcat`` -> ``strlcat`` -> ``strncat_s``
``strtok`` -> ``strltok`` -> ``strtok_s``
``scanf`` -> ``scanf_s``
``sprintf`` -> ``pcap_snprintf``
Add ``(u_int)`` to some comparisons
