### PR TITLE
Create plugin API for read/write file I/O, e.g. to allow compression

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,13 +16,13 @@ install:
 
 environment:
   matrix:
-    - GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 14 2015"
       SDK: WpdPack
-    - GENERATOR: "Visual Studio 12 2013 Win64"
+    - GENERATOR: "Visual Studio 14 2015 Win64"
       SDK: WpdPack
-    - GENERATOR: "Visual Studio 12 2013"
+    - GENERATOR: "Visual Studio 14 2015"
       SDK: npcap-sdk-0.1
-    - GENERATOR: "Visual Studio 12 2013 Win64"
+    - GENERATOR: "Visual Studio 14 2015 Win64"
       SDK: npcap-sdk-0.1
 
 build_script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1869,13 +1869,8 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.devel OR EXISTS ${CMAKE_BINARY_DIR}/.deve
         #
         # We do *not* care about every single place the compiler would
         # have inserted Spectre mitigation if only we had told it to
-        # do so with /Qspectre.  I guess the theory is that it's seeing
-        # bounds checks that would prevent out-of-bounds loads and that
-        # those out-of-bounds loads could be done speculatively and that
-        # the Spectre attack could detect the value of the out-of-bounds
-        # data *if* it's within our address space, but unless I'm
-        # missing something I don't see that as being any form of
-        # security hole.
+        # do so with /Qspectre.  Maybe it's worth it, as that's in
+        # Bison-generated code that we don't control.
         #
         # XXX - add /Qspectre if that is really worth doing.
         #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1866,6 +1866,20 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.devel OR EXISTS ${CMAKE_BINARY_DIR}/.deve
         # structure members.
         #
         check_and_add_compiler_option(-wd4820)
+        #
+        # We do *not* care about every single place the compiler would
+        # have inserted Spectre mitigation if only we had told it to
+        # do so with /Qspectre.  I guess the theory is that it's seeing
+        # bounds checks that would prevent out-of-bounds loads and that
+        # those out-of-bounds loads could be done speculatively and that
+        # the Spectre attack could detect the value of the out-of-bounds
+        # data *if* it's within our address space, but unless I'm
+        # missing something I don't see that as being any form of
+        # security hole.
+        #
+        # XXX - add /Qspectre if that is really worth doing.
+        #
+        check_and_add_compiler_option(-wd5045)
     else()
         #
         # Other compilers, including MSVC with a Clang front end and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,7 +87,7 @@ endif()
 # We assume that UTF-8 source is OK with other compilers.
 #
 if(MSVC AND NOT ${CMAKE_C_COMPILER} MATCHES "clang*")
