### PR TITLE
Made pcap_set_timeout() function work even after pcap device is activated on Windows.

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -655,7 +655,15 @@ int
 pcap_set_timeout(pcap_t *p, int timeout_ms)
 {
 	if (pcap_check_activated(p))
+#ifdef _WIN32
+		if (p->opt.timeout != timeout_ms)
+			if (PacketSetReadTimeout(p->adapter, p->opt.timeout))
+				return 0;
+			else
+				return PCAP_ERROR;
+#else
 		return (PCAP_ERROR_ACTIVATED);
+#endif
 	p->opt.timeout = timeout_ms;
 	return (0);
 }


### PR DESCRIPTION
This commit is to fix this issue: https://github.com/nmap/nmap/issues/426

I will paste some of comments from that issue here:

--------------
Now Npcap has moved to latest libpcap 1.8.0. So it seems that we can use the new **immediate mode** @guyharris mentioned now. I think all we need to do is to call ``pcap_set_immediate_mode`` before ``pcap_activate``, then remove the ``PacketSetReadTimeout`` call, right?

But according to @dmiller-nmap , our goal is ``setting varying timeouts on a single pcap descriptor``. So it seems that we need to change this timeout when the adapter is opened. Not just setting the mode to immediate before activating the adapter. Do libpcap have a way to do this?
