### PR TITLE
Use CMAKE_SIZEOF_VOID_P to determine the target architecture.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -996,7 +996,7 @@ if(NOT BUILD_SHARED_LIBS)
 endif(NOT BUILD_SHARED_LIBS)
 
 if(WIN32)
-    if(CMAKE_CL_64)
+    if(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
         #
         # Install 64-bit code built with MSVC in the amd64 subdirectories,
         # as that's where it expects it to be.
@@ -1013,7 +1013,7 @@ if(WIN32)
                         DESTINATION bin/amd64 OPTIONAL)
             endif(BUILD_SHARED_LIBS)
         endif(NOT MINGW)
-    else(CMAKE_CL_64)
+    else(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
         #
         # Install 32-bit code, and 64-bit code not built with MSVC
         # in the top-level directories, as those are where they
@@ -1031,7 +1031,7 @@ if(WIN32)
                         DESTINATION bin OPTIONAL)
             endif(BUILD_SHARED_LIBS)
         endif(NOT MINGW)
-    endif(CMAKE_CL_64)
+    endif(MSVC AND CMAKE_SIZEOF_VOID_P EQUAL 8)
 else(WIN32)
     install(TARGETS ${LIBRARY_NAME} ${LIBRARY_NAME_STATIC} DESTINATION lib)
 endif(WIN32)

--- a/cmake/FindPacket.cmake
+++ b/cmake/FindPacket.cmake
@@ -49,7 +49,7 @@ endif()
 # The 64-bit Packet.lib is located under /x64
 # MinGW users may manually define TARGET_IS_MINGW64 to point to /x64
 set(64BIT_SUBDIR "")
-if(CMAKE_CL_64 OR TARGET_IS_MINGW64)
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   set(64BIT_SUBDIR "/x64")
 endif()
 


### PR DESCRIPTION
Using CMAKE_CL_64 is discouraged by cmake's authors and is limited to Windows (MSVC).