### PR TITLE
Added support for ICMPv6 upper layer protocol filtering

### DIFF
--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -864,8 +864,9 @@ intervening fragment.
 Some offsets and field values may be expressed as names rather than
 as numeric values.
 The following protocol header field offsets are
-available: \fBicmptype\fP (ICMP type field), \fBicmpcode\fP (ICMP
-code field), and \fBtcpflags\fP (TCP flags field).
+available: \fBicmptype\fP (ICMP type field), \fBicmp6type (ICMP v6 type field)
+\fBicmpcode\fP (ICMP code field), \fBicmp6code\fP (ICMP v6 code field), and
+\fBtcpflags\fP (TCP flags field).
 
 The following ICMP type field values are available: \fBicmp-echoreply\fP,
 \fBicmp-unreach\fP, \fBicmp-sourcequench\fP, \fBicmp-redirect\fP,
@@ -873,6 +874,20 @@ The following ICMP type field values are available: \fBicmp-echoreply\fP,
 \fBicmp-timxceed\fP, \fBicmp-paramprob\fP, \fBicmp-tstamp\fP,
 \fBicmp-tstampreply\fP, \fBicmp-ireq\fP, \fBicmp-ireqreply\fP,
 \fBicmp-maskreq\fP, \fBicmp-maskreply\fP.
+
+The following ICMPv6 type fields are available: \fBicmp6-echo\fP,
+\fBicmp6-echoreply\fP, \fBicmp6-multicastlistenerquery\fP,
+\fBicmp6-multicastlistenerreportv1\fP, \fBicmp6-multicastlistenerdone\fP,
+\fBicmp6-routersolicit\fP, \fBicmp6-routeradvert\fP,
+\fBicmp6-neighborsolicit\fP, \fBicmp6-neighboradvert\fP, \fBicmp6-redirect\fP,
+\fBicmp6-routerrenum\fP, \fBicmp6-nodeinformationquery\fP,
+\fBicmp6-nodeinformationresponse\fP, \fBicmp6-ineighbordiscoverysolicit\fP,
+\fBicmp6-ineighbordiscoveryadvert\fP, \fBicmp6-multicastlistenerreportv2\fP,
+\fBicmp6-homeagentdiscoveryrequest\fP, \fBicmp6-homeagentdiscoveryreply\fP,
+\fBicmp6-mobileprefixsolicit\fP, \fBicmp6-mobileprefixadvert\fP,
+\fBicmp6-certpathsolicit\fP, \fBicmp6-certpathadvert\fP,
+\fBicmp6-multicastrouteradvert\fP, \fBicmp6-multicastroutersolicit\fP,
+\fBicmp6-multicastrouterterm\fP.
 
 The following TCP flags field values are available: \fBtcp-fin\fP,
 \fBtcp-syn\fP, \fBtcp-rst\fP, \fBtcp-push\fP,

--- a/scanner.l
+++ b/scanner.l
@@ -435,6 +435,36 @@ icmp-ireq		{ yylval->i = 15; return NUM; }
 icmp-ireqreply		{ yylval->i = 16; return NUM; }
 icmp-maskreq		{ yylval->i = 17; return NUM; }
 icmp-maskreply		{ yylval->i = 18; return NUM; }
+
+icmp6type       { yylval->i = 0; return NUM; }
+icmp6code       { yylval->i = 1; return NUM; }
+
+icmp6-echo      { yylval->i = 128; return NUM; }
+icmp6-echoreply { yylval->i = 129; return NUM; }
+icmp6-multicastlistenerquery    { yylval->i = 130; return NUM; }
+icmp6-multicastlistenerreportv1 { yylval->i = 131; return NUM; }
+icmp6-multicastlistenerdone     { yylval->i = 132; return NUM; }
+icmp6-routersolicit   { yylval->i = 133; return NUM; }
+icmp6-routeradvert    { yylval->i = 134; return NUM; }
+icmp6-neighborsolicit { yylval->i = 135; return NUM; }
+icmp6-neighboradvert  { yylval->i = 136; return NUM; }
+icmp6-redirect    { yylval->i = 137; return NUM; }
+icmp6-routerrenum { yylval->i = 138; return NUM; }
+icmp6-nodeinformationquery      { yylval->i = 139; return NUM; }
+icmp6-nodeinformationresponse   { yylval->i = 140; return NUM; }
+icmp6-ineighbordiscoverysolicit { yylval->i = 141; return NUM; }
+icmp6-ineighbordiscoveryadvert  { yylval->i = 142; return NUM; }
+icmp6-multicastlistenerreportv2 { yylval->i = 143; return NUM; }
+icmp6-homeagentdiscoveryrequest { yylval->i = 144; return NUM; }
+icmp6-homeagentdiscoveryreply   { yylval->i = 145; return NUM; }
+icmp6-mobileprefixsolicit       { yylval->i = 146; return NUM; }
+icmp6-mobileprefixadvert        { yylval->i = 147; return NUM; }
+icmp6-certpathsolicit           { yylval->i = 148; return NUM; }
+icmp6-certpathadvert            { yylval->i = 149; return NUM; }
+icmp6-multicastrouteradvert     { yylval->i = 151; return NUM; }
+icmp6-multicastroutersolicit    { yylval->i = 152; return NUM; }
+icmp6-multicastrouterterm       { yylval->i = 153; return NUM; }
+
 tcpflags		{ yylval->i = 13; return NUM; }
 tcp-fin			{ yylval->i = 0x01; return NUM; }
 tcp-syn			{ yylval->i = 0x02; return NUM; }


### PR DESCRIPTION
Hi!

We implemented support for filtering by ICMPv6 header attributes
as part of the Ripe NCC IPv6 Hackathon in Copenhagen.

Using a filter like
        `icmp6[icmptype] = icmp6-neighboradvert`

no longer results in
       `tcpdump: IPv6 upper-layer protocol is not supported by proto[x]` 

Now it provides the expected result.


