### PR TITLE
Add -Wformat-nonliteral and fix most warnings that come up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1676,6 +1676,7 @@ if(EXISTS ${CMAKE_SOURCE_DIR}/.devel OR EXISTS ${CMAKE_BINARY_DIR}/.devel)
         # check_and_add_compiler_option(-Wcovered-switch-default)
         check_and_add_compiler_option(-Wmissing-variable-declarations)
 	check_and_add_compiler_option(-Wunused-parameter)
+	check_and_add_compiler_option(-Wformat-nonliteral)
     endif()
 endif()
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -855,6 +855,7 @@ AC_DEFUN(AC_LBL_DEVEL,
 		    # AC_LBL_CHECK_COMPILER_OPT($1, -Wcovered-switch-default)
 		    AC_LBL_CHECK_COMPILER_OPT($1, -Wmissing-variable-declarations)
 		    AC_LBL_CHECK_COMPILER_OPT($1, -Wunused-parameter)
+		    AC_LBL_CHECK_COMPILER_OPT($1, -Wformat-nonliteral)
 	    fi
 	    AC_LBL_CHECK_DEPENDENCY_GENERATION_OPT()
 	    #

--- a/configure
+++ b/configure
@@ -8920,6 +8920,49 @@ $as_echo "no" >&6; }
 fi
 rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 
+
+	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports the -Wformat-nonliteral option" >&5
+$as_echo_n "checking whether the compiler supports the -Wformat-nonliteral option... " >&6; }
+	save_CFLAGS="$CFLAGS"
+	if expr "x-Wformat-nonliteral" : "x-W.*" >/dev/null
+	then
+	    CFLAGS="$CFLAGS $ac_lbl_unknown_warning_option_error -Wformat-nonliteral"
+	elif expr "x-Wformat-nonliteral" : "x-f.*" >/dev/null
+	then
+	    CFLAGS="$CFLAGS -Werror -Wformat-nonliteral"
+	elif expr "x-Wformat-nonliteral" : "x-m.*" >/dev/null
+	then
+	    CFLAGS="$CFLAGS -Werror -Wformat-nonliteral"
+	else
+	    CFLAGS="$CFLAGS -Wformat-nonliteral"
+	fi
+	cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+int
+main ()
+{
+return 0
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+		CFLAGS="$save_CFLAGS"
+		V_CCOPT="$V_CCOPT -Wformat-nonliteral"
+
+else
+
+		{ $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+		CFLAGS="$save_CFLAGS"
+
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+
 	    fi
 
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the compiler supports generating dependencies" >&5

--- a/optimize.c
+++ b/optimize.c
@@ -2187,7 +2187,7 @@ convert_code_r(compiler_state_t *cstate, conv_state_t *conv_state,
 	    {
 		u_int i;
 		int jt, jf;
-		const char *ljerr = "%s for block-local relative jump: off=%d";
+		const char ljerr[] = "%s for block-local relative jump: off=%d";
 
 #if 0
 		printf("code=%x off=%d %x %x\n", src->s.code,

--- a/testprogs/can_set_rfmon_test.c
+++ b/testprogs/can_set_rfmon_test.c
@@ -39,7 +39,7 @@ The Regents of the University of California.  All rights reserved.\n";
 static const char *program_name;
 
 /* Forwards */
-static void PCAP_NORETURN error(const char *, ...);
+static void PCAP_NORETURN error(PCAP_FORMAT_STRING(const char *), ...) PCAP_PRINTFLIKE(1,2);
 
 int
 main(int argc, char **argv)

--- a/testprogs/reactivatetest.c
+++ b/testprogs/reactivatetest.c
@@ -36,7 +36,7 @@ The Regents of the University of California.  All rights reserved.\n";
 #include "pcap/funcattrs.h"
 
 /* Forwards */
-static void PCAP_NORETURN error(const char *, ...);
+static void PCAP_NORETURN error(PCAP_FORMAT_STRING(const char *), ...) PCAP_PRINTFLIKE(1,2);
 
 int
 main(void)


### PR DESCRIPTION
The remaining ocurrences are genuine and intentional.
I have no idea why a "const char *" doesn't qualify but I replaced it with a #define

warning: format string is not a string literal [-Wformat-nonliteral]