### PR TITLE
Add .appveyor.yml for MSVC automated builds

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,21 @@
+branches:
+  only:
+  - master
+
+clone_depth: 5
+
+matrix:
+  fast_finish: true
+
+install:
+  - cinst winflexbison
+  - win_flex --version
+  - win_bison --version
+  - appveyor DownloadFile http://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+  - 7z x .\WpdPack_4_1_2.zip -oc:\projects\libpcap\Win32
+
+build_script:
+  - md build
+  - cd build
+  - cmake -DPACKET_DLL_DIR=c:\projects\libpcap\Win32\WpdPack -G"Visual Studio 12 2013" ..
+  - msbuild -nologo -p:Configuration=Release pcap.sln

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ cmake_minimum_required( VERSION 2.8.8 )
 if (POLICY CMP0042)
     cmake_policy(SET CMP0042 OLD)
 endif()
- 
+
 project( pcap )
 #
 # Call the library "wpcap" on Windows, for backwards compatibility.
@@ -54,6 +54,9 @@ include_directories(
 )
 
 if( WIN32 )
+    #
+    # The 'Win32/WpdPack/' directory branch is for an AppVeyor build.
+    #
     if( NOT "${PACKET_DLL_DIR}" STREQUAL "" )
         include_directories("${PACKET_DLL_DIR}/Include")
         if( CMAKE_CL_64 )
@@ -65,6 +68,7 @@ if( WIN32 )
     include_directories(
         ../Common/
         Win32/Include
+        Win32/WpdPack/Include
     )
 endif( WIN32)
 

--- a/pcap.c
+++ b/pcap.c
@@ -1610,7 +1610,7 @@ pcap_open_live(const char *device, int snaplen, int promisc, int to_ms, char *er
 		    NULL, errbuf));
 	}
 	if (srctype == PCAP_SRC_FILE) {
-		snprintf(errbuf, PCAP_ERRBUF_SIZE, "unknown URL scheme \"file\"");
+		pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "unknown URL scheme \"file\"");
 		return (NULL);
 	}
 	if (srctype == PCAP_SRC_IFLOCAL) {


### PR DESCRIPTION
After umpteen trials and errors, the AppVeyor finally produces a `wpcap.dll` and `wpcap.lib` (I assume that is an import-lib for the former). The build-log is [here](https://ci.appveyor.com/project/gvanem/libpcap).
