### PR TITLE
Address CLang "undefined defined" warnings.

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -60,7 +60,7 @@ int pcap_optimizer_debug;
  *
  * This is the same as the count of trailing zeroes in the word.
  */
-#if PCAP_IS_AT_LEAST_GNUC_VERSION(3, 4)
+#if PCAP_IS_AT_LEAST_GNUC_VERSION_3_4
   /*
    * GCC 3.4 and later; we have __builtin_ctz().
    */

--- a/pcap/compiler-tests.h
+++ b/pcap/compiler-tests.h
@@ -59,10 +59,36 @@
  * compiler that claims to be "just like GCC" of that version or a
  * later release.
  */
-#define PCAP_IS_AT_LEAST_GNUC_VERSION(major, minor) \
-	(defined(__GNUC__) && \
-	    (__GNUC__ > (major) || \
-	     (__GNUC__ == (major) && __GNUC_MINOR__ >= (minor))))
+
+#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 3))
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_2_3 1
+#else
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_2_3 0
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ > 2 || (__GNUC__ == 2 && __GNUC_MINOR__ >= 5))
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_2_5 1
+#else
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_2_5 0
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1))
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_3_1 1
+#else
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_3_1 0
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 4))
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_3_4 1
+#else
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_3_4 0
+#endif
+
+#if defined(__GNUC__) && (__GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 5))
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_4_5 1
+#else
+#define PCAP_IS_AT_LEAST_GNUC_VERSION_4_5 0
+#endif
 
 /*
  * Check wehether this is Sun C/SunPro C/Oracle Studio major.minor
@@ -85,9 +111,24 @@
 	(((minor) >= 10) ? \
 	    (((major) << 12) | (((minor)/10) << 8) | (((minor)%10) << 4)) : \
 	    (((major) << 8) | ((minor) << 4)))
-#define PCAP_IS_AT_LEAST_SUNC_VERSION(major, minor) \
-	(defined(__SUNPRO_C) && \
-	    (__SUNPRO_C >= PCAP_SUNPRO_VERSION_TO_BCD((major), (minor))))
+
+#if defined(__SUNPRO_C) && __SUNPRO_C >= PCAP_SUNPRO_VERSION_TO_BCD(5, 5)
+#define PCAP_IS_AT_LEAST_SUNC_VERSION_5_5 1
+#else
+#define PCAP_IS_AT_LEAST_SUNC_VERSION_5_5 0
+#endif
+
+#if defined(__SUNPRO_C) && __SUNPRO_C >= PCAP_SUNPRO_VERSION_TO_BCD(5, 9)
+#define PCAP_IS_AT_LEAST_SUNC_VERSION_5_9 1
+#else
+#define PCAP_IS_AT_LEAST_SUNC_VERSION_5_9 0
+#endif
+
+#if defined(__SUNPRO_C) && __SUNPRO_C >= PCAP_SUNPRO_VERSION_TO_BCD(5, 13)
+#define PCAP_IS_AT_LEAST_SUNC_VERSION_5_13 1
+#else
+#define PCAP_IS_AT_LEAST_SUNC_VERSION_5_13 0
+#endif
 
 /*
  * Check wehether this is IBM XL C major.minor or a later release.
@@ -95,8 +136,18 @@
  * The version number in __xlC__ has the major version in the
  * upper 8 bits and the minor version in the lower 8 bits.
  */
-#define PCAP_IS_AT_LEAST_XL_C_VERSION(major, minor) \
-	(defined(__xlC__) && __xlC__ >= (((major) << 8) | (minor)))
+
+#if defined(__xlC__) && __xlC__ >= ((10 << 8) | 1)
+#define PCAP_IS_AT_LEAST_XL_C_VERSION_10_1 1
+#else
+#define PCAP_IS_AT_LEAST_XL_C_VERSION_10_1 0
+#endif
+
+#if defined(__xlC__) && __xlC__ >= ((12 << 8) | 0)
+#define PCAP_IS_AT_LEAST_XL_C_VERSION_12_0 1
+#else
+#define PCAP_IS_AT_LEAST_XL_C_VERSION_12_0 0
+#endif
 
 /*
  * Check wehether this is Sun C/SunPro C/Oracle Studio major.minor
@@ -109,8 +160,11 @@
  * (Strip off the A., remove the . between the major and minor version
  * number, and add two digits of patch.)
  */
-#define PCAP_IS_AT_LEAST_HP_C_VERSION(major, minor) \
-	(defined(__HP_aCC) && \
-	    (__HP_aCC >= ((major)*10000 + (minor)*100)))
+
+#if defined(__HP_aCC) && (__HP_aCC >= (6*10000 + 10*100))
+#define PCAP_IS_AT_LEAST_HP_C_VERSION_6_10 1
+#else
+#define PCAP_IS_AT_LEAST_HP_C_VERSION_6_10 0
+#endif
 
 #endif /* lib_pcap_funcattrs_h */

