### PR TITLE
Instruct static linking on Windows with PCAP_STATIC_LIB

### DIFF
--- a/pcap/funcattrs.h
+++ b/pcap/funcattrs.h
@@ -59,6 +59,11 @@
      * API.
      */
     #define PCAP_API_DEF	__declspec(dllexport)
+     /*
+     * Define PCAP_STATIC_LIB when linking your application statically.
+     */
+  #elif defined(PCAP_STATIC_LIB)
+    #define PCAP_API_DEF
   #else
     #define PCAP_API_DEF	__declspec(dllimport)
   #endif


### PR DESCRIPTION
When linking statically with pcap variables/functions can not be decorated/marked as imported (__declspec(dllimport). 
To prevent this a users can (and should) define PCAP_STATIC_LIB when building their applications statically.