### PR TITLE
pcap_set_fanout function for PACKET_FANOUT support on linux platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1975,6 +1975,7 @@ set(MAN3PCAP_NOEXPAND
 	pcap_set_buffer_size.3pcap
 	pcap_set_datalink.3pcap
 	pcap_set_immediate_mode.3pcap
+	pcap_set_fanout.3pcap
 	pcap_set_promisc.3pcap
 	pcap_set_protocol.3pcap
 	pcap_set_rfmon.3pcap

--- a/Makefile.in
+++ b/Makefile.in
@@ -202,6 +202,7 @@ MAN3PCAP_NOEXPAND = \
 	pcap_set_buffer_size.3pcap \
 	pcap_set_datalink.3pcap \
 	pcap_set_immediate_mode.3pcap \
+	pcap_set_fanout.3pcap \
 	pcap_set_promisc.3pcap \
 	pcap_set_protocol.3pcap \
 	pcap_set_rfmon.3pcap \

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -343,6 +343,7 @@ PCAP_API const char *pcap_tstamp_type_val_to_description(int);
 
 #ifdef __linux__
 PCAP_API int	pcap_set_protocol(pcap_t *, int);
+PCAP_API int    pcap_set_fanout(pcap_t *, int, int);
 #endif
 
 /*

--- a/pcap_set_fanout.3pcap
+++ b/pcap_set_fanout.3pcap
@@ -1,0 +1,48 @@
+.\" Copyright (c) 1994, 1996, 1997
+.\"	The Regents of the University of California.  All rights reserved.
+.\"
+.\" Redistribution and use in source and binary forms, with or without
+.\" modification, are permitted provided that: (1) source code distributions
+.\" retain the above copyright notice and this paragraph in its entirety, (2)
+.\" distributions including binary code include the above copyright notice and
+.\" this paragraph in its entirety in the documentation or other materials
+.\" provided with the distribution, and (3) all advertising materials mentioning
+.\" features or use of this software display the following acknowledgement:
+.\" ``This product includes software developed by the University of California,
+.\" Lawrence Berkeley Laboratory and its contributors.'' Neither the name of
+.\" the University nor the names of its contributors may be used to endorse
+.\" or promote products derived from this software without specific prior
+.\" written permission.
+.\" THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+.\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+.\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+.\"
+.TH PCAP_SET_FANTOUT 3PCAP "10 February 2018"
+.SH NAME
+pcap_set_fanout \- set fanout group for load balancing
+among processes
+.SH SYNOPSIS
+.nf
+.ft B
+#include <linux/if_packet.h>
+#include <pcap/pcap.h>
+.LP
+.ft B
+int pcap_set_fanout(pcap_t *p, int flags, int group_id);
+.ft
+.fi
+.SH DESCRIPTION
+.B pcap_set_protocol()
+is used for forming sockets in fanout groups. Each received
+packet will be scheduled to only one socket from this group.
+More information about scheduling policies could be found in the 
+.BR packet(7).
+.SH RETURN VALUE
+.B pcap_set_fanout()
+returns 0 on success or -1 in case of error. If -1 is returned, 
+.B pcap_geterr()
+or 
+.B pcap_perror()
+may be called with p as an argument to fetch or display the error text.
+.SH SEE ALSO
+pcap(3PCAP), socket(2), packet(7)


### PR DESCRIPTION
For multithreaded applications, it will be useful to add PACKET_FANOUT support. 

Tests for n cpu thread per application without FANOUT, only RX_RING:

3412458 pps
3432391 pps

Test for n cpu thread per application with FANOUT and RX_RING:

8813457 pps
8932582 pps

More information about PACKET_FANOUT and examples https://www.kernel.org/doc/Documentation/networking/packet_mmap.txt