### PR TITLE
Fix warning when compiling with BDEBUG defined

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -65,6 +65,10 @@ struct rtentry;
 #include <arpa/inet.h>
 #endif /* _WIN32 */
 
+#ifdef YYDEBUG
+extern int pcap_debug;
+#endif
+
 #include <stdio.h>
 
 #include "diag-control.h"

--- a/missing/getopt.h
+++ b/missing/getopt.h
@@ -2,6 +2,6 @@
  * Header for the getopt() we supply if the platform doesn't supply it.
  */
 extern char *optarg;			/* getopt(3) external variables */
-extern int optind, opterr, optopt;
+extern int optind, opterr, optopt, optreset;
 
 extern int getopt(int nargc, char * const *nargv, const char *ostr);

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -64,7 +64,7 @@ static void PCAP_NORETURN error(const char *, ...) PCAP_PRINTFLIKE(1, 2);
 static void warn(const char *, ...) PCAP_PRINTFLIKE(1, 2);
 
 #ifdef BDEBUG
-int dflag;
+static int dflag;
 #endif
 
 /*


### PR DESCRIPTION
warning: no previous extern declaration for non-static variable 'dflag' [-Wmissing-variable-declarations]