### PR TITLE
Rename SOCK_ASSERT to SOCK_MESSAGE

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1260,7 +1260,7 @@ static int pcap_startcapture_remote(pcap_t *fp)
 	if (res == -1)
 	{
 		sock_geterror("pcap_startcapture_remote()", fp->errbuf, PCAP_ERRBUF_SIZE);
-		SOCK_ASSERT(fp->errbuf, 1);
+		SOCK_MESSAGE(fp->errbuf);
 	}
 
 	/*
@@ -2730,7 +2730,7 @@ SOCKET pcap_remoteact_accept(const char *address, const char *port, const char *
 	{
 		if (sock_initaddress(address, RPCAP_DEFAULT_NETPORT_ACTIVE, &hints, &addrinfo, errbuf, PCAP_ERRBUF_SIZE) == -1)
 		{
-			SOCK_ASSERT(errbuf, 1);
+			SOCK_MESSAGE(errbuf);
 			return (SOCKET)-2;
 		}
 	}
@@ -2738,7 +2738,7 @@ SOCKET pcap_remoteact_accept(const char *address, const char *port, const char *
 	{
 		if (sock_initaddress(address, port, &hints, &addrinfo, errbuf, PCAP_ERRBUF_SIZE) == -1)
 		{
-			SOCK_ASSERT(errbuf, 1);
+			SOCK_MESSAGE(errbuf);
 			return (SOCKET)-2;
 		}
 	}
@@ -2746,7 +2746,7 @@ SOCKET pcap_remoteact_accept(const char *address, const char *port, const char *
 
 	if ((sockmain = sock_open(addrinfo, SOCKOPEN_SERVER, 1, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
 	{
-		SOCK_ASSERT(errbuf, 1);
+		SOCK_MESSAGE(errbuf);
 		freeaddrinfo(addrinfo);
 		return (SOCKET)-2;
 	}

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -656,9 +656,8 @@ void *daemon_serviceloop(void *ptr)
 				// signal to the main that the user closed the control connection
 				// This is used only in case of active mode
 				pars->activeclose = 1;
-				SOCK_ASSERT("The other end system asked to close the connection.", 1);
+				SOCK_MESSAGE("The other end system asked to close the connection.");
 				goto end;
-				break;
 			}
 
 			case RPCAP_MSG_STATS_REQ:
@@ -859,8 +858,8 @@ end:
 	}
 
 	// Print message and exit
-	SOCK_ASSERT("I'm exiting from the child loop", 1);
-	SOCK_ASSERT(errbuf, 1);
+	SOCK_MESSAGE("I'm exiting from the child loop");
+	SOCK_MESSAGE(errbuf);
 
 	if (!pars->isactive)
 	{

--- a/rpcapd/fileconf.c
+++ b/rpcapd/fileconf.c
@@ -42,7 +42,7 @@
 #include <signal.h>
 #include <pcap.h>		// for PCAP_ERRBUF_SIZE
 
-#include "sockutils.h"		// for SOCK_ASSERT
+#include "sockutils.h"		// for SOCK_MESSAGE
 #include "portability.h"
 #include "rpcapd.h"
 #include "fileconf.h"
@@ -93,7 +93,7 @@ void fileconf_read(void)
 					activelist[i].port[MAX_LINE] = 0;
 				}
 				else
-					SOCK_ASSERT("Only MAX_ACTIVE_LIST active connections are currently supported.", 1);
+					SOCK_MESSAGE("Only MAX_ACTIVE_LIST active connections are currently supported.");
 
 				i++;
 				continue;
@@ -133,7 +133,7 @@ void fileconf_read(void)
 		strrem(hostlist, '\n');
 
 		pcap_snprintf(msg, PCAP_ERRBUF_SIZE, "New passive host list: %s\n\n", hostlist);
-		SOCK_ASSERT(msg, 1);
+		SOCK_MESSAGE(msg);
 		fclose(fp);
 	}
 }

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 
 	if (sock_init(errbuf, PCAP_ERRBUF_SIZE) == -1)
 	{
-		SOCK_ASSERT(errbuf, 1);
+		SOCK_MESSAGE(errbuf);
 		exit(-1);
 	}
 
@@ -229,7 +229,7 @@ int main(int argc, char *argv[])
 				}
 
 				if (i > MAX_ACTIVE_LIST)
-					SOCK_ASSERT("Only MAX_ACTIVE_LIST active connections are currently supported.", 1);
+					SOCK_MESSAGE("Only MAX_ACTIVE_LIST active connections are currently supported.");
 
 				// I don't initialize the remaining part of the structure, since
 				// it is already zeroed (it is a global var)
@@ -249,11 +249,8 @@ int main(int argc, char *argv[])
 		}
 	}
 
-	if (savefile[0])
-	{
-		if (fileconf_save(savefile))
-			SOCK_ASSERT("Error when saving the configuration to file", 1);
-	}
+	if (savefile[0] && fileconf_save(savefile))
+			SOCK_MESSAGE("Error when saving the configuration to file");
 
 	// If the file does not exist, it keeps the settings provided by the command line
 	if (loadfile[0])
@@ -334,7 +331,7 @@ int main(int argc, char *argv[])
 #else
 		// If this call succeeds, it is blocking on Win32
 		if (svc_start() != 1)
-			SOCK_ASSERT("Unable to start the service", 1);
+			SOCK_MESSAGE("Unable to start the service");
 
 		// When the previous call returns, the entire application has to be stopped.
 		exit(0);
@@ -395,7 +392,7 @@ void main_startup(void)
 		    (void *)&activelist[i], 0, NULL);
 		if (threadId == 0)
 		{
-			SOCK_ASSERT("Error creating the active child threads", 1);
+			SOCK_MESSAGE("Error creating the active child threads");
 			continue;
 		}
 		CloseHandle(threadId);
@@ -430,7 +427,7 @@ void main_startup(void)
 		//
 		if (sock_initaddress((address[0]) ? address : NULL, port, &mainhints, &addrinfo, errbuf, PCAP_ERRBUF_SIZE) == -1)
 		{
-			SOCK_ASSERT(errbuf, 1);
+			SOCK_MESSAGE(errbuf);
 			return;
 		}
 
@@ -442,7 +439,7 @@ void main_startup(void)
 
 			if ((sock = sock_open(tempaddrinfo, SOCKOPEN_SERVER, SOCKET_MAXCONN, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
 			{
-				SOCK_ASSERT(errbuf, 1);
+				SOCK_MESSAGE(errbuf);
 				continue;
 			}
 
@@ -468,7 +465,7 @@ void main_startup(void)
 	//
 	// We're done; exit.
 	//
-	SOCK_ASSERT(PROGRAM_NAME " is closing.\n", 1);
+	SOCK_MESSAGE(PROGRAM_NAME " is closing.\n");
 
 #ifndef _WIN32
 	//
@@ -614,7 +611,7 @@ static void main_reap_children(int sign)
 	// For reference, Stevens, pg 128
 
 	while ((pid = waitpid(-1, &exitstat, WNOHANG)) > 0)
-		SOCK_ASSERT("Child terminated", 1);
+		SOCK_MESSAGE("Child terminated");
 
 	return;
 }
@@ -1084,7 +1081,7 @@ main_active(void *ptr)
 	pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "Connecting to host %s, port %s, using protocol %s",
 			activepars->address, activepars->port, (hints.ai_family == AF_INET) ? "IPv4":
 			(hints.ai_family == AF_INET6) ? "IPv6" : "Unspecified");
-	SOCK_ASSERT(errbuf, 1);
+	SOCK_MESSAGE(errbuf);
 
 	// Initialize errbuf
 	memset(errbuf, 0, sizeof(errbuf));
@@ -1092,7 +1089,7 @@ main_active(void *ptr)
 	// Do the work
 	if (sock_initaddress(activepars->address, activepars->port, &hints, &addrinfo, errbuf, PCAP_ERRBUF_SIZE) == -1)
 	{
-		SOCK_ASSERT(errbuf, 1);
+		SOCK_MESSAGE(errbuf);
 		return 0;
 	}
 
@@ -1102,13 +1099,13 @@ main_active(void *ptr)
 
 		if ((sockctrl = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
 		{
-			SOCK_ASSERT(errbuf, 1);
+			SOCK_MESSAGE(errbuf);
 
 			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "Error connecting to host %s, port %s, using protocol %s",
 					activepars->address, activepars->port, (hints.ai_family == AF_INET) ? "IPv4":
 					(hints.ai_family == AF_INET6) ? "IPv6" : "Unspecified");
 
-			SOCK_ASSERT(errbuf, 1);
+			SOCK_MESSAGE(errbuf);
 
 			sleep_secs(RPCAP_ACTIVE_WAIT);
 

--- a/rpcapd/win32-svc.c
+++ b/rpcapd/win32-svc.c
@@ -33,7 +33,7 @@
 
 #include "rpcapd.h"
 #include <pcap.h>		// for PCAP_ERRBUF_SIZE
-#include "sockutils.h"	// for SOCK_ASSERT
+#include "sockutils.h"		// for SOCK_MESSAGE
 #include "portability.h"
 #include "fileconf.h"
 
@@ -75,7 +75,7 @@ void svc_geterr(char *str)
 
 	pcap_snprintf(message, PCAP_ERRBUF_SIZE, "%s failed with error %d: %s", str, val, string);
 
-	SOCK_ASSERT(message, 1);
+	SOCK_MESSAGE(message);
 }
 
 void WINAPI svc_control_handler(DWORD Opcode)

--- a/sockutils.c
+++ b/sockutils.c
@@ -848,7 +848,7 @@ int sock_recv(SOCKET sock, void *buffer, size_t size, int flags,
 
 	if (size == 0)
 	{
-		SOCK_ASSERT("I have been requested to read zero bytes", 1);
+		SOCK_MESSAGE("I have been requested to read zero bytes");
 		return 0;
 	}
 	if (size > INT_MAX)
@@ -939,7 +939,7 @@ int sock_recv_dgram(SOCKET sock, void *buffer, size_t size,
 
 	if (size == 0)
 	{
-		SOCK_ASSERT("I have been requested to read zero bytes", 1);
+		SOCK_MESSAGE("I have been requested to read zero bytes");
 		return 0;
 	}
 	if (size > INT_MAX)
@@ -1095,7 +1095,7 @@ int sock_discard(SOCKET sock, int size, char *errbuf, int errbuflen)
 			return -1;
 	}
 
-	SOCK_ASSERT("I'm currently discarding data\n", 1);
+	SOCK_MESSAGE("I'm currently discarding data\n");
 
 	return 0;
 }
@@ -1170,7 +1170,7 @@ int sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage
 				if (errbuf)
 					pcap_snprintf(errbuf, errbuflen, "getaddrinfo() %s", gai_strerror(retval));
 
-				SOCK_ASSERT(errbuf, 1);
+				SOCK_MESSAGE(errbuf);
 
 				/* Get next token */
 				token = pcap_strtok_r(NULL, sep, &lasts);

