### PR TITLE
Change the Npcap macro from "NPF_DRIVER_NAME_NORMAL" to "HAVE_NPCAP_PACKET_API", because "NPF_DRIVER_NAME_NORMAL" is not defined in Packet32.h.

### DIFF
--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -95,10 +95,10 @@ BOOL WINAPI DllMain(
 
 /*
  * Define stub versions of the monitor-mode support routines if this
- * isn't Npcap.  NPF_DRIVER_NAME_NORMAL is defined by Npcap but not
+ * isn't Npcap. HAVE_NPCAP_PACKET_API is defined by Npcap but not
  * WinPcap.
  */
-#ifndef NPF_DRIVER_NAME_NORMAL
+#ifndef HAVE_NPCAP_PACKET_API
 static int
 PacketIsMonitorModeSupported(PCHAR AdapterName _U_)
 {


### PR DESCRIPTION
Although ``NPF_DRIVER_NAME_NORMAL`` is defined in Npcap's ``WpcapNames.h``, this header is not included directly or indirectly by libpcap, so it's no use.

So I defined a new macro: ``HAVE_NPCAP_PACKET_API`` is currently defined in ``Packet32.h``, which is directly included by libpcap here: https://github.com/nmap/npcap/commit/b2221fd4ddba0c6cd0a5be99b769c6db547a73c6