### PR TITLE
Fixed naming collision in MSVC builds (cmake)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -750,7 +750,12 @@ add_library(${LIBRARY_NAME}_static STATIC
     ${PROJECT_SOURCE_LIST_H}
 )
 add_dependencies(${LIBRARY_NAME}_static SerializeTarget)
-set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}")
+
+if(MSVC)
+    set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}_static")
+else(MSVC)
+    set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}")
+endif(MSVC)
 
 target_link_libraries(${LIBRARY_NAME} ${PCAP_LINK_LIBRARIES})
 


### PR DESCRIPTION
The dll's import library as well as the static library are named wpcap.lib.
The static library is created last and deletes the import library.

There's no agreed naming convention for static libraries on MSVC.
A popular conventions is to add the _static suffix to the static library.

Microsoft sometimes adds the lib prefix to their static libraries (libvcruntime.lib, libucrt.lib). This is also how [boost ](http://www.boost.org/doc/libs/1_42_0/more/getting_started/windows.html#library-naming) decided to name their static libraries on MSVC.
I like that, but this may not be obvious to everyone.

The new name for the static is of course up to you.
Another way to fix this is would be to change the output directory. But both libraries are meant to be eventually installed into lib.