### PR TITLE
Fixed wrong quote usage in rc files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,7 @@ if(WIN32)
 
     # Append NANO (used for Windows internal versioning) to PCAP_VERSION_PREDLL
     # 0 means unused.
-    set(PACKAGE_VERSION_DLL "${PACKAGE_VERSION_PREDLL},0")
+    set(PACKAGE_VERSION_DLL ${PACKAGE_VERSION_PREDLL},0)
 endif(WIN32)
 
 set(PACKAGE_NAME "${LIBRARY_NAME}")

--- a/pcap-dll.rc
+++ b/pcap-dll.rc
@@ -21,12 +21,12 @@
         VALUE "CompanyName",      "The TCPdump Group"
         VALUE "FileDescription",  "System-Independent Interface for User-Level Packet Capture"
         VALUE "FileVersion",      "PACKAGE_VERSION_DLL"
-        VALUE "InternalName",     "PACKAGE_NAME"
+        VALUE "InternalName",     PACKAGE_NAME
         VALUE "LegalCopyright",   "Copyright (c) The TCPdump Group"
         VALUE "LegalTrademarks",  ""
         VALUE "OriginalFilename", "wpcap.dll"
-        VALUE "ProductName",      "PACKAGE_NAME"
-        VALUE "ProductVersion",   "PACKAGE_VERSION"
+        VALUE "ProductName",      PACKAGE_NAME
+        VALUE "ProductVersion",   PACKAGE_VERSION
       END
     END
   BLOCK "VarFileInfo"

--- a/rpcapd/rpcapd.rc
+++ b/rpcapd/rpcapd.rc
@@ -24,12 +24,12 @@
         VALUE "CompanyName",      "The TCPdump Group"
         VALUE "FileDescription",  "Remote Packet Capture Daemon"
         VALUE "FileVersion",      "PACKAGE_VERSION_DLL"
-        VALUE "InternalName",     "PACKAGE_NAME"
+        VALUE "InternalName",     PACKAGE_NAME
         VALUE "LegalCopyright",   "Copyright (c) The TCPdump Group"
         VALUE "LegalTrademarks",  ""
         VALUE "OriginalFilename", "rpcapd.exe"
-        VALUE "ProductName",      "PACKAGE_NAME"
-        VALUE "ProductVersion",   "PACKAGE_VERSION"
+        VALUE "ProductName",      PACKAGE_NAME
+        VALUE "ProductVersion",   PACKAGE_VERSION
       END
     END
   BLOCK "VarFileInfo"


### PR DESCRIPTION
The usage of quotes rc files is not very straight forward.
PACKAGE_VERSION_DLL may not be put in quotes except when used for FileVersion. There, it must be in quotes or windres will complain.
PACKAGE_NAME and PACKAGE_VERSION are already carring quotes when arriving form config.h.
So no need to put them in quotes again.

Currently none of these three defines is properly handled by the preprocessor because of this. This PR fixes this.