### PR TITLE
Libpcap 1.8 fix HAVE_REMOTE on Unix

### DIFF
--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -526,10 +526,10 @@ PCAP_API void	bpf_dump(const struct bpf_program *, int);
 
 #endif /* _WIN32/MSDOS/UN*X */
 
-#ifdef HAVE_REMOTE
+#if defined(_WIN32) && defined(HAVE_REMOTE)
   /* Includes most of the public stuff that is needed for the remote capture */
   #include <remote-ext.h>
-#endif	 /* HAVE_REMOTE */
+#endif /* _WIN32 && HAVE_REMOTE */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
The libpcap 1.8 branch doesn't ensure HAVE_REMOTE is only honored by WIN32 systems. Currently software that tries to support HAVE_REMOTE for WIN32 systems fail to build on Unix because the remote-ext.h header is missing.