### PR TITLE
Libpcap version can be automatically generated based on the source.

### DIFF
--- a/GenVersion.bat
+++ b/GenVersion.bat
@@ -1,0 +1,25 @@
+REM
+REM Automatically generate version.h based on version.h.in for Windows
+REM The version string comes from VERSION
+REM @echo off
+REM
+
+setlocal enableextensions disabledelayedexpansion
+
+set "search=%%%%LIBPCAP_VERSION%%%%"
+set /p replace=<%0\..\VERSION
+
+set "inputTextFile=%0\..\version.h.in"
+set "outputTextFile=%0\..\version.h"
+
+del "%outputTextFile%" 2>nul
+
+for /f "delims=" %%i in ('type "%inputTextFile%"' ) do (
+	set "line=%%i"
+	setlocal enabledelayedexpansion
+	set "line=!line:%search%=%replace%!"
+	>>"%outputTextFile%" echo(!line!
+	endlocal
+)
+
+echo version.h generated

--- a/Win32/Prj/wpcap.vcxproj
+++ b/Win32/Prj/wpcap.vcxproj
@@ -113,7 +113,8 @@
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
+      <Command>..\..\GenVersion.bat
+win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -140,7 +141,8 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\x64\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
+      <Command>..\..\GenVersion.bat
+win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -169,7 +171,8 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
+      <Command>..\..\GenVersion.bat
+win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>
@@ -197,7 +200,8 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\x64\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
+      <Command>..\..\GenVersion.bat
+win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
   </ItemDefinitionGroup>

--- a/version.h.in
+++ b/version.h.in
@@ -1,0 +1,5 @@
+//{{NO_DEPENDENCIES}}
+// Microsoft Developer Studio generated include file.
+//
+#include "..\..\version.h"
+static const char pcap_version_string[] = "libpcap version %%LIBPCAP_VERSION%%";


### PR DESCRIPTION
This PR is to fix this issue: https://github.com/the-tcpdump-group/libpcap/issues/518
The corresponding change for Npcap is here: https://github.com/nmap/npcap/commit/db8b65da23a77c46624ea6278c15ade077a9e386