### PR TITLE
MSVC's strdup() in _DEBUG mode

### DIFF
--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -826,25 +826,15 @@ pcap_read_win32_dag(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 
 /* Send a packet to the network */
 static int
-pcap_inject_win32(pcap_t *p, const void *buf, size_t size){
-	LPPACKET PacketToSend;
+pcap_inject_win32(pcap_t *p, const void *buf, size_t size)
+{
+	PACKET pkt;
 
-	PacketToSend=PacketAllocatePacket();
-
-	if (PacketToSend == NULL)
-	{
-		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE, "send error: PacketAllocatePacket failed");
-		return (-1);
-	}
-
-	PacketInitPacket(PacketToSend, (PVOID)buf, (UINT)size);
-	if(PacketSendPacket(p->adapter,PacketToSend,TRUE) == FALSE){
+	PacketInitPacket(&pkt, buf, size);
+	if(PacketSendPacket(p->adapter,&pkt,TRUE) == FALSE) {
 		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE, "send error: PacketSendPacket failed");
-		PacketFreePacket(PacketToSend);
 		return (-1);
 	}
-
-	PacketFreePacket(PacketToSend);
 
 	/*
 	 * We assume it all got sent if "PacketSendPacket()" succeeded.

--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -464,6 +464,11 @@ pcap_live_dump_win32(pcap_t *p, char *filename, int maxsize, int maxpacks)
 
 	/* Set the limits of the dump file */
 	res = PacketSetDumpLimits(p->adapter, maxsize, maxpacks);
+	if(res == FALSE) {
+		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		    		"Error setting dump limit");
+		return (-1);
+	}
 
 	return (0);
 }

--- a/pcap-win32.c
+++ b/pcap-win32.c
@@ -830,7 +830,7 @@ pcap_inject_win32(pcap_t *p, const void *buf, size_t size)
 {
 	PACKET pkt;
 
-	PacketInitPacket(&pkt, buf, size);
+	PacketInitPacket(&pkt, (PVOID)buf, size);
 	if(PacketSendPacket(p->adapter,&pkt,TRUE) == FALSE) {
 		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE, "send error: PacketSendPacket failed");
 		return (-1);

--- a/portability.h
+++ b/portability.h
@@ -100,7 +100,9 @@ extern "C" {
 #endif
 
 #ifdef _MSC_VER
+  #ifndef _DEBUG
   #define strdup	_strdup
+  #endif
   #define sscanf	sscanf_s
   #define setbuf(x, y) \
 	setvbuf((x), (y), _IONBF, 0)


### PR DESCRIPTION
In MSVC debug-mode (`-MDd` or `-MTd`), there is an important warning on
the redefinition of `strdup`:
```
  portability.h(104): warning C4005: 'strdup': macro redefinition
  f:\ProgramFiler-x86\WindowsKits\Include\10.0.10586.0\ucrt\crtdbg.h(319):
    note: see previous definition of 'strdup'
```
It's definition is:
```
  #define strdup(s)  _strdup_dbg(s, _NORMAL_BLOCK, __FILE__, __LINE__)
```
Undoing that in `"portability.h"` would defeat the purpose of `_DEBUG` mode.
