### PR TITLE
Expand "non-promisc" packet filter to include edge cases

### DIFF
--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -1034,7 +1034,17 @@ pcap_activate_npf(pcap_t *p)
 	}
 	else
 	{
-		if (PacketSetHwFilter(pw->adapter,NDIS_PACKET_TYPE_ALL_LOCAL) == FALSE)
+		/* NDIS_PACKET_TYPE_ALL_LOCAL selects "All packets sent by installed
+		 * protocols and all packets indicated by the NIC" but if no protocol
+		 * drivers (like TCP/IP) are installed, NDIS_PACKET_TYPE_DIRECTED,
+		 * NDIS_PACKET_TYPE_BROADCAST, and NDIS_PACKET_TYPE_MULTICAST are needed to
+		 * capture incoming frames.
+		 */
+		if (PacketSetHwFilter(pw->adapter,
+			NDIS_PACKET_TYPE_ALL_LOCAL |
+			NDIS_PACKET_TYPE_DIRECTED |
+			NDIS_PACKET_TYPE_BROADCAST |
+			NDIS_PACKET_TYPE_MULTICAST) == FALSE)
 		{
 			pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE, "failed to set hardware filter to non-promiscuous mode");
 			goto bad;


### PR DESCRIPTION
First reported in 2013 by Sebastian Walther:
https://www.winpcap.org/pipermail/winpcap-bugs/2013-May/001620.html

The hardware packet filters for non-promisc mode on Windows were based
on an incomplete understanding. Npcap developers reviewing MS
documentation agree with Sebastian's assessment and propose the combined
packet filter of NDIS_PACKET_TYPE_ALL_LOCAL | NDIS_PACKET_TYPE_DIRECTED
| NDIS_PACKET_TYPE_BROADCAST | NDIS_PACKET_TYPE_MULTICAST for the
inverse of "promiscuous mode" on Windows.

Packet filter reference:
https://docs.microsoft.com/en-us/windows-hardware/drivers/network/oid-gen-current-packet-filter