### PR TITLE
Use pthread_equal() to compare thread IDs

### DIFF
--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -2,30 +2,30 @@
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.
- * 
- * Redistribution and use in source and binary forms, with or without 
- * modification, are permitted provided that the following conditions 
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
  * are met:
- * 
- * 1. Redistributions of source code must retain the above copyright 
+ *
+ * 1. Redistributions of source code must retain the above copyright
  * notice, this list of conditions and the following disclaimer.
- * 2. Redistributions in binary form must reproduce the above copyright 
- * notice, this list of conditions and the following disclaimer in the 
- * documentation and/or other materials provided with the distribution. 
- * 3. Neither the name of the Politecnico di Torino nor the names of its 
- * contributors may be used to endorse or promote products derived from 
- * this software without specific prior written permission. 
- * 
- * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 
- * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT 
- * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR 
- * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT 
- * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, 
- * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT 
- * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, 
- * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY 
- * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
- * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
+ * 2. Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the Politecnico di Torino nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+ * LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+ * DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+ * THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
@@ -76,7 +76,7 @@ static int daemon_AuthUserPwd(char *username, char *password, char *errbuf);
 static int daemon_findalldevs(SOCKET sockctrl, char *errbuf);
 
 static int daemon_opensource(SOCKET sockctrl, char *source, int srclen, uint32 plen, char *errbuf);
-static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddata, char *source, int active, 
+static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddata, char *source, int active,
     struct rpcap_sampling *samp_param, uint32 plen, char *errbuf);
 static int daemon_endcapture(struct session *session, pthread_t *threaddata, char *errbuf);
 
@@ -84,7 +84,7 @@ static int daemon_updatefilter(struct session *session, uint32 plen);
 static int daemon_unpackapplyfilter(struct session *session, uint32 *totread, uint32 *plen, char *errbuf);
 
 static int daemon_getstats(struct session *session);
