### PR TITLE
Added DLT_PPP in function gen_inbound()

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -7549,6 +7549,7 @@ gen_inbound(compiler_state_t *cstate, int dir)
 	 */
 	switch (cstate->linktype) {
 	case DLT_SLIP:
+	case DLT_PPP:
 		b0 = gen_relation(cstate, BPF_JEQ,
 			  gen_load(cstate, Q_LINK, gen_loadi(cstate, 0), 1),
 			  gen_loadi(cstate, 0),


### PR DESCRIPTION
Patch applied to add DLT for PPP in function gen_inbound(). We have added the #ifdef as suggested in #556.