### PR TITLE
Add link-layer header type for Linux vsock.

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -3306,6 +3306,13 @@ static void map_arphrd_to_dlt(pcap_t *handle, int sock_fd, int arptype,
 		/* handlep->cooked = 1; */
 		break;
 
+#ifndef ARPHRD_VSOCKMON
+#define ARPHRD_VSOCKMON	826
+#endif
+	case ARPHRD_VSOCKMON:
+		handle->linktype = DLT_VSOCK;
+		break;
+
 	default:
 		handle->linktype = -1;
 		break;

--- a/pcap.c
+++ b/pcap.c
@@ -2090,6 +2090,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(OPENFLOW, "OpenBSD DLT_OPENFLOW"),
 	DLT_CHOICE(SDLC, "IBM SDLC frames"),
 	DLT_CHOICE(TI_LLN_SNIFFER, "TI LLN sniffer frames"),
+	DLT_CHOICE(VSOCK, "Linux vsock"),
 	DLT_CHOICE_SENTINEL
 };
 


### PR DESCRIPTION
Linux 4.12 has the vsockmon kernel module for AF_VSOCK packet capture.
AF_VSOCK is used for host<->guest communication between a hypervisor and
virtual machines.  It is supported by VMware and KVM.

Traffic can be captured as follows:

    # modprobe vsockmon
    # ip link add type vsockmon
    # ip link set vsockmon0 up

This work was originally written as part of Google Summer of Code 2016 by @GerardGarcia.  I was hist mentor and am upstreaming his code now that Linux 4.12 has been released with vsockmon support.