### PR TITLE
 No need to manually define _WINSOCKAPI_

### DIFF
--- a/pcap-types.h
+++ b/pcap-types.h
@@ -35,14 +35,6 @@
  * Get u_int defined, by hook or by crook.
  */
 #ifdef _WIN32
-  /*
-   * Avoids a compiler warning in case this was already defined
-   * (someone defined _WINSOCKAPI_ when including 'windows.h', in order
-   * to prevent it from including 'winsock.h')
-   */
-  #ifdef _WINSOCKAPI_
-    #undef _WINSOCKAPI_
-  #endif
 
   /*
    * This defines u_int.

--- a/rpcapd/win32-svc.c
+++ b/rpcapd/win32-svc.c
@@ -33,7 +33,6 @@
 
 #include "rpcapd.h"
 #include <signal.h>
-#define	_WINSOCKAPI_
 #include "windows.h"
 #include <pcap.h>		// for PCAP_ERRBUF_SIZE
 #include "sockutils.h"	// for SOCK_ASSERT

--- a/rpcapd/win32-svc.c
+++ b/rpcapd/win32-svc.c
@@ -33,7 +33,6 @@
 
 #include "rpcapd.h"
 #include <signal.h>
-#include "windows.h"
 #include <pcap.h>		// for PCAP_ERRBUF_SIZE
 #include "sockutils.h"	// for SOCK_ASSERT
 #include "fileconf.h"

--- a/sockutils.h
+++ b/sockutils.h
@@ -38,14 +38,6 @@
 #endif
 
 #ifdef _WIN32
-  /* Windows */
-  /*
-   * Prevents a compiler warning in case this was already defined (to
-   * avoid that windows.h includes winsock.h)
-   */
-  #ifdef _WINSOCKAPI_
-    #undef _WINSOCKAPI_
-  #endif
   /* Need windef.h for defines used in winsock2.h under MingW32 */
   #ifdef __MINGW32__
     #include <windef.h>


### PR DESCRIPTION
Turns out that neither  or WIN32_LEAN_AND_MEAN have to be defined.
winsock2.h defines _WINSOCKAPI_ and then includes windows.h by itself.