### PR TITLE
Apparently ctc interfaces on s390 has ethernet DLT

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -3510,6 +3510,12 @@ activate_new(pcap_t *handle)
 				handle->linktype = DLT_LINUX_SLL;
 		}
 
+#if defined(__s390__)
+		/* Hack to make things work on s390 ctc interfaces */
+		if (strncmp("ctc", device, 3) == 0)
+		    handle->linktype = DLT_EN10MB;
+#endif
+
 		handlep->ifindex = iface_get_id(sock_fd, device,
 		    handle->errbuf);
 		if (handlep->ifindex == -1) {


### PR DESCRIPTION
There was an open issue #196 closed as won't fix but we still need to set the type to be ethernet there, thus providing this patch in function activate_new() that was kindly written by RH maintainer @msekletar. Could you please review this issue?

This issue is a continuation of #556.