### PR TITLE
optimizer: show edges in dot graph

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -2334,10 +2334,8 @@ dot_dump(compiler_state_t *cstate, struct icode *ic)
 	f.bf_insns = icode_to_fcode(cstate, ic, ic->root, &f.bf_len);
 
 	fprintf(out, "digraph BPF {\n");
-	ic->cur_mark = 0;
 	unMarkAll(ic);
 	dot_dump_node(ic, ic->root, &f, out);
-	ic->cur_mark = 0;
 	unMarkAll(ic);
 	dot_dump_edge(ic, ic->root, out);
 	fprintf(out, "}\n");


### PR DESCRIPTION
Resetting ic->cur_mark to 0 in dot_dump() results in no edges in dot graph
exported for pcap_optimizer_debug > 3 as all blocks are marked with 1 after
running dot_dump_node(); resetting ic->cur_mark to 0 and incrementing it
results in all blocks "marked" when we enter dot_dump_edge().

Fixes: fb2069644165 ("Don't use global state for the BPF compiler.")