-    set(C_ADDITIONAL_FLAGS "${C_ADDITIONAL_FLAGS} -utf-8")
+    set(C_ADDITIONAL_FLAGS "${C_ADDITIONAL_FLAGS} /utf-8")
 endif(MSVC AND NOT ${CMAKE_C_COMPILER} MATCHES "clang*")
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,7 +955,7 @@ set(PROJECT_SOURCE_LIST_C
     optimize.c
     pcap-common.c
     pcap.c
-	pcap-ioplugin.c
+    pcap-ioplugin.c
     savefile.c
     sf-pcapng.c
     sf-pcap.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,6 +955,7 @@ set(PROJECT_SOURCE_LIST_C
     optimize.c
     pcap-common.c
     pcap.c
+	pcap-ioplugin.c
     savefile.c
     sf-pcapng.c
     sf-pcap.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,7 +93,7 @@ MODULE_C_SRC =		@MODULE_C_SRC@
 REMOTE_C_SRC =		@REMOTE_C_SRC@
 COMMON_C_SRC =	pcap.c gencode.c optimize.c nametoaddr.c etherent.c \
 		fmtutils.c \
-		savefile.c sf-pcap.c sf-pcapng.c pcap-common.c \
+		pcap-ioplugin.c savefile.c sf-pcap.c sf-pcapng.c pcap-common.c \
 		bpf_image.c bpf_filter.c bpf_dump.c
 GENERATED_C_SRC = scanner.c grammar.c
 LIBOBJS = @LIBOBJS@
@@ -326,6 +326,7 @@ EXTRA_DIST = \
 	pcap-dpdk.h \
 	pcap-enet.c \
 	pcap-int.h \
+	pcap-ioplugin.c \
 	pcap-libdlpi.c \
 	pcap-linux.c \
 	pcap-namedb.h \

--- a/Win32/Prj/wpcap.vcxproj
+++ b/Win32/Prj/wpcap.vcxproj
@@ -209,6 +209,7 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
     <ClCompile Include="..\..\pcap-rpcap.c" />
     <ClCompile Include="..\..\pcap-win32.c" />
     <ClCompile Include="..\..\pcap.c" />
+    <ClCompile Include="..\..\pcap-ioplugin.c" />
     <ClCompile Include="..\..\savefile.c" />
     <ClCompile Include="..\..\scanner.c" />
     <ClCompile Include="..\..\sf-pcapng.c" />

--- a/config.h.in
+++ b/config.h.in
@@ -42,17 +42,17 @@
 /* Define to 1 if you have the declaration of `ether_hostton' */
 #undef HAVE_DECL_ETHER_HOSTTON
 
-/* Define to 1 if `dl_module_id_1' is a member of `dl_hp_ppa_info_t'. */
-#undef HAVE_DL_HP_PPA_INFO_T_DL_MODULE_ID_1
-
-/* Define to 1 if the system has the type `dl_passive_req_t'. */
-#undef HAVE_DL_PASSIVE_REQ_T
-
 /* Define to 1 if you have the <dlfcn.h> header file. */
 #undef HAVE_DLFCN_H
 
 /* Define to 1 if you have the `dlopen' function. */
 #undef HAVE_DLOPEN
+
+/* Define to 1 if `dl_module_id_1' is a member of `dl_hp_ppa_info_t'. */
+#undef HAVE_DL_HP_PPA_INFO_T_DL_MODULE_ID_1
+
+/* Define to 1 if the system has the type `dl_passive_req_t'. */
+#undef HAVE_DL_PASSIVE_REQ_T
 
 /* Define to 1 if you have the `ether_hostton' function. */
 #undef HAVE_ETHER_HOSTTON

--- a/config.h.in
+++ b/config.h.in
@@ -54,6 +54,9 @@
 /* Define to 1 if you have the `ffs' function. */
 #undef HAVE_FFS
 
+/* Define to 1 if you have the `fopencookie' function. */
+#undef HAVE_FOPENCOOKIE
+
 /* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
 #undef HAVE_FSEEKO
 
@@ -62,6 +65,12 @@
 
 /* Define to 1 if you have a GNU-style `strerror_r' function. */
 #undef HAVE_GNU_STRERROR_R
+
+/* Define to 1 if you have the `funopen' function. */
+#undef HAVE_FUNOPEN
+
+/* Define to 1 if you have the `gzopen' function. */
+#undef HAVE_GZOPEN
 
 /* on HP-UX 10.20 or later */
 #undef HAVE_HPUX10_20_OR_LATER
@@ -92,6 +101,9 @@
 
 /* libnl has new-style socket api */
 #undef HAVE_LIBNL_SOCKETS
+
+/* Define to 1 if you have the `z' library (-lz). */
+#undef HAVE_LIBZ
 
 /* Define to 1 if you have the <linux/compiler.h> header file. */
 #undef HAVE_LINUX_COMPILER_H
@@ -294,6 +306,9 @@
 
 /* Define to 1 if you have the `vsyslog' function. */
 #undef HAVE_VSYSLOG
+
+/* Define to 1 if you have the <zlib.h> header file. */
+#undef HAVE_ZLIB_H
 
 /* IPv6 */
 #undef INET6

--- a/config.h.in
+++ b/config.h.in
@@ -60,9 +60,6 @@
 /* Define to 1 if you have the `ffs' function. */
 #undef HAVE_FFS
 
-/* Define to 1 if you have the `fopencookie' function. */
-#undef HAVE_FOPENCOOKIE
-
 /* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
 #undef HAVE_FSEEKO
 
@@ -71,9 +68,6 @@
 
 /* Define to 1 if you have a GNU-style `strerror_r' function. */
 #undef HAVE_GNU_STRERROR_R
-
-/* Define to 1 if you have the `funopen' function. */
-#undef HAVE_FUNOPEN
 
 /* on HP-UX 10.20 or later */
 #undef HAVE_HPUX10_20_OR_LATER

--- a/config.h.in
+++ b/config.h.in
@@ -48,6 +48,12 @@
 /* Define to 1 if the system has the type `dl_passive_req_t'. */
 #undef HAVE_DL_PASSIVE_REQ_T
 
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
+/* Define to 1 if you have the `dlopen' function. */
+#undef HAVE_DLOPEN
+
 /* Define to 1 if you have the `ether_hostton' function. */
 #undef HAVE_ETHER_HOSTTON
 
@@ -69,9 +75,6 @@
 /* Define to 1 if you have the `funopen' function. */
 #undef HAVE_FUNOPEN
 
-/* Define to 1 if you have the `gzopen' function. */
-#undef HAVE_GZOPEN
-
 /* on HP-UX 10.20 or later */
 #undef HAVE_HPUX10_20_OR_LATER
 
@@ -83,6 +86,9 @@
 
 /* Define to 1 if you have the `dag' library (-ldag). */
 #undef HAVE_LIBDAG
+
+/* Define to 1 if you have the `dl' library (-ldl). */
+#undef HAVE_LIBDL
 
 /* if libdlpi exists */
 #undef HAVE_LIBDLPI
@@ -101,9 +107,6 @@
 
 /* libnl has new-style socket api */
 #undef HAVE_LIBNL_SOCKETS
-
-/* Define to 1 if you have the `z' library (-lz). */
-#undef HAVE_LIBZ
 
 /* Define to 1 if you have the <linux/compiler.h> header file. */
 #undef HAVE_LINUX_COMPILER_H
@@ -306,9 +309,6 @@
 
 /* Define to 1 if you have the `vsyslog' function. */
 #undef HAVE_VSYSLOG
-
-/* Define to 1 if you have the <zlib.h> header file. */
-#undef HAVE_ZLIB_H
 
 /* IPv6 */
 #undef INET6

--- a/configure
+++ b/configure
@@ -11703,13 +11703,12 @@ fi
 
 done
 
-for ac_func in dlopen funopen fopencookie
+for ac_func in dlopen
 do :
-  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
-ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
-if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
+if test "x$ac_cv_func_dlopen" = xyes; then :
   cat >>confdefs.h <<_ACEOF
-#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+#define HAVE_DLOPEN 1
 _ACEOF
 
 fi

--- a/configure
+++ b/configure
@@ -11646,13 +11646,13 @@ fi
 
 fi
 
-{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gzopen in -lz" >&5
-$as_echo_n "checking for gzopen in -lz... " >&6; }
-if ${ac_cv_lib_z_gzopen+:} false; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+$as_echo_n "checking for dlopen in -ldl... " >&6; }
+if ${ac_cv_lib_dl_dlopen+:} false; then :
   $as_echo_n "(cached) " >&6
 else
   ac_check_lib_save_LIBS=$LIBS
-LIBS="-lz  $LIBS"
+LIBS="-ldl  $LIBS"
 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 /* end confdefs.h.  */
 
@@ -11662,48 +11662,48 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
 #ifdef __cplusplus
 extern "C"
 #endif
-char gzopen ();
+char dlopen ();
 int
 main ()
 {
-return gzopen ();
+return dlopen ();
   ;
   return 0;
 }
 _ACEOF
 if ac_fn_c_try_link "$LINENO"; then :
-  ac_cv_lib_z_gzopen=yes
+  ac_cv_lib_dl_dlopen=yes
 else
-  ac_cv_lib_z_gzopen=no
+  ac_cv_lib_dl_dlopen=no
 fi
 rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
 LIBS=$ac_check_lib_save_LIBS
 fi
-{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_gzopen" >&5
-$as_echo "$ac_cv_lib_z_gzopen" >&6; }
-if test "x$ac_cv_lib_z_gzopen" = xyes; then :
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+$as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_LIBZ 1
+#define HAVE_LIBDL 1
 _ACEOF
 
-  LIBS="-lz $LIBS"
+  LIBS="-ldl $LIBS"
 
 fi
 
-for ac_header in zlib.h
+for ac_header in dlfcn.h
 do :
-  ac_fn_c_check_header_mongrel "$LINENO" "zlib.h" "ac_cv_header_zlib_h" "$ac_includes_default"
-if test "x$ac_cv_header_zlib_h" = xyes; then :
+  ac_fn_c_check_header_mongrel "$LINENO" "dlfcn.h" "ac_cv_header_dlfcn_h" "$ac_includes_default"
+if test "x$ac_cv_header_dlfcn_h" = xyes; then :
   cat >>confdefs.h <<_ACEOF
-#define HAVE_ZLIB_H 1
+#define HAVE_DLFCN_H 1
 _ACEOF
 
 fi
 
 done
 
-for ac_func in gzopen funopen fopencookie
+for ac_func in dlopen funopen fopencookie
 do :
   as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
 ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"

--- a/configure
+++ b/configure
@@ -11646,6 +11646,76 @@ fi
 
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for gzopen in -lz" >&5
+$as_echo_n "checking for gzopen in -lz... " >&6; }
+if ${ac_cv_lib_z_gzopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-lz  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char gzopen ();
+int
+main ()
+{
+return gzopen ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_z_gzopen=yes
+else
+  ac_cv_lib_z_gzopen=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_z_gzopen" >&5
+$as_echo "$ac_cv_lib_z_gzopen" >&6; }
+if test "x$ac_cv_lib_z_gzopen" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBZ 1
+_ACEOF
+
+  LIBS="-lz $LIBS"
+
+fi
+
+for ac_header in zlib.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "zlib.h" "ac_cv_header_zlib_h" "$ac_includes_default"
+if test "x$ac_cv_header_zlib_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_ZLIB_H 1
+_ACEOF
+
+fi
+
+done
+
+for ac_func in gzopen funopen fopencookie
+do :
+  as_ac_var=`$as_echo "ac_cv_func_$ac_func" | $as_tr_sh`
+ac_fn_c_check_func "$LINENO" "$ac_func" "$as_ac_var"
+if eval test \"x\$"$as_ac_var"\" = x"yes"; then :
+  cat >>confdefs.h <<_ACEOF
+#define `$as_echo "HAVE_$ac_func" | $as_tr_cpp` 1
+_ACEOF
+
+fi
+done
+
+
 # Find a good install program.  We prefer a C program (faster),
 # so one script is as good as another.  But avoid the broken or
 # incompatible versions:

--- a/configure.ac
+++ b/configure.ac
@@ -2731,10 +2731,10 @@ if test "x$enable_rdma" != "xno"; then
 	AC_SUBST(PCAP_SUPPORT_RDMASNIFF)
 fi
 
-dnl check for gzip support
-AC_CHECK_LIB(z, gzopen)
-AC_CHECK_HEADERS(zlib.h)
-AC_CHECK_FUNCS(gzopen funopen fopencookie)
+dnl check for dynamic gzip support
+AC_CHECK_LIB(dl, dlopen)
+AC_CHECK_HEADERS(dlfcn.h)
+AC_CHECK_FUNCS(dlopen funopen fopencookie)
 
 AC_PROG_INSTALL
 

--- a/configure.ac
+++ b/configure.ac
@@ -2734,7 +2734,7 @@ fi
 dnl check for dynamic gzip support
 AC_CHECK_LIB(dl, dlopen)
 AC_CHECK_HEADERS(dlfcn.h)
-AC_CHECK_FUNCS(dlopen funopen fopencookie)
+AC_CHECK_FUNCS(dlopen)
 
 AC_PROG_INSTALL
 

--- a/configure.ac
+++ b/configure.ac
@@ -2731,6 +2731,11 @@ if test "x$enable_rdma" != "xno"; then
 	AC_SUBST(PCAP_SUPPORT_RDMASNIFF)
 fi
 
+dnl check for gzip support
+AC_CHECK_LIB(z, gzopen)
+AC_CHECK_HEADERS(zlib.h)
+AC_CHECK_FUNCS(gzopen funopen fopencookie)
+
 AC_PROG_INSTALL
 
 AC_CONFIG_HEADER(config.h)

--- a/gencode.c
+++ b/gencode.c
@@ -8310,7 +8310,6 @@ gen_inbound(compiler_state_t *cstate, int dir)
 			/* We have a FILE *, so this is a savefile */
 			bpf_error(cstate, "inbound/outbound not supported on %s when reading savefiles",
 			    pcap_datalink_val_to_description_or_dlt(cstate->linktype));
-			b0 = NULL;
 			/*NOTREACHED*/
 		}
 		/* match outgoing packets */

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -558,7 +558,6 @@
  */
 #define LINKTYPE_LAPD		203
 