-static int daemon_getstatsnopcap(SOCKET sockctrl, unsigned int ifdrops, unsigned int ifrecv, 
+static int daemon_getstatsnopcap(SOCKET sockctrl, unsigned int ifdrops, unsigned int ifrecv,
 						  unsigned int krnldrop, unsigned int svrcapt, char *errbuf);
 
 static int daemon_setsampling(SOCKET sockctrl, struct rpcap_sampling *samp_param, int plen, char *errbuf);
@@ -98,8 +98,8 @@ static void *daemon_thrdatamain(void *ptr);
 	thread, which is created as soon as a new connection is accepted.
 
 	\param ptr: a void pointer that keeps the reference of the 'pthread_chain'
-	value corrisponding to this thread. This variable is casted into a 'pthread_chain'
-	value in order to retrieve the socket we're currently using, the thread ID, and 
+	value corresponding to this thread. This variable is casted into a 'pthread_chain'
+	value in order to retrieve the socket we're currently using, the thread ID, and
 	some pointers to the previous and next elements into this struct.
 
 	\return None.
@@ -112,7 +112,7 @@ void daemon_serviceloop(void *ptr)
 	struct session *session = NULL;		// struct session main variable
 	struct daemon_slpars *pars;		// parameters related to the present daemon loop
 
-	pthread_t threaddata = 0;		// handle to the 'read from daemon and send to client' thread
+	pthread_t threaddata;		// handle to the 'read from daemon and send to client' thread
 
 	unsigned int ifdrops, ifrecv, krnldrop, svrcapt;	// needed to save the values of the statistics
 
@@ -124,7 +124,7 @@ void daemon_serviceloop(void *ptr)
 	int retval;				// select() return value
 
 	pars = (struct daemon_slpars *) ptr;
-	
+
 	*errbuf = 0;	// Initialize errbuf
 
 	// If we're in active mode, this is not a separate thread
@@ -145,7 +145,7 @@ auth_again:
 		// We do not have to block here
 		tv.tv_sec = RPCAP_TIMEOUT_INIT;
 		tv.tv_usec = 0;
-		
+
 		FD_SET(pars->sockctrl, &rfds);
 
 		retval = select(pars->sockctrl + 1, &rfds, NULL, NULL, &tv);
@@ -172,7 +172,7 @@ auth_again:
 		// the other user requested to close the connection
 		// It can be also the case of 'active mode', in which this host is not
 		// allowed to connect to the other peer; in that case, it drops down the connection
-		if (retval == -3) 
+		if (retval == -3)
 			goto end;
 
 		// It can be an authentication failure or an unrecoverable error
@@ -224,7 +224,7 @@ auth_again:
 			// We do not have to block here
 			tv.tv_sec = RPCAP_TIMEOUT_RUNTIME;
 			tv.tv_usec = 0;
-			
+
 			FD_SET(pars->sockctrl, &rfds);
 
 			retval = select(pars->sockctrl + 1, &rfds, NULL, NULL, &tv);
@@ -394,7 +394,7 @@ auth_again:
 			{
 				// signal to the main that the user closed the control connection
 				// This is used only in case of active mode
-				pars->activeclose = 1;	
+				pars->activeclose = 1;
 				SOCK_ASSERT("The other end system asked to close the connection.", 1);
 				goto end;
 				break;
@@ -421,10 +421,10 @@ end:
 	// perform pcap_t cleanup, in case it has not been done
 	if (session)
 	{
-		if (threaddata)
+		if (pthread_equal(threaddata, pthread_self()))
 		{
 			pthread_cancel(threaddata);
-			threaddata = 0;
+			threaddata;
 		}
 		if (session->sockdata)
 		{
@@ -444,7 +444,7 @@ end:
 	{
 		if (pars->sockctrl)
 			sock_close(pars->sockctrl, NULL, 0);
-		
+
 		free(pars);
 #ifdef _WIN32
 		pthread_exit(0);
@@ -456,11 +456,11 @@ end:
 	\brief It checks if the authentication credentials supplied by the user are valid.
 
 	This function is called each time the rpcap daemon starts a new serving thread.
-	It reads the authentication message from the network and it checks that the 
+	It reads the authentication message from the network and it checks that the
 	user information are valid.
 
 	\param sockctrl: the socket if of the control connection.
-	
+
 	\param nullAuthAllowed: '1' if the NULL authentication is allowed.
 
 	\param errbuf: a user-allocated buffer in which the error message (if one) has to be written.
@@ -513,7 +513,7 @@ int daemon_checkauth(SOCKET sockctrl, int nullAuthAllowed, char *errbuf)
 				{
 					if (sock_discard(sockctrl, ntohl(header.plen), NULL, 0))
 						return -1;
-				}		
+				}
 				return -3;
 			};
 
@@ -699,7 +699,7 @@ int daemon_AuthUserPwd(char *username, char *password, char *errbuf)
 	 * we have getspnam(), otherwise we just do traditional
 	 * authentication, which, on some platforms, might work, even
 	 * with shadow passwords, if we're running as root.  Traditional
-	 * authenticaion won't work if we're not running as root, as
+	 * authentication won't work if we're not running as root, as
 	 * I think these days all UN*Xes either won't return the password
 	 * at all with getpwnam() or will only do so if you're root.
 	 *
@@ -793,7 +793,7 @@ int daemon_findalldevs(SOCKET sockctrl, char *errbuf)
 		rpcap_senderror(sockctrl,
 			"No interfaces found! Make sure libpcap/WinPcap is properly installed"
 			" and you have the right to access to the remote device.",
-			PCAP_ERR_NOREMOTEIF, 
+			PCAP_ERR_NOREMOTEIF,
 			errbuf);
 		return -1;
 	}
@@ -831,7 +831,7 @@ int daemon_findalldevs(SOCKET sockctrl, char *errbuf)
 	}
 
 	// RPCAP findalldevs command
-	if (sock_bufferize(NULL, sizeof(struct rpcap_header), NULL, 
+	if (sock_bufferize(NULL, sizeof(struct rpcap_header), NULL,
 		&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, errbuf, PCAP_ERRBUF_SIZE) == -1)
 		return -1;
 
@@ -879,7 +879,7 @@ int daemon_findalldevs(SOCKET sockctrl, char *errbuf)
 		}
 		findalldevs_if->naddr = htons(findalldevs_if->naddr);
 
-		if (sock_bufferize(d->name, lname, sendbuf, &sendbufidx, 
+		if (sock_bufferize(d->name, lname, sendbuf, &sendbufidx,
 			RPCAP_NETBUF_SIZE, SOCKBUF_BUFFERIZE, errbuf, PCAP_ERRBUF_SIZE) == -1)
 			return -1;
 
@@ -902,13 +902,13 @@ int daemon_findalldevs(SOCKET sockctrl, char *errbuf)
 			case AF_INET6:
 #endif
 				sockaddr = (struct rpcap_sockaddr *) &sendbuf[sendbufidx];
-				if (sock_bufferize(NULL, sizeof(struct rpcap_sockaddr), NULL, 
+				if (sock_bufferize(NULL, sizeof(struct rpcap_sockaddr), NULL,
 					&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, errbuf, PCAP_ERRBUF_SIZE) == -1)
 					return -1;
 				daemon_seraddr((struct sockaddr_storage *) address->addr, sockaddr);
 
 				sockaddr = (struct rpcap_sockaddr *) &sendbuf[sendbufidx];
-				if (sock_bufferize(NULL, sizeof(struct rpcap_sockaddr), NULL, 
+				if (sock_bufferize(NULL, sizeof(struct rpcap_sockaddr), NULL,
 					&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, errbuf, PCAP_ERRBUF_SIZE) == -1)
 					return -1;
 				daemon_seraddr((struct sockaddr_storage *) address->netmask, sockaddr);
@@ -979,9 +979,9 @@ static int daemon_opensource(SOCKET sockctrl, char *source, int srclen, uint32 p
 
 	// Open the selected device
 	// This is a fake open, since we do that only to get the needed parameters, then we close the device again
-	if ((fp = pcap_open_live(source, 
+	if ((fp = pcap_open_live(source,
 			1500 /* fake snaplen */,
-			0 /* no promis */, 
+			0 /* no promis */,
 			1000 /* fake timeout */,
 			errbuf)) == NULL)
 	{
@@ -998,8 +998,8 @@ static int daemon_opensource(SOCKET sockctrl, char *source, int srclen, uint32 p
 	rpcap_createhdr((struct rpcap_header *) sendbuf, RPCAP_MSG_OPEN_REPLY, 0, sizeof(struct rpcap_openreply));
 
 	openreply = (struct rpcap_openreply *) &sendbuf[sendbufidx];
-	
-	if (sock_bufferize(NULL, sizeof(struct rpcap_openreply), NULL, &sendbufidx, 
+
+	if (sock_bufferize(NULL, sizeof(struct rpcap_openreply), NULL, &sendbufidx,
 		RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, errbuf, PCAP_ERRBUF_SIZE) == -1)
 		goto error;
 
@@ -1077,9 +1077,9 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 	}
 
 	// Open the selected device
-	if ((session->fp = pcap_open(source, 
+	if ((session->fp = pcap_open(source,
 			ntohl(startcapreq.snaplen),
-			(startcapreq.flags & RPCAP_STARTCAPREQ_FLAG_PROMISC) ? PCAP_OPENFLAG_PROMISCUOUS : 0 /* local device, other flags not needed */, 
+			(startcapreq.flags & RPCAP_STARTCAPREQ_FLAG_PROMISC) ? PCAP_OPENFLAG_PROMISCUOUS : 0 /* local device, other flags not needed */,
 			ntohl(startcapreq.read_timeout),
 			NULL /* local device, so no auth */,
 			errbuf)) == NULL)
@@ -1108,9 +1108,9 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 	Gets the sockaddr structure referred to the other peer in the ctrl connection
 
 	We need that because:
-	- if we're in passive mode, we need to know the address family we want to use 
+	- if we're in passive mode, we need to know the address family we want to use
 	(the same used for the ctrl socket)
-	- if we're in active mode, we need to know the network address of the other host 
+	- if we're in active mode, we need to know the network address of the other host
 	we want to connect to
 	*/
 	saddrlen = sizeof(struct sockaddr_storage);
@@ -1130,7 +1130,7 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 		sprintf(portdata, "%d", ntohs(startcapreq.portdata));
 
 		// Get the name of the other peer (needed to connect to that specific network address)
-		if (getnameinfo((struct sockaddr *) &saddr, saddrlen, peerhost, 
+		if (getnameinfo((struct sockaddr *) &saddr, saddrlen, peerhost,
 				sizeof(peerhost), NULL, 0, NI_NUMERICHOST))
 		{
 			sock_geterror("getnameinfo(): ", errbuf, PCAP_ERRBUF_SIZE);
@@ -1163,7 +1163,7 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 		}
 
 		// Get the local port the system picked up
-		if (getnameinfo((struct sockaddr *) &saddr, saddrlen, NULL, 
+		if (getnameinfo((struct sockaddr *) &saddr, saddrlen, NULL,
 				0, portdata, sizeof(portdata), NI_NUMERICSERV))
 		{
 			sock_geterror("getnameinfo(): ", errbuf, PCAP_ERRBUF_SIZE);
@@ -1190,7 +1190,7 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 	rpcap_createhdr((struct rpcap_header *) sendbuf, RPCAP_MSG_STARTCAP_REPLY, 0, sizeof(struct rpcap_startcapreply));
 
 	startcapreply = (struct rpcap_startcapreply *) &sendbuf[sendbufidx];
-	
+
 	if (sock_bufferize(NULL, sizeof(struct rpcap_startcapreply), NULL,
 		&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, errbuf, PCAP_ERRBUF_SIZE) == -1)
 		goto error;
@@ -1215,7 +1215,7 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 		saddrlen = sizeof(struct sockaddr_storage);
 
 		socktemp = accept(sockdata, (struct sockaddr *) &saddr, &saddrlen);
-		
+
 		if (socktemp == INVALID_SOCKET)
 		{
 			sock_geterror("accept(): ", errbuf, PCAP_ERRBUF_SIZE);
@@ -1231,9 +1231,9 @@ static struct session *daemon_startcapture(SOCKET sockctrl, pthread_t *threaddat
 
 	/* GV we need this to create the thread as detached. */
 	/* GV otherwise, the thread handle is not destroyed  */
-	pthread_attr_init(&detachedAttribute); 
+	pthread_attr_init(&detachedAttribute);
 	pthread_attr_setdetachstate(&detachedAttribute, PTHREAD_CREATE_DETACHED);
-	
+
 	// Now we have to create a new thread to receive packets
 	if (pthread_create(threaddata, &detachedAttribute, daemon_thrdatamain, (void *) session))
 	{
@@ -1295,7 +1295,7 @@ static int daemon_endcapture(struct session *session, pthread_t *threaddata, cha
 
 	if (sock_send(session->sockctrl, (char *) &header, sizeof(struct rpcap_header), errbuf, PCAP_ERRBUF_SIZE) == -1)
 		return -1;
-	
+
 	return 0;
 }
 
@@ -1338,7 +1338,7 @@ static int daemon_unpackapplyfilter(struct session *session, uint32 *totread, ui
 
 	for (i = 0; i < bf_prog.bf_len; i++)
 	{
-		nread = sock_recv(session->sockctrl, (char *) &insn, 
+		nread = sock_recv(session->sockctrl, (char *) &insn,
 		    sizeof(struct rpcap_filterbpf_insn), SOCK_RECEIVEALL_YES,
 		    errbuf, PCAP_ERRBUF_SIZE);
 		if (nread == -1)
@@ -1415,11 +1415,11 @@ int daemon_setsampling(SOCKET sockctrl, struct rpcap_sampling *samp_param, int p
 	struct rpcap_sampling rpcap_samp;
 	int nread;					// number of bytes of the payload read from the socket
 
-	if ((nread = sock_recv(sockctrl, (char *) &rpcap_samp, sizeof(struct rpcap_sampling), 
+	if ((nread = sock_recv(sockctrl, (char *) &rpcap_samp, sizeof(struct rpcap_sampling),
 			SOCK_RECEIVEALL_YES, errbuf, PCAP_ERRBUF_SIZE)) == -1)
 		goto error;
 
-	// Save these settings in the pcap_t 
+	// Save these settings in the pcap_t
 	samp_param->method = rpcap_samp.method;
 	samp_param->value = ntohl(rpcap_samp.value);
 
@@ -1450,7 +1450,7 @@ int daemon_getstats(struct session *session)
 	struct pcap_stat stats;				// local statistics
 	struct rpcap_stats *netstats;		// statistics sent on the network
 
-	if (sock_bufferize(NULL, sizeof(struct rpcap_header), NULL, 
+	if (sock_bufferize(NULL, sizeof(struct rpcap_header), NULL,
 		&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, pcap_geterr(session->fp), PCAP_ERRBUF_SIZE) == -1)
 		goto error;
 
@@ -1481,7 +1481,7 @@ error:
 	return -1;
 }
 
-int daemon_getstatsnopcap(SOCKET sockctrl, unsigned int ifdrops, unsigned int ifrecv, 
+int daemon_getstatsnopcap(SOCKET sockctrl, unsigned int ifdrops, unsigned int ifrecv,
 						  unsigned int krnldrop, unsigned int svrcapt, char *errbuf)
 {
 	char sendbuf[RPCAP_NETBUF_SIZE];	// temporary buffer in which data to be sent is buffered
@@ -1691,7 +1691,7 @@ void pthread_suspend(int msec)
 	pthread_cond_init(&cond, NULL);
 
 	gettimeofday(&now, NULL);
-	
+
 	abstime.tv_sec = now.tv_sec + msec/1000;
 	abstime.tv_nsec = now.tv_usec * 1000 + (msec%1000) * 1000 * 1000;
 


### PR DESCRIPTION
Some pthread implementations define pthread_t as a structure rather than a pointer or an integer.

Perfectly fine according to The Open Group Base Specifications.
What is not fine is for daemon_serviceloop() to assume it to always be an integer.

So to improve portability, pthread_equal() should be used to compare thread IDs.

From http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_equal.html:

> RATIONALE
> Implementations may choose to define a thread ID as a structure. This allows additional flexibility and
> robustness over using an int. For example, a thread ID could include a sequence number that allows
> detection of "dangling IDs" (copies of a thread ID that has been detached). Since the C language does
> not support comparison on structure types, the pthread_equal() function is provided to compare thread
> IDs.