### PR TITLE
Trivial cleanups to bpf_filter.c

### DIFF
--- a/bpf/net/bpf_filter.c
+++ b/bpf/net/bpf_filter.c
@@ -44,36 +44,17 @@
 
 #include <pcap/pcap-inttypes.h>
 #include "pcap-types.h"
+#include "varattrs.h"	// for _U_
 
 #ifndef _WIN32
 #include <sys/param.h>
 #include <sys/types.h>
 #include <sys/time.h>
-
-#if defined(sun) && (defined(__SVR4) || defined(__svr4__))
-#define SOLARIS
-#else
-#undef SOLARIS
-#endif
-
-#if defined(__hpux) || defined(SOLARIS)
-# include <sys/sysmacros.h>
-# include <sys/stream.h>
-# define	mbuf	msgb
-# define	m_next	b_cont
-# define	MLEN(m)	((m)->b_wptr - (m)->b_rptr)
-# define	mtod(m,t)	((t)(m)->b_rptr)
-#else /* defined(__hpux) || defined(SOLARIS) */
-# define	MLEN(m)	((m)->m_len)
-#endif /* defined(__hpux) || defined(SOLARIS) */
-
 #endif /* _WIN32 */
 
 #include <pcap/bpf.h>
 
-#if !defined(KERNEL) && !defined(_KERNEL)
 #include <stdlib.h>
-#endif
 
 #define int32 bpf_int32
 #define u_int32 bpf_u_int32
@@ -111,80 +92,6 @@
 		 (u_int32)*((u_char *)p+3)<<0)
 #endif
 
-#if defined(KERNEL) || defined(_KERNEL)
-# if !defined(__hpux) && !defined(SOLARIS)
-#include <sys/mbuf.h>
-# endif
-#define MINDEX(len, _m, _k) \
-{ \
-	len = MLEN(m); \
-	while ((_k) >= len) { \
-		(_k) -= len; \
-		(_m) = (_m)->m_next; \
-		if ((_m) == 0) \
-			return 0; \
-		len = MLEN(m); \
-	} \
-}
-
-static int
-m_xword(struct mbuf *m, int k, int *err)
-{
-	register int len;
-	register u_char *cp, *np;
-	register struct mbuf *m0;
-
-	MINDEX(len, m, k);
-	cp = mtod(m, u_char *) + k;
-	if (len - k >= 4) {
-		*err = 0;
-		return EXTRACT_LONG(cp);
-	}
-	m0 = m->m_next;
-	if (m0 == 0 || MLEN(m0) + len - k < 4)
-		goto bad;
-	*err = 0;
-	np = mtod(m0, u_char *);
-	switch (len - k) {
-
-	case 1:
-		return (cp[0] << 24) | (np[0] << 16) | (np[1] << 8) | np[2];
-
-	case 2:
-		return (cp[0] << 24) | (cp[1] << 16) | (np[0] << 8) | np[1];
-
-	default:
-		return (cp[0] << 24) | (cp[1] << 16) | (cp[2] << 8) | np[0];
-	}
-    bad:
-	*err = 1;
-	return 0;
-}
-
-static int
-m_xhalf(struct mbuf *m, int k, int *err)
-{
-	register int len;
-	register u_char *cp;
-	register struct mbuf *m0;
-
-	MINDEX(len, m, k);
-	cp = mtod(m, u_char *) + k;
-	if (len - k >= 2) {
-		*err = 0;
-		return EXTRACT_SHORT(cp);
-	}
-	m0 = m->m_next;
-	if (m0 == 0)
-		goto bad;
-	*err = 0;
-	return (cp[0] << 8) | mtod(m0, u_char *)[0];
- bad:
-	*err = 1;
-	return 0;
-}
-#endif
-
 #ifdef __linux__
 #include <linux/types.h>
 #include <linux/if_packet.h>
@@ -209,24 +116,19 @@ enum {
  *
  * Thanks to Ani Sinha <ani@arista.com> for providing initial implementation
  */
+// Unused if no VLAN
+#if defined(SKF_AD_VLAN_TAG_PRESENT)
+#define _UNV_
+#else
+#define _UNV_ _U_
+#endif
 u_int
 bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
-    u_int wirelen, u_int buflen, const struct bpf_aux_data *aux_data)
+    u_int wirelen, u_int buflen, const struct bpf_aux_data *aux_data _UNV_)
 {
 	register u_int32 A, X;
 	register bpf_u_int32 k;
 	u_int32 mem[BPF_MEMWORDS];
-#if defined(KERNEL) || defined(_KERNEL)
-	struct mbuf *m, *n;
-	int merr, len;
-
-	if (buflen == 0) {
-		m = (struct mbuf *)p;
-		p = mtod(m, u_char *);
-		buflen = MLEN(m);
-	} else
-		m = NULL;
-#endif
 
 	if (pc == 0)
 		/*
@@ -241,11 +143,8 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 		switch (pc->code) {
 
 		default:
-#if defined(KERNEL) || defined(_KERNEL)
-			return 0;
-#else
 			abort();
-#endif
+
 		case BPF_RET|BPF_K:
 			return (u_int)pc->k;
 
@@ -255,16 +154,7 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 		case BPF_LD|BPF_W|BPF_ABS:
 			k = pc->k;
 			if (k > buflen || sizeof(int32_t) > buflen - k) {
-#if defined(KERNEL) || defined(_KERNEL)
-				if (m == NULL)
-					return 0;
-				A = m_xword(m, k, &merr);
-				if (merr != 0)
-					return 0;
-				continue;
-#else
 				return 0;
-#endif
 			}
 			A = EXTRACT_LONG(&p[k]);
 			continue;
@@ -272,50 +162,35 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 		case BPF_LD|BPF_H|BPF_ABS:
 			k = pc->k;
 			if (k > buflen || sizeof(int16_t) > buflen - k) {
-#if defined(KERNEL) || defined(_KERNEL)
-				if (m == NULL)
-					return 0;
-				A = m_xhalf(m, k, &merr);
-				if (merr != 0)
-					return 0;
-				continue;
-#else
 				return 0;
-#endif
 			}
 			A = EXTRACT_SHORT(&p[k]);
 			continue;
 
 		case BPF_LD|BPF_B|BPF_ABS:
 			{
-#if defined(SKF_AD_VLAN_TAG) && defined(SKF_AD_VLAN_TAG_PRESENT)
+#if defined(SKF_AD_VLAN_TAG_PRESENT)
 				int code = BPF_S_ANC_NONE;
-#define ANCILLARY(CODE) case SKF_AD_OFF + SKF_AD_##CODE:		\
-				code = BPF_S_ANC_##CODE;		\
-                                        if (!aux_data)                  \
-                                                return 0;               \
-                                        break;
 
 				switch (pc->k) {
-					ANCILLARY(VLAN_TAG);
-					ANCILLARY(VLAN_TAG_PRESENT);
+				case SKF_AD_OFF + SKF_AD_VLAN_TAG:
+					code = BPF_S_ANC_VLAN_TAG;
+                                        if (!aux_data)
+                                                return 0;
+                                        break;
+				case SKF_AD_OFF + SKF_AD_VLAN_TAG_PRESENT:
+					code = BPF_S_ANC_VLAN_TAG_PRESENT;
+                                        if (!aux_data)
+                                                return 0;
+                                        break;
 				default :
 #endif
 					k = pc->k;
 					if (k >= buflen) {
-#if defined(KERNEL) || defined(_KERNEL)
-						if (m == NULL)
-							return 0;
-						n = m;
-						MINDEX(len, n, k);
-						A = mtod(n, u_char *)[k];
-						continue;
-#else
 						return 0;
-#endif
 					}
 					A = p[k];
-#if defined(SKF_AD_VLAN_TAG) && defined(SKF_AD_VLAN_TAG_PRESENT)
+#if defined(SKF_AD_VLAN_TAG_PRESENT)
 				}
 				switch (code) {
 				case BPF_S_ANC_VLAN_TAG:
@@ -343,16 +218,7 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			k = X + pc->k;
 			if (pc->k > buflen || X > buflen - pc->k ||
 			    sizeof(int32_t) > buflen - k) {
-#if defined(KERNEL) || defined(_KERNEL)
-				if (m == NULL)
-					return 0;
-				A = m_xword(m, k, &merr);
-				if (merr != 0)
-					return 0;
-				continue;
-#else
 				return 0;
-#endif
 			}
 			A = EXTRACT_LONG(&p[k]);
 			continue;
@@ -361,16 +227,7 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			k = X + pc->k;
 			if (X > buflen || pc->k > buflen - X ||
 			    sizeof(int16_t) > buflen - k) {
-#if defined(KERNEL) || defined(_KERNEL)
-				if (m == NULL)
-					return 0;
-				A = m_xhalf(m, k, &merr);
-				if (merr != 0)
-					return 0;
-				continue;
-#else
 				return 0;
-#endif
 			}
 			A = EXTRACT_SHORT(&p[k]);
 			continue;
@@ -378,16 +235,7 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 		case BPF_LD|BPF_B|BPF_IND:
 			k = X + pc->k;
 			if (pc->k >= buflen || X >= buflen - pc->k) {
-#if defined(KERNEL) || defined(_KERNEL)
-				if (m == NULL)
-					return 0;
-				n = m;
-				MINDEX(len, n, k);
-				A = mtod(n, u_char *)[k];
-				continue;
-#else
 				return 0;
-#endif
 			}
 			A = p[k];
 			continue;
@@ -395,16 +243,7 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 		case BPF_LDX|BPF_MSH|BPF_B:
 			k = pc->k;
 			if (k >= buflen) {
-#if defined(KERNEL) || defined(_KERNEL)
-				if (m == NULL)
-					return 0;
-				n = m;
-				MINDEX(len, n, k);
-				X = (mtod(n, char *)[k] & 0xf) << 2;
-				continue;
-#else
 				return 0;
-#endif
 			}
 			X = (p[pc->k] & 0xf) << 2;
 			continue;
@@ -434,18 +273,11 @@ bpf_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			continue;
 
 		case BPF_JMP|BPF_JA:
-#if defined(KERNEL) || defined(_KERNEL)
-			/*
-			 * No backward jumps allowed.
-			 */
-			pc += pc->k;
-#else
 			/*
 			 * XXX - we currently implement "ip6 protochain"
 			 * with backward jumps, so sign-extend pc->k.
 			 */
 			pc += (bpf_int32)pc->k;
-#endif
 			continue;
 
 		case BPF_JMP|BPF_JGT|BPF_K:
@@ -614,11 +446,6 @@ bpf_validate(const struct bpf_insn *f, int len)
 	/*
 	 * There's no maximum program length in userland.
 	 */
-#if defined(KERNEL) || defined(_KERNEL)
-	if (len > BPF_MAXINSNS)
-		return 0;
-#endif
-
 	for (i = 0; i < (u_int)len; ++i) {
 		p = &f[i];
 		switch (BPF_CLASS(p->code)) {
@@ -638,14 +465,6 @@ bpf_validate(const struct bpf_insn *f, int len)
 				 * in userland.  The runtime packet length
 				 * check suffices.
 				 */
-#if defined(KERNEL) || defined(_KERNEL)
-				/*
-				 * More strict check with actual packet length
-				 * is done runtime.
-				 */
-				if (p->k >= bpf_maxbufsize)
-					return 0;
-#endif
 				break;
 			case BPF_MEM:
 				if (p->k >= BPF_MEMWORDS)
@@ -717,11 +536,7 @@ bpf_validate(const struct bpf_insn *f, int len)
 			from = i + 1;
 			switch (BPF_OP(p->code)) {
 			case BPF_JA:
-#if defined(KERNEL) || defined(_KERNEL)
-				if (from + p->k < from || from + p->k >= len)
-#else
 				if (from + p->k >= (u_int)len)
-#endif
 					return 0;
 				break;
 			case BPF_JEQ:


### PR DESCRIPTION
- Remove all code when this file is used to compile a kernel module,
  i.e. inside KERNEL or _KERNEL (not done anymore)
- Remove all(?) helper stuff that was only needed for KERNEL stuff
- Fix an unused warning when VLAN_TAG matching is not done via aux_data
- Expand macro ANCILLARY - it didn't help readability
- Assume that SKF_AD_VLAN_TAG exists if SKF_AD_VLAN_TAG_PRESENT exists