### PR TITLE
Use strtok_r as strtok_s under MinGW as well

### DIFF
--- a/portability.h
+++ b/portability.h
@@ -154,7 +154,7 @@ extern int pcap_vsnprintf(char *, size_t, const char *, va_list ap);
 #ifdef HAVE_STRTOK_R
   #define pcap_strtok_r	strtok_r
 #else
-  #ifdef _MSC_VER
+  #ifdef _WIN32
     /*
      * Microsoft gives it a different name.
      */


### PR DESCRIPTION
With cmake, strtok_r isn't tested for on windows and assumed not to exist.
Newer version of MinGW have implemented it. Older version (e. g. the one provided by Debian) however seem to only have it under strtok_s.
It's probably a ok to stick with strtok_s for all of windows for now.