--- a/pcap/funcattrs.h
+++ b/pcap/funcattrs.h
@@ -73,15 +73,15 @@
      * shared library by default, so we might have to explicitly mark
      * functions as exported.
      */
-    #if PCAP_IS_AT_LEAST_GNUC_VERSION(3, 4) \
-        || PCAP_IS_AT_LEAST_XL_C_VERSION(12, 0)
+    #if PCAP_IS_AT_LEAST_GNUC_VERSION_3_4 \
+        || PCAP_IS_AT_LEAST_XL_C_VERSION_12_0
       /*
        * GCC 3.4 or later, or some compiler asserting compatibility with
        * GCC 3.4 or later, or XL C 13.0 or later, so we have
        * __attribute__((visibility()).
        */
       #define PCAP_API_DEF	__attribute__((visibility("default")))
-    #elif PCAP_IS_AT_LEAST_SUNC_VERSION(5, 5)
+    #elif PCAP_IS_AT_LEAST_SUNC_VERSION_5_5
       /*
        * Sun C 5.5 or later, so we have __global.
        * (Sun C 5.9 and later also have __attribute__((visibility()),
@@ -111,10 +111,10 @@
  * declaration, as the MSVC version has to go before the declaration.)
  */
 #if __has_attribute(noreturn) \
-    || PCAP_IS_AT_LEAST_GNUC_VERSION(2, 5) \
-    || PCAP_IS_AT_LEAST_SUNC_VERSION(5, 9) \
-    || PCAP_IS_AT_LEAST_XL_C_VERSION(10, 1) \
-    || PCAP_IS_AT_LEAST_HP_C_VERSION(6, 10)
+    || PCAP_IS_AT_LEAST_GNUC_VERSION_2_5 \
+    || PCAP_IS_AT_LEAST_SUNC_VERSION_5_9 \
+    || PCAP_IS_AT_LEAST_XL_C_VERSION_10_1 \
+    || PCAP_IS_AT_LEAST_HP_C_VERSION_6_10
   /*
    * Compiler with support for __attribute((noreturn)), or GCC 2.5 and
    * later, or Solaris Studio 12 (Sun C 5.9) and later, or IBM XL C 10.1
@@ -138,9 +138,9 @@
  * string".
  */
 #if __has_attribute(__format__) \
-    || PCAP_IS_AT_LEAST_GNUC_VERSION(2, 3) \
-    || PCAP_IS_AT_LEAST_XL_C_VERSION(10, 1) \
-    || PCAP_IS_AT_LEAST_HP_C_VERSION(6, 10)
+    || PCAP_IS_AT_LEAST_GNUC_VERSION_2_3 \
+    || PCAP_IS_AT_LEAST_XL_C_VERSION_10_1 \
+    || PCAP_IS_AT_LEAST_HP_C_VERSION_6_10
   /*
    * Compiler with support for it, or GCC 2.3 and later, or IBM XL C 10.1
    * and later (do any earlier versions of XL C support this?),
@@ -161,8 +161,8 @@
  * (Thank you, Microsoft, for requiring the function name.)
  */
 #if __has_attribute(deprecated) \
-    || PCAP_IS_AT_LEAST_GNUC_VERSION(4, 5) \
-    || PCAP_IS_AT_LEAST_SUNC_VERSION(5, 13)
+    || PCAP_IS_AT_LEAST_GNUC_VERSION_4_5 \
+    || PCAP_IS_AT_LEAST_SUNC_VERSION_5_13
   /*
    * Compiler that supports __has_attribute and __attribute__((deprecated)),
    * or GCC 4.5 and later, or Sun/Oracle C 12.4 (Sun C 5.13) or later.
@@ -172,7 +172,7 @@
    * recent enough to support __attribute__((deprecated(msg)))).
    */
   #define PCAP_DEPRECATED(func, msg)	__attribute__((deprecated(msg)))
-#elif PCAP_IS_AT_LEAST_GNUC_VERSION(3, 1)
+#elif PCAP_IS_AT_LEAST_GNUC_VERSION_3_1
   /*
    * GCC 3.1 through 4.4.
    *


### PR DESCRIPTION
With this change in libpcap tcpdump compiles in 79 seconds instead of 145 seconds. Most importantly, it does not flood the terminal with warnings (https://travis-ci.org/the-tcpdump-group/tcpdump/jobs/287485992 is a good example, see commit message for additional details). I am not sure this is the best solution, though the best I could produce so far.