### PR TITLE
Enable generating version.c from batch file in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -667,6 +667,13 @@ if(WIN32)
     file(TO_NATIVE_PATH "${pcap_SOURCE_DIR}/VERSION" VERSION_path)
     file(TO_NATIVE_PATH "${pcap_SOURCE_DIR}/pcap_version.h.in" version_h_in_path)
     file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/pcap_version.h" version_h_path)
+    file(TO_NATIVE_PATH "${CMAKE_CURRENT_BINARY_DIR}/version.c" version_c_path) 
+    add_custom_command( 
+        OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/version.c 
+        SOURCE ${pcap_SOURCE_DIR}/VERSION 
+        COMMAND ${GenVersion_path} ${VERSION_path} ${version_h_in_path} ${version_c_path} 
+        DEPENDS ${pcap_SOURCE_DIR}/VERSION 
+    ) 
     add_custom_command(
         OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/pcap_version.h
         SOURCE ${pcap_SOURCE_DIR}/VERSION ${pcap_SOURCE_DIR}/pcap_version.h.in


### PR DESCRIPTION
Using NMake in cmake instead MSBUILD causes the build to fail because of a missing version.c file.
Adding a custom command to generate it before building fixes this.
I'm not exactly sure why this step is necessary for NMake but not for MSBUILD.