### PR TITLE
Renamed Wspiapi.h to wspiapi.h

### DIFF
--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -57,7 +57,7 @@
      *
      * We use getaddrinfo(), so we include Wspiapi.h here.
      */
-    #include <Wspiapi.h>
+    #include <wspiapi.h>
   #endif /* INET6 */
 #else /* _WIN32 */
   #include <sys/param.h>

--- a/scanner.l
+++ b/scanner.l
@@ -124,7 +124,7 @@ void pcap_set_column(int, yyscan_t);
  *
  * We use getaddrinfo(), so we include Wspiapi.h here.
  */
-#include <Wspiapi.h>
+#include <wspiapi.h>
 #else /* _WIN32 */
 #include <sys/socket.h>	/* for "struct sockaddr" in "struct addrinfo" */
 #include <netdb.h>	/* for "struct addrinfo" */


### PR DESCRIPTION
cmd and powershell are not case sensitive, but this file has always been all lowercase.