### PR TITLE
Fix --with-libnl configure option

### DIFF
--- a/configure
+++ b/configure
@@ -5727,6 +5727,8 @@ done
 # Check whether --with-libnl was given.
 if test "${with_libnl+set}" = set; then :
   withval=$with_libnl; with_libnl=$withval
+else
+  with_libnl=if_available
 fi
 
 
@@ -5735,10 +5737,16 @@ fi
 
                 incdir=-I/usr/include/libnl3
                 libnldir=
-                if test x$withval != x ; then
-                  libnldir=-L${withval}/lib/.libs
-                  incdir=-I${withval}/include
-                fi
+                case "$with_libnl" in
+                yes|if_available)
+                  ;;
+                *)
+                  if test -d $withval; then
+                    libnldir=-L${withval}/lib/.libs
+                    incdir=-I${withval}/include
+                  fi
+                  ;;
+                esac
 
 		#
 		# Try libnl 3.x first.

--- a/configure.ac
+++ b/configure.ac
@@ -517,17 +517,25 @@ linux)
 	#
 	AC_ARG_WITH(libnl,
 	AC_HELP_STRING([--without-libnl],[disable libnl support @<:@default=yes, on Linux, if present@:>@]),
-		with_libnl=$withval,,)
+		with_libnl=$withval,with_libnl=if_available)
 
 	if test x$with_libnl != xno ; then
 		have_any_nl="no"
 
                 incdir=-I/usr/include/libnl3
                 libnldir=
-                if test x$withval != x ; then
-                  libnldir=-L${withval}/lib/.libs
-                  incdir=-I${withval}/include
-                fi
+                case "$with_libnl" in
+
+                yes|if_available)
+                  ;;
+
+                *)
+                  if test -d $withval; then
+                    libnldir=-L${withval}/lib/.libs
+                    incdir=-I${withval}/include
+                  fi
+                  ;;
+                esac
 
 		#
 		# Try libnl 3.x first.


### PR DESCRIPTION
If given --with-libnl (this is equivalent to --with-libnl=yes) then
libpcap will add -Lyes/lib/.libs to the build flags.