### PR TITLE
cross compile for android error duo to the command line is too long

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -400,7 +400,7 @@ shared: libpcap.$(DYEXT)
 libpcap.so: $(OBJ)
 	@rm -f $@
 	VER=`cat $(srcdir)/VERSION`; \
-	MAJOR_VER=`sed 's/\([0-9][0-9]*\)\..*/\1/' $(srcdir)/VERSION`; \
+	MAJOR_VER=`sed 's/\([0-9][0-9]*\)\..*/\1/' $(srcdir)/VERSION`
 	@V_SHLIB_CMD@ $(LDFLAGS) @V_SHLIB_OPT@ @V_SONAME_OPT@$@.$$MAJOR_VER \
 	    -o $@.$$VER $(OBJ) $(ADDLOBJS) $(LIBS)
 


### PR DESCRIPTION
When compiling it use the android NDK standalone toolchains, the `CC` command will be long enough with its extra options. After all of this, the command line may be too long to the environment (like Windows).