### PR TITLE
Small fixes for RDMA sniffing support

### DIFF
--- a/pcap-rdmasniff.c
+++ b/pcap-rdmasniff.c
@@ -59,7 +59,20 @@ struct pcap_rdmasniff {
 	u_char *			oneshot_buffer;
 	unsigned			port_num;
 	int                             cq_event;
+	u_int                           packets_recv;
 };
+
+static int
+rdmasniff_stats(pcap_t *handle, struct pcap_stat *stat)
+{
+	struct pcap_rdmasniff *priv = handle->priv;
+
+	stat->ps_recv = priv->packets_recv;
+	stat->ps_drop = 0;
+	stat->ps_ifdrop = 0;
+
+	return 0;
+}
 
 static void
 rdmasniff_cleanup(pcap_t *handle)
@@ -145,6 +158,7 @@ rdmasniff_read(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 		if (handle->fcode.bf_insns == NULL ||
 		    bpf_filter(handle->fcode.bf_insns, pktd, pkth.len, pkth.caplen)) {
 			callback(user, &pkth, pktd);
+			++priv->packets_recv;
 			++count;
 		}
 
@@ -291,6 +305,7 @@ rdmasniff_activate(pcap_t *handle)
 
 	handle->offset = 0;
 	handle->read_op = rdmasniff_read;
+	handle->stats_op = rdmasniff_stats;
 	handle->cleanup_op = rdmasniff_cleanup;
 	handle->setfilter_op = install_bpf_program;
 	handle->setdirection_op = NULL;


### PR DESCRIPTION
A couple of fixes for issues reported by users.  Basically make ctrl-C on tcpdump work better and produce stats output on exit.