### PR TITLE
Declare some variables static (found via -Wmissing-variable-declarations)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1674,6 +1674,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.devel OR EXISTS ${CMAKE_BINARY_DIR}/.devel)
         check_and_add_compiler_option(-Wmissing-noreturn)
         # Warns about safeguards added in case the enums are extended
         # check_and_add_compiler_option(-Wcovered-switch-default)
+        check_and_add_compiler_option(-Wmissing-variable-declarations)
     endif()
 endif()
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -853,6 +853,7 @@ AC_DEFUN(AC_LBL_DEVEL,
 		    # Warns about safeguards added in case the enums are
 		    # extended
 		    # AC_LBL_CHECK_COMPILER_OPT($1, -Wcovered-switch-default)
+		    AC_LBL_CHECK_COMPILER_OPT($1, -Wmissing-variable-declarations)
 	    fi
 	    AC_LBL_CHECK_DEPENDENCY_GENERATION_OPT()
 	    #

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -70,14 +70,14 @@ struct listen_sock {
 
 // Global variables
 char hostlist[MAX_HOST_LIST + 1];		//!< Keeps the list of the hosts that are allowed to connect to this server
-struct active_pars activelist[MAX_ACTIVE_LIST];		//!< Keeps the list of the hosts (host, port) on which I want to connect to (active mode)
+struct active_pars activelist[MAX_ACTIVE_LIST];	//!< Keeps the list of the hosts (host, port) on which I want to connect to (active mode)
 int nullAuthAllowed;				//!< '1' if we permit NULL authentication, '0' otherwise
 static struct listen_sock *listen_socks;	//!< sockets on which we listen
 char loadfile[MAX_LINE + 1];			//!< Name of the file from which we have to load the configuration
-int passivemode = 1;				//!< '1' if we want to run in passive mode as well
-struct addrinfo mainhints;			//!< temporary struct to keep settings needed to open the new socket
-char address[MAX_LINE + 1];			//!< keeps the network address (either numeric or literal) to bind to
-char port[MAX_LINE + 1];			//!< keeps the network port to bind to
+static int passivemode = 1;			//!< '1' if we want to run in passive mode as well
+static struct addrinfo mainhints;		//!< temporary struct to keep settings needed to open the new socket
+static char address[MAX_LINE + 1];		//!< keeps the network address (either numeric or literal) to bind to
+static char port[MAX_LINE + 1];			//!< keeps the network port to bind to
 #ifdef _WIN32
 static HANDLE shutdown_event;			//!< event to signal to shut down the main loop
 #else


### PR DESCRIPTION
Question: What is the preferred way to get rid of the fowllowing warnings, where the comments state that this is intentional:

pcap.c:180:19: warning: no previous extern declaration for non-static variable 'pcap_version' [-Wmissing-variable-declarations]
nametoaddr.c:549:28: warning: no previous extern declaration for non-static variable 'eproto_db' [-Wmissing-variable-declarations]

- Create a pcap-deprecated.h file and add it there
- Add DIAG_OFF/ON_MISSING_STATIC macros to diag-control.h
- Add generic DIAG_OFF/ON_WARNING macros to diag-control.h
- Use #pragma clang directly in the code
- Don't enable the warning at all