### PR TITLE
rpcapd: The remote capture does not start when the remote client uses the non null authentication procedure.

### DIFF
--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -566,7 +566,7 @@ int daemon_checkauth(SOCKET sockctrl, int nullAuthAllowed, char *errbuf)
 				retcode = -1;
 				goto error;
 			}
-			totread = nread;
+			totread += nread;
 			nread = sock_recv(sockctrl, string2, len2,
 			    SOCK_RECEIVEALL_YES, errbuf, PCAP_ERRBUF_SIZE);
 			if (nread == -1)


### PR DESCRIPTION
When a remote client sent a non null authentication request message (RPCAP_RMTAUTH_PWD), the rpcapd daemon did not respond it and the capture was not able to start.

The counter that stores the bytes read from the received payload was not updated after reading the username. When the procedure was completed, the server kept waiting for more inexistent data, avoiding the start of the capture.