-
 /*
  * PPP, with a one-byte direction pseudo-header prepended - zero means
  * "received by this host", non-zero (any non-zero value) means "sent by
@@ -1170,7 +1169,14 @@
 #define LINKTYPE_DSA_TAG_DSA	284
 #define LINKTYPE_DSA_TAG_EDSA	285
 
-#define LINKTYPE_MATCHING_MAX	285		/* highest value in the "matching" range */
+/*
+ * Payload of lawful intercept packets using the ELEE protocol;
+ * http://socket.hr/draft-dfranusic-opsawg-elee-00.xml
+ * http://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi?url=http://socket.hr/draft-dfranusic-opsawg-elee-00.xml&modeAsFormat=html/ascii
+ */
+#define LINKTYPE_ELEE		286
+
+#define LINKTYPE_MATCHING_MAX	286		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -539,6 +539,11 @@ int	pcap_parsesrcstr_ex(const char *, int *, char *, char *,
 extern int pcap_debug;
 #endif
 
+/*
+ * Internal interfaces for I/O plugins
+ */
+const pcap_ioplugin_t* pcap_ioplugin_init(const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pcap-ioplugin.c
+++ b/pcap-ioplugin.c
@@ -78,7 +78,8 @@
  * fopen's safe version on Windows.
  */
 #ifdef _MSC_VER
-FILE *fopen_safe(const char *filename, const char* mode)
+FILE *
+fopen_safe(const char *filename, const char* mode)
 {
 	FILE *fp = NULL;
 	errno_t errno;
@@ -142,7 +143,8 @@ stdio_open_write(const char *fname, char *errbuf)
 	return fp;
 }
 
-static const pcap_ioplugin_t* pcap_ioplugin_stdio() {
+static const pcap_ioplugin_t*
+pcap_ioplugin_stdio() {
 	static pcap_ioplugin_t plugin = {
 		.open_read = stdio_open_read,
 		.open_write = stdio_open_write
@@ -159,7 +161,8 @@ static const pcap_ioplugin_t* pcap_ioplugin_stdio() {
  *     stdio-based output if the plugin fails to load
  */
 
-const pcap_ioplugin_t* pcap_ioplugin_init(const char *name)
+const pcap_ioplugin_t*
+pcap_ioplugin_init(const char *name)
 {
 	void *lib = NULL;
 	if (name == NULL) {
@@ -196,7 +199,8 @@ static struct {
 static int registered_atexit = 0;
 static int running_atexit = 0;
 
-static void pcap_ioplugin_closeall()
+static void
+pcap_ioplugin_closeall(void)
 {
 	struct file_entry *entry = file_list.head;
 
@@ -212,7 +216,8 @@ static void pcap_ioplugin_closeall()
 	file_list.head = NULL;
 }
 
-void pcap_ioplugin_register_fp_cookie(FILE *fp, const void *cookie)
+void
+pcap_ioplugin_register_fp_cookie(FILE *fp, const void *cookie)
 {
 	struct file_entry *entry = malloc(sizeof *entry);
 	if (!entry) {
@@ -231,7 +236,8 @@ void pcap_ioplugin_register_fp_cookie(FILE *fp, const void *cookie)
 	file_list.head = entry;
 }
 
-void pcap_ioplugin_unregister_fp_cookie(const void *cookie)
+void
+pcap_ioplugin_unregister_fp_cookie(const void *cookie)
 {
 	struct file_entry *entry = file_list.head;
 

--- a/pcap-ioplugin.c
+++ b/pcap-ioplugin.c
@@ -98,8 +98,15 @@ stdio_open_read(const char *fname, char *errbuf)
 
 	if (strcmp(fname, "-") == 0) {
 		fp = stdin;
+		SET_BINMODE(fp);
 	} else {
-		fp = fopen(fname, "r");
+		/*
+		 * "b" is supported as of C90, so *all* UN*Xes should
+		 * support it, even though it does nothing.  It's
+		 * required on Windows, as the file is a binary file
+		 * and must be written in binary mode.
+		 */
+		fp = fopen(fname, "rb");
 		if (fp == NULL) {
 			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "%s: fopen: %s", fname,
 				pcap_strerror(errno));
@@ -107,7 +114,6 @@ stdio_open_read(const char *fname, char *errbuf)
 		}
 	}
 
-	SET_BINMODE(fp);
 	return fp;
 }
 
@@ -118,8 +124,15 @@ stdio_open_write(const char *fname, char *errbuf)
 
 	if (strcmp(fname, "-") == 0) {
 		fp = stdout;
+		SET_BINMODE(fp);
 	} else {
-		fp = fopen(fname, "w");
+		/*
+		 * "b" is supported as of C90, so *all* UN*Xes should
+		 * support it, even though it does nothing.  It's
+		 * required on Windows, as the file is a binary file
+		 * and must be written in binary mode.
+		 */
+		fp = fopen(fname, "wb");
 		if (fp == NULL) {
 			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "%s: fopen: %s", fname,
 				pcap_strerror(errno));
@@ -127,7 +140,6 @@ stdio_open_write(const char *fname, char *errbuf)
 		}
 	}
 
-	SET_BINMODE(fp);
 	return fp;
 }
 

--- a/pcap-ioplugin.c
+++ b/pcap-ioplugin.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (c) 2017
+ *	Internet Systems Consortium, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code distributions
+ * retain the above copyright notice and this paragraph in its entirety, (2)
+ * distributions including binary code include the above copyright notice and
+ * this paragraph in its entirety in the documentation or other materials
+ * provided with the distribution, and (3) all advertising materials mentioning
+ * features or use of this software display the following acknowledgement:
+ * ``This product includes software developed by the University of California,
+ * Lawrence Berkeley Laboratory and its contributors.'' Neither the name of
+ * the University nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior
+ * written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * pcap-ioplugin.c - supports dynamic loading of compression modules
+ *	Created by Ray Bellis, ISC.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ftmacros.h"
+
+#ifdef _WIN32
+#include <pcap-stdinc.h>
+#else /* _WIN32 */
+#if HAVE_INTTYPES_H
+#include <inttypes.h>
+#elif HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#ifdef HAVE_SYS_BITYPES_H
+#include <sys/bitypes.h>
+#endif
+#include <sys/types.h>
+#endif /* _WIN32 */
+
+#include <errno.h>
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pcap-int.h"
+
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif
+
+#ifdef HAVE_OS_PROTO_H
+#include "os-proto.h"
+#endif
+
+/*
+ * Setting O_BINARY on DOS/Windows is a bit tricky
+ */
+#if defined(_WIN32)
+  #define SET_BINMODE(f)  _setmode(_fileno(f), _O_BINARY)
+#elif defined(MSDOS)
+  #if defined(__HIGHC__)
+  #define SET_BINMODE(f)  setmode(f, O_BINARY)
+  #else
+  #define SET_BINMODE(f)  setmode(fileno(f), O_BINARY)
+  #endif
+#else
+  #define SET_BINMODE(f)  (void)f
+#endif
+
+/*
+ * fopen's safe version on Windows.
+ */
+#ifdef _MSC_VER
+FILE *fopen_safe(const char *filename, const char* mode)
+{
+	FILE *fp = NULL;
+	errno_t errno;
+	errno = fopen_s(&fp, filename, mode);
+	if (errno == 0)
+		return fp;
+	else
+		return NULL;
+}
+#endif
+
+/*
+ * file I/O plugin support
+ */
+static FILE*
+stdio_open_read(const char *fname, char *errbuf)
+{
+	FILE *fp = NULL;
+
+	if (strcmp(fname, "-") == 0) {
+		fp = stdin;
+	} else {
+		fp = fopen(fname, "r");
+		if (fp == NULL) {
+			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "%s: fopen: %s", fname,
+				pcap_strerror(errno));
+			return (NULL);
+		}
+	}
+
+	SET_BINMODE(fp);
+	return fp;
+}
+
+static FILE*
+stdio_open_write(const char *fname, char *errbuf)
+{
+	FILE *fp = NULL;
+
+	if (strcmp(fname, "-") == 0) {
+		fp = stdout;
+	} else {
+		fp = fopen(fname, "w");
+		if (fp == NULL) {
+			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "%s: fopen: %s", fname,
+				pcap_strerror(errno));
+			return (NULL);
+		}
+	}
+
+	SET_BINMODE(fp);
+	return fp;
+}
+
+static const pcap_ioplugin_t* pcap_ioplugin_stdio() {
+	static pcap_ioplugin_t plugin = {
+		.open_read = stdio_open_read,
+		.open_write = stdio_open_write
+	};
+
+	return &plugin;
+}
+
+const pcap_ioplugin_t* pcap_ioplugin_init(const char *name)
+{
+	void *lib = NULL;
+
+	if (name == NULL) {
+		goto fail;
+	}
+
+#if HAVE_DLOPEN
+	lib = dlopen(name, RTLD_NOW);
+	if (lib != NULL) {
+		pcap_ioplugin_init_fn ioplugin_init = dlsym(lib, "ioplugin_init");
+		if (ioplugin_init == NULL) {
+			dlclose(lib);
+			goto fail;
+		} else {
+			return ioplugin_init();
+		}
+	}
+#endif /* HAVE_DLOPEN */
+
+fail:
+	return pcap_ioplugin_stdio();
+}

--- a/pcap-ioplugin.c
+++ b/pcap-ioplugin.c
@@ -74,23 +74,6 @@
   #define SET_BINMODE(f)  (void)f
 #endif
 
-/*
- * fopen's safe version on Windows.
- */
-#ifdef _MSC_VER
-FILE *
-fopen_safe(const char *filename, const char* mode)
-{
-	FILE *fp = NULL;
-	errno_t errno;
-	errno = fopen_s(&fp, filename, mode);
-	if (errno == 0)
-		return fp;
-	else
-		return NULL;
-}
-#endif
-
 static FILE*
 stdio_open_read(const char *fname, char *errbuf)
 {

--- a/pcap-ioplugin.c
+++ b/pcap-ioplugin.c
@@ -140,6 +140,14 @@ static const pcap_ioplugin_t* pcap_ioplugin_stdio() {
 	return &plugin;
 }
 
+/*
+ * loads an I/O plugin with the given name
+ * (on UNIX, a .so shared library)
+ *
+ * NB: fails silently and falls back to existing uncompressed
+ *     stdio-based output if the plugin fails to load
+ */
+
 const pcap_ioplugin_t* pcap_ioplugin_init(const char *name)
 {
 	void *lib = NULL;
@@ -147,7 +155,6 @@ const pcap_ioplugin_t* pcap_ioplugin_init(const char *name)
 		goto fail;
 	}
 
-	dlerror();
 #if HAVE_DLOPEN
 	lib = dlopen(name, RTLD_NOW);
 	if (lib != NULL) {

--- a/pcap.c
+++ b/pcap.c
@@ -802,7 +802,7 @@ get_if_description(const char *name)
 		}
 #endif /* __FreeBSD__ */
 		close(s);
-		if (description != NULL && strlen(description) == 0) {
+		if (description != NULL && description[0] == '\0') {
 			/*
 			 * Description is empty, so discard it.
 			 */

--- a/pcap.c
+++ b/pcap.c
@@ -3132,6 +3132,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(DSA_TAG_BRCM_PREPEND, "Broadcom tag (prepended)"),
 	DLT_CHOICE(DSA_TAG_DSA, "Marvell DSA"),
 	DLT_CHOICE(DSA_TAG_EDSA, "Marvell EDSA"),
+	DLT_CHOICE(ELEE, "ELEE lawful intercept packets"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1456,6 +1456,13 @@
 #define DLT_DSA_TAG_EDSA	285
 
 /*
+ * Payload of lawful intercept packets using the ELEE protocol;
+ * http://socket.hr/draft-dfranusic-opsawg-elee-00.xml
+ * http://xml2rfc.tools.ietf.org/cgi-bin/xml2rfc.cgi?url=http://socket.hr/draft-dfranusic-opsawg-elee-00.xml&modeAsFormat=html/ascii
+ */
+#define DLT_ELEE		286
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1465,7 +1472,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	285	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	286	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -974,6 +974,8 @@ typedef struct pcap_ioplugin {
 	pcap_ioplugin_open_write_fn		open_write;
 } pcap_ioplugin_t;
 
+typedef const pcap_ioplugin_t* (*pcap_ioplugin_init_fn)();
+
 #ifdef __cplusplus
 }
 #endif

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -976,6 +976,9 @@ typedef struct pcap_ioplugin {
 
 typedef const pcap_ioplugin_t* (*pcap_ioplugin_init_fn)();
 
+PCAP_API void pcap_ioplugin_register_fp_cookie(FILE *fp, const void *cookie);
+PCAP_API void pcap_ioplugin_unregister_fp_cookie(const void *cookie);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -962,6 +962,18 @@ PCAP_API int	pcap_remoteact_list(char *hostlist, char sep, int size,
 PCAP_API int	pcap_remoteact_close(const char *host, char *errbuf);
 PCAP_API void	pcap_remoteact_cleanup(void);
 
+/*
+ * I/O Plugin Support
+ */
+
+typedef FILE* (*pcap_ioplugin_open_read_fn)(const char *fname, char *errbuf);
+typedef FILE* (*pcap_ioplugin_open_write_fn)(const char *fname, char *errbuf);
+
+typedef struct pcap_ioplugin {
+	pcap_ioplugin_open_read_fn		open_read;
+	pcap_ioplugin_open_write_fn		open_write;
+} pcap_ioplugin_t;
+
 #ifdef __cplusplus
 }
 #endif

--- a/savefile.c
+++ b/savefile.c
@@ -312,6 +312,10 @@ static FILE* pcap_open_gzfile(void *gz, char *errbuf)
 	}
 	return fp;
 }
+#else
+
+/* null function pointer to silence linker error when the real function isn't available */
+static FILE* (*pcap_open_gzfile)(void *gz, char *errbuf) = NULL;
 
 #endif /* HAVE_DLOPEN */
 

--- a/savefile.c
+++ b/savefile.c
@@ -232,22 +232,6 @@ sf_cleanup(pcap_t *p)
 	pcap_freecode(&p->fcode);
 }
 
-/*
-* fopen's safe version on Windows.
-*/
-#ifdef _MSC_VER
-FILE *fopen_safe(const char *filename, const char* mode)
-{
-	FILE *fp = NULL;
-	errno_t errno;
-	errno = fopen_s(&fp, filename, mode);
-	if (errno == 0)
-		return fp;
-	else
-		return NULL;
-}
-#endif
-
 pcap_t *
 pcap_open_offline_with_tstamp_precision(const char *fname, u_int precision,
 					char *errbuf)

--- a/savefile.c
+++ b/savefile.c
@@ -33,8 +33,6 @@
 #endif
 
 #include <pcap-types.h>
-#include "ftmacros.h"
-
 #ifdef _WIN32
 #include <io.h>
 #include <fcntl.h>

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -56,19 +56,6 @@
 #include "sf-pcap.h"
 
 /*
- * Setting O_BINARY on DOS/Windows is a bit tricky
- */
-#if defined(_WIN32)
-  #define SET_BINMODE(f)  _setmode(_fileno(f), _O_BINARY)
-#elif defined(MSDOS)
-  #if defined(__HIGHC__)
-  #define SET_BINMODE(f)  setmode(f, O_BINARY)
-  #else
-  #define SET_BINMODE(f)  setmode(fileno(f), O_BINARY)
-  #endif
-#endif
-
-/*
  * Standard libpcap format.
  */
 #define TCPDUMP_MAGIC		0xa1b2c3d4
@@ -774,15 +761,11 @@ pcap_setup_dump(pcap_t *p, int linktype, FILE *f, const char *fname)
 
 #if defined(_WIN32) || defined(MSDOS)
 	/*
-	 * If we're writing to the standard output, put it in binary
-	 * mode, as savefiles are binary files.
+	 * If we're not writing to the standard output, turn of buffering.
 	 *
-	 * Otherwise, we turn off buffering.
 	 * XXX - why?  And why not on the standard output?
 	 */
-	if (f == stdout)
-		SET_BINMODE(f);
-	else
+	if (f != stdout)
 		setvbuf(f, NULL, _IONBF, 0);
 #endif
 	if (sf_write_header(p, f, linktype, p->snapshot) == -1) {
@@ -801,6 +784,7 @@ pcap_setup_dump(pcap_t *p, int linktype, FILE *f, const char *fname)
 pcap_dumper_t *
 pcap_dump_open(pcap_t *p, const char *fname)
 {
+	const pcap_ioplugin_t *plugin = pcap_ioplugin_init(getenv("PCAP_IOPLUGIN_WRITE"));
 	FILE *f;
 	int linktype;
 
@@ -828,23 +812,18 @@ pcap_dump_open(pcap_t *p, const char *fname)
 		    "A null pointer was supplied as the file name");
 		return NULL;
 	}
-	if (fname[0] == '-' && fname[1] == '\0') {
-		f = stdout;
-		fname = "standard output";
-	} else {
-		/*
-		 * "b" is supported as of C90, so *all* UN*Xes should
-		 * support it, even though it does nothing.  It's
-		 * required on Windows, as the file is a binary file
-		 * and must be written in binary mode.
-		 */
-		f = fopen(fname, "wb");
-		if (f == NULL) {
-			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
-			    errno, "%s", fname);
-			return (NULL);
-		}
+
+	if (plugin->open_write == NULL) {
+		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		    "No file writing function found");
+		return NULL;
 	}
+
+	f = plugin->open_write(fname, p->errbuf);
+	if (f == NULL) {
+		return NULL;
+	}
+
 	return (pcap_setup_dump(p, linktype, f, fname));
 }
 

--- a/sockutils.c
+++ b/sockutils.c
@@ -347,7 +347,8 @@ SOCKET sock_open(struct addrinfo *addrinfo, int server, int nconn, char *errbuf,
 		 * Don't treat an error as a failure.
 		 */
 		int optval = 1;
-		(void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval));
+		(void)setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
+		    (char *)&optval, sizeof (optval));
 
 #if defined(IPV6_V6ONLY) || defined(IPV6_BINDV6ONLY)
 		/*


### PR DESCRIPTION
This patch adds automatic on-the-fly decompression of files with names ending '.gz' on supported systems when those filenames are passed to `pcap_open_offline()` family functions that take a filename.

It uses `fopencookie` on glibc systems, and `funopen` on BSD.