### PR TITLE
Fixing typo in dag_platform_cleanup() from 4418d04

### DIFF
--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -237,7 +237,7 @@ delete_pcap_dag(pcap_t *p)
 static void
 dag_platform_cleanup(pcap_t *p)
 {
-	struct pcap_dag *pd = p->pr;
+	struct pcap_dag *pd = p->priv;
 
 #ifdef HAVE_DAG_STREAMS_API
 	if(dag_stop_stream(p->fd, pd->dag_stream) < 0)


### PR DESCRIPTION
It looks like 4418d04 in the upstream introduced a typo where DAG support does not build.

This fix also needs to be cherry-picked to libpcap-1.8 branch.
