### PR TITLE
Makefile.in: Fix missing dependency

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -465,7 +465,7 @@ grammar.h: grammar.c
 		$(MAKE) $(MAKEFLAGS) grammar.c; \
 	fi
 
-grammar.o: grammar.c
+grammar.o: grammar.c scanner.h
 	$(CC) $(FULL_CFLAGS) -c grammar.c
 
 gencode.o: $(srcdir)/gencode.c grammar.h scanner.h


### PR DESCRIPTION
Fixes the following error which sometimes shows up on parallel builds:
grammar.y:78:21: fatal error: scanner.h: No such file or directory
 #include "scanner.h"