### PR TITLE
Fix man page locations on Solaris

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1191,6 +1191,8 @@ fi
 DYEXT="none"
 MAN_FILE_FORMATS=5
 MAN_MISC_INFO=7
+MAN_USERMOD_SECTION=1M
+MAN_ETHERS_SECTION=3N
 case "$host_os" in
 
 aix*)
@@ -1423,12 +1425,25 @@ sinix*)
 solaris*)
 	AC_DEFINE(HAVE_SOLARIS,1,[On solaris])
 
+	case "`uname -r`" in
+	    5.12)
+		MAN_USERMOD_SECTION=8
+		MAN_ETHERS_SECTION=5
+		MAN_FILE_FORMATS=5
+		MAN_MISC_INFO=7
+		;;
+	    *)
+		#
+		# Use System V conventions for man pages.
+		#
+
+		MAN_USERMOD_SECTION=1m
+		MAN_ETHERS_SECTION=4
+		MAN_FILE_FORMATS=4
+		MAN_MISC_INFO=5
+	esac
+
 	DYEXT="so"
-	#
-	# Use System V conventions for man pages.
-	#
-	MAN_FILE_FORMATS=4
-	MAN_MISC_INFO=5
 	;;
 esac
 
@@ -1472,6 +1487,8 @@ AC_SUBST(SSRC)
 AC_SUBST(DYEXT)
 AC_SUBST(MAN_FILE_FORMATS)
 AC_SUBST(MAN_MISC_INFO)
+AC_SUBST(MAN_USERMOD_SECTION)
+AC_SUBST(MAN_ETHERS_SECTION)
 
 AC_ARG_ENABLE([usb],
 [AC_HELP_STRING([--enable-usb],[enable nusb support @<:@default=yes, if support available@:>@])],

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -182,7 +182,7 @@ be checked for a match.
 True if the Ethernet destination address is \fIehost\fP.
 \fIEhost\fP
 may be either a name from /etc/ethers or a number (see
-.IR ethers (3N)
+.IR ethers (@MAN_ETHERS_SECTION@)
 for numeric format).
 .IP "\fBether src \fIehost\fP"
 True if the Ethernet source address is \fIehost\fP.

--- a/pcap.3pcap.in
+++ b/pcap.3pcap.in
@@ -244,7 +244,7 @@ that device.  A user can be given that privilege by, for example, adding
 that privilege to the user's
 .B defaultpriv
 key with the
-.B usermod (1M)
+.B usermod (@MAN_USERMOD_SECTION@)
 command.
 .TP
 .B Under HP-UX with DLPI:
@@ -915,7 +915,7 @@ script or some other configuration script to check whether the libpcap
 1.0 APIs are available and use them only if they are.
 .SH SEE ALSO
 autoconf(1), tcpdump(1), tcpslice(1), pcap-filter(@MAN_MISC_INFO@), pfconfig(8),
-usermod(1M)
+usermod(@MAN_USERMOD_SECTION@)
 .SH AUTHORS
 The original authors of libpcap are:
 .LP


### PR DESCRIPTION
There are two problems:
a) usermod and ethers man pages lie in nonstandard path
b) Solaris 12 has the man pages sections reordered completely
