### PR TITLE
Install things where MSVC and MinGW expect them

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -805,7 +805,7 @@ add_library(${LIBRARY_NAME}_static STATIC
 add_dependencies(${LIBRARY_NAME}_static SerializeTarget)
 
 if(MSVC)
-    set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}_static")
+    set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}_static" COMPILE_OPTIONS "/Z7")
 else(MSVC)
     set_target_properties(${LIBRARY_NAME}_static PROPERTIES OUTPUT_NAME "${LIBRARY_NAME}")
 endif(MSVC)
@@ -821,7 +821,24 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmakeconfig.h.in ${CMAKE_CURRENT_BINA
 ######################################
 # Install pcap library and include files
 ######################################
-install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
-install(TARGETS ${LIBRARY_NAME}_static DESTINATION lib)
+if(WIN32)
+    if(NOT CMAKE_CL_64)
+        install(TARGETS ${LIBRARY_NAME} ${LIBRARY_NAME}_static
+                RUNTIME DESTINATION bin
+                LIBRARY DESTINATION lib
+                ARCHIVE DESTINATION lib)
+        install(FILES $<TARGET_PDB_FILE:${LIBRARY_NAME}> DESTINATION bin OPTIONAL)
+    else(NOT CMAKE_CL_64)
+        install(TARGETS ${LIBRARY_NAME} ${LIBRARY_NAME}_static
+                RUNTIME DESTINATION bin/amd64
+                LIBRARY DESTINATION lib/amd64
+                ARCHIVE DESTINATION lib/amd64)
+        install(FILES $<TARGET_PDB_FILE:${LIBRARY_NAME}> DESTINATION bin/amd64 OPTIONAL)
+    endif(NOT CMAKE_CL_64)
+else(WIN32)
+    install(TARGETS ${LIBRARY_NAME} DESTINATION lib)
+    install(TARGETS ${LIBRARY_NAME}_static DESTINATION lib)
+endif(WIN32)
+
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/pcap/ DESTINATION include/pcap)
 install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/pcap.h DESTINATION include)


### PR DESCRIPTION
- dlls go into bin
- debugging symbols (pdb files generated during debug builds) MUST be install (also into bin)
- only the import library and the static library end up in lib
- MSVC only: 64 bit build MUST go into amd64 sub-folders of both the bin and lib folder

Debugging information are now directly embedded into the static library (/Z7). This should make the it much more self-contained.

As an aside, an end user may want to install the dll to their system path instead.