--- a/sockutils.h
+++ b/sockutils.h
@@ -139,16 +139,15 @@ int WSAAPI getnameinfo(const struct sockaddr*,socklen_t,char*,DWORD,
  * \return No return values.
  */
 #ifdef NDEBUG
-  #define SOCK_ASSERT(msg, expr) ((void)0)
+  #define SOCK_MESSAGE(msg) ((void)0)
 #else
-  #include <assert.h>
   #if (defined(_WIN32) && defined(_MSC_VER))
     #include <crtdbg.h>				/* for _CrtDbgReport */
     /* Use MessageBox(NULL, msg, "warning", MB_OK)' instead of the other calls if you want to debug a Win32 service */
     /* Remember to activate the 'allow service to interact with desktop' flag of the service */
-    #define SOCK_ASSERT(msg, expr) { _CrtDbgReport(_CRT_WARN, NULL, 0, NULL, "%s\n", msg); fprintf(stderr, "%s\n", msg); assert(expr); }
+    #define SOCK_MESSAGE(msg) { _CrtDbgReport(_CRT_WARN, NULL, 0, NULL, "%s\n", msg); fprintf(stderr, "%s\n", msg); }
   #else
-    #define SOCK_ASSERT(msg, expr) { fprintf(stderr, "%s\n", msg); assert(expr); }
+    #define SOCK_MESSAGE(msg) { fprintf(stderr, "%s\n", msg); }
   #endif
 #endif
 


### PR DESCRIPTION
SOCK_ASSERT was always called with a true expression ("1") thus only ever executing the message part.
Rename the macro, remove the assert part and remove the "1" parameter.