### PR TITLE
Resolve integer conversion problems.

### DIFF
--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -142,7 +142,7 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 	strncpy(ifr.ifr_name, d->req.nr_name, sizeof(ifr.ifr_name));
 	switch (what) {
 	case SIOCSIFFLAGS:
-		ifr.ifr_flags = *if_flags;
+		ifr.ifr_flags = *if_flags & 0xffff;
 #ifdef __FreeBSD__
 		ifr.ifr_flagshigh = *if_flags >> 16;
 #endif /* __FreeBSD__ */
@@ -152,7 +152,7 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 	if (!error) {
 		switch (what) {
 		case SIOCGIFFLAGS:
-			*if_flags = ifr.ifr_flags;
+			*if_flags = ifr.ifr_flags & 0xffff;
 #ifdef __FreeBSD__
 			*if_flags |= (ifr.ifr_flagshigh << 16);
 #endif /* __FreeBSD__ */


### PR DESCRIPTION
Resolve two problems:
1. When uint32_t if_flags is bigger than SHORT_MAX then assigning it to the
short ifr_flags is "implementation-defined" ie. it may give diffrent results
on different compilers/machines (according to C11).
2. When the short ifr_flags has MSB set to 1 then it is "negative signed".
If it will be assigned to the uint32_t if_flags then in result of integer
promotion all bits higer than MSB will be set to 1 and therefore in if_flags
we will see flags that are not really set. This problem affects only FreeBSD
where flags are stored on all 32 bits (on Linux only 16 bits are used).

Using 16-bits mask resolves both problems.