### PR TITLE
Add DLT_LINUX_SLL2 and LINKTYPE_LINUX_SLL2

### DIFF
--- a/doc/DLT_ALLOCATE_HOWTO.md
+++ b/doc/DLT_ALLOCATE_HOWTO.md
@@ -26,10 +26,4 @@ DEVELOPER NOTES
 
 When allocating a new DLT_ value, a corresponding value needs to be
 added to pcap-common.c.
-It not necessary to copy to commonts from dlt.h to pcap-common.c.
-
-
-
-
-
-
+It not necessary to copy to comments from dlt.h to pcap-common.c.

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1081,7 +1081,12 @@
  */
 #define LINKTYPE_DISPLAYPORT_AUX	275
 
-#define LINKTYPE_MATCHING_MAX	275		/* highest value in the "matching" range */
+/*
+ * Linux cooked sockets v2.
+ */
+#define LINKTYPE_LINUX_SLL2	276
+
+#define LINKTYPE_MATCHING_MAX	276		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -246,7 +246,7 @@
  */
 
 /*
- * This is for Linux cooked sockets.
+ * Linux cooked sockets.
  */
 #define DLT_LINUX_SLL	113
 
@@ -1368,6 +1368,11 @@
 #define DLT_DISPLAYPORT_AUX	275
 
 /*
+ * Linux cooked sockets v2.
+ */
+#define DLT_LINUX_SLL2	276
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1377,7 +1382,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	275	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	276	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
with linktype value 276.

This is a preparation for implementing Linux "cooked" capture
encapsulation v2.

See: GH the-tcpdump-group/libpcap#127

Signed-off-by: Petr Vorel <pvorel@suse.cz>