### PR TITLE
fix the issue that the win_flex and win_bison commands don't get executed in MSVC's prebuild event.

### DIFF
--- a/Win32/Prj/wpcap.vcxproj
+++ b/Win32/Prj/wpcap.vcxproj
@@ -113,7 +113,7 @@
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>..\..\GenVersion.bat
+      <Command>call ..\..\GenVersion.bat
 win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
@@ -141,7 +141,7 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\x64\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>..\..\GenVersion.bat
+      <Command>call ..\..\GenVersion.bat
 win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
@@ -171,7 +171,7 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>..\..\GenVersion.bat
+      <Command>call ..\..\GenVersion.bat
 win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>
@@ -200,7 +200,7 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
       <AdditionalDependencies>ws2_32.lib;..\..\..\..\packetWin7\Dll\Project\x64\Release No NetMon and AirPcap\Packet.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PreBuildEvent>
-      <Command>..\..\GenVersion.bat
+      <Command>call ..\..\GenVersion.bat
 win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
 win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Command>
     </PreBuildEvent>


### PR DESCRIPTION
Currently, the MSVC pre-build event has 3 lines like:
```
..\..\GenVersion.bat ..\VERSION ..\version.h.in ..\version.h
win_flex -Ppcap_ -7 --outfile=..\..\scanner.c --header-file=..\..\scanner.h ..\..\scanner.l
win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y
```

If we do not add ``call`` before ``..\..\GenVersion.bat``, the build log is:
```
1>------ Rebuild All started: Project: wpcap, Configuration: Release Win32 ------
1>  version.h generated
1>  bpf_filter.c
1>  bpf_dump.c
1>  bpf_image.c
```

If we do add ``call`` before ``..\..\GenVersion.bat``, the build log is:
```
1>------ Rebuild All started: Project: wpcap, Configuration: Release Win32 ------
1>  version.h generated
1>  conflicts: 38 shift/reduce
1>  bpf_filter.c
1>  bpf_dump.c
1>  bpf_image.c
```

This line ``conflicts: 38 shift/reduce`` is printed by WinFlexBison, so it means that without adding ``call``, MSVC seems to not execute the following commands in pre-build event.

This can also be confirmed by deleting ``scanner.l``. If we delete this file, the WinFlexBison commands will certainly fail in MSVC build log. But if we don't add ``call``, there's no error.

Since this fix is very trivial, you can check in the code by yourself. And I will close this PR.