### PR TITLE
Also include version strings defined by Npcap/WinPcap on Windows.

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -2140,6 +2140,12 @@ pcap_offline_filter(const struct bpf_program *fp, const struct pcap_pkthdr *h,
  * when building WinPcap.  (It'd be nice to do so for the packet.dll version
  * number as well.)
  */
+
+/*
+ * Also include version strings defined by Npcap/WinPcap on Windows.
+ */
+#include "..\..\version.h"
+
 static const char wpcap_version_string[] = WINPCAP_VER_STRING;
 static const char pcap_version_string_fmt[] =
 	WINPCAP_PRODUCT_NAME " version %s, based on %s";


### PR DESCRIPTION
Or MSVC will complain:
```
1>  pcap.c
1>..\..\pcap.c(2144): error C2065: 'WINPCAP_VER_STRING' : undeclared identifier
1>..\..\pcap.c(2144): error C2099: initializer is not a constant
1>..\..\pcap.c(2146): error C2065: 'WINPCAP_PRODUCT_NAME' : undeclared identifier
1>..\..\pcap.c(2146): error C2099: initializer is not a constant
1>..\..\pcap.c(2146): error C2143: syntax error : missing ';' before 'string'
1>..\..\pcap.c(2148): error C2065: 'WINPCAP_PRODUCT_NAME' : undeclared identifier
1>..\..\pcap.c(2148): error C2099: initializer is not a constant
1>..\..\pcap.c(2148): error C2143: syntax error : missing ';' before 'string'
1>..\..\pcap.c(2169): warning C4034: sizeof returns 0
1>..\..\pcap.c(2189): warning C4034: sizeof returns 0
1>  savefile.c
1>  scanner.c
1>  sf-pcap-ng.c
1>  sf-pcap.c
1>  Compiling...
1>  sockutils.c
========== Rebuild All: 0 succeeded, 1 failed, 0 skipped ==========
```

Because the strings like ``WINPCAP_VER_STRING`` are only defined in Npcap/WinPcap's ``version.h`` header.