### PR TITLE
Make sure we don't overflow the bids array when running a binary that…

### DIFF
--- a/bpf_dump.c
+++ b/bpf_dump.c
@@ -48,9 +48,15 @@ bpf_dump(const struct bpf_program *p, int option)
 			       insn->code, insn->jt, insn->jf, insn->k);
 		return;
 	}
+#ifdef BDEBUG
+#undef NDEBUG
+#include <assert.h>
+extern int bids[];
+#define	MAX_BIDS 1000
+assert(n <= MAX_BIDS);
+#endif
 	for (i = 0; i < n; ++insn, ++i) {
 #ifdef BDEBUG
-		extern int bids[];
 		if (bids[i] > 0)
 			printf("[%02d]", bids[i] - 1);
 		else

--- a/optimize.c
+++ b/optimize.c
@@ -43,6 +43,9 @@
 #endif
 
 #ifdef BDEBUG
+#undef NDEBUG
+#include <assert.h>
+PCAP_API int pcap_optimizer_debug;
 int pcap_optimizer_debug;
 #endif
 
@@ -2062,7 +2065,9 @@ opt_init(compiler_state_t *cstate, opt_state_t *opt_state, struct icode *ic)
  * and expect it to provide meaningful information.
  */
 #ifdef BDEBUG
-int bids[1000];
+#define MAX_BIDS 1000
+PCAP_API int bids[];
+int bids[MAX_BIDS];
 #endif
 
 /*
@@ -2190,6 +2195,7 @@ filled:
 		free(offset);
 
 #ifdef BDEBUG
+	assert(dst - conv_state->fstart < MAX_BIDS);
 	bids[dst - conv_state->fstart] = p->id + 1;
 #endif
 	dst->code = (u_short)p->s.code;

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -64,7 +64,7 @@ static void PCAP_NORETURN error(const char *, ...) PCAP_PRINTFLIKE(1, 2);
 static void warn(const char *, ...) PCAP_PRINTFLIKE(1, 2);
 
 #ifdef BDEBUG
-int dflag;
+static int dflag;
 #endif
 
 /*


### PR DESCRIPTION
… was compiled with BDEBUG.

Fix a few compile warnings that pop up only when BDEBUG is defined.