### PR TITLE
documentation: make it clear that stream passed to pcap_dump_fopen() is closed by pcap_dump_close()

### DIFF
--- a/pcap_dump_open.3pcap.in
+++ b/pcap_dump_open.3pcap.in
@@ -48,7 +48,9 @@ for
 .PP
 .B pcap_dump_fopen()
 is called to write data to an existing open stream
-.IR fp .
+.IR fp ;
+this stream will be closed by a subsequent call to 
+.BR pcap_dump_close() .
 Note that on Windows, that stream should be opened in binary mode.
 .PP
 .I p


### PR DESCRIPTION
It isn't stated in the documentation whether the FILE* passed to pcap_dump_fopen() will be closed by a subsequent pcap_dump_close().

This lack of clarity can cause the user to close the FILE* themselves after calling pcap_dump_close(), leading to SIGABRT on some platforms.