### PR TITLE
Tame -Wall on MSVC and improve Clang/C2 support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1557,15 +1557,19 @@ endmacro()
 set(C_ADDITIONAL_FLAGS "")
 if(EXISTS ${CMAKE_SOURCE_DIR}/.devel)
     #
-    # -W options, used by GCC and compilers that try to behave like it.
-    #
-    check_and_add_compiler_option(-Wall)
-    check_and_add_compiler_option(-Wsign-compare)
-    check_and_add_compiler_option(-Wmissing-prototypes)
-    check_and_add_compiler_option(-Wstrict-prototypes)
-    check_and_add_compiler_option(-Wshadow)
-    check_and_add_compiler_option(-Wdeclaration-after-statement)
-    check_and_add_compiler_option(-Wused-but-marked-unused)
+    # -W options, used by GCC and compilers that try to behave like it including
+    # the Clang/C2 toolsets (which is disguises as MSVC).
+    if(MSVC AND NOT ${CMAKE_C_COMPILER} MATCHES "clang*")
+        check_and_add_compiler_option(-W4)
+    else()
+        check_and_add_compiler_option(-Wall)
+        check_and_add_compiler_option(-Wsign-compare)
+        check_and_add_compiler_option(-Wmissing-prototypes)
+        check_and_add_compiler_option(-Wstrict-prototypes)
+        check_and_add_compiler_option(-Wshadow)
+        check_and_add_compiler_option(-Wdeclaration-after-statement)
+        check_and_add_compiler_option(-Wused-but-marked-unused)
+    endif()
 endif()
 
 #

--- a/optimize.c
+++ b/optimize.c
@@ -71,7 +71,10 @@ int pcap_optimizer_debug;
    * _BitScanForward().
    */
 #include <intrin.h>
+
+#ifndef __clang__
 #pragma intrinsic(_BitScanForward)
+#endif
 
 static __forceinline int
 lowest_set_bit(int mask)


### PR DESCRIPTION
MSVC's -Wall has more in common with clang's -Weverthing than gcc's -Wall. The result is very overwhelming (3000+ lines of warnings). 
From now on, if building with MSVC *and* if a a .devel is found *and* if MSVC is not using clang as it's front end, increase the warning level to 4. Else do the regular  check_and_add_compiler_option() routine.

It is probably also worth noticing that cmake's compiler identification string for LLVM/Clang is *not* true when using the Clang/C2 toolset. Only something like `if(MSVC AND NOT ${CMAKE_C_COMPILER} MATCHES "clang*")` or `if(CMAKE_GENERATOR_TOOLSET STREQUAL "v140_clang_3_7")` can detect it.