### PR TITLE
optimizer: replacing unknown value with unknown value is not a no-op

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -578,7 +578,7 @@ F(opt_state_t *opt_state, int code, int v0, int v1)
 static inline void
 vstore(struct stmt *s, int *valp, int newval, int alter)
 {
-	if (alter && *valp == newval)
+	if (alter && newval != 0 && *valp == newval)
 		s->code = NOP;
 	else
 		*valp = newval;


### PR DESCRIPTION
Function vstore() checks if new and old value are the same and if they are,
it replaces the instruction with NOP. We must not do this if both old and
new value are 0 which means "unknown" as in this case, the actual values
(at runtime) can differ so that the instruction cannot be omitted.

An example of a program where this leads to incorrect optimization is shown
in issue #581.