### PR TITLE
pcap-usb-linux.c: add missing limits.h for musl systems.

### DIFF
--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -50,6 +50,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <limits.h>
 #include <string.h>
 #include <dirent.h>
 #include <byteswap.h>


### PR DESCRIPTION
fix compilation on musl libc systems like Void Linux and Alpine.

error log if this isn't present.
```
./pcap-usb-linux.c: In function 'usb_findalldevs':
./pcap-usb-linux.c:264:19: error: 'PATH_MAX' undeclared (first use in this function); did you mean 'AF_MAX'?
  char usb_mon_dir[PATH_MAX];
                   ^~~~~~~~
                   AF_MAX
./pcap-usb-linux.c:264:19: note: each undeclared identifier is reported only once for each function it appears in
./pcap-usb-linux.c: In function 'probe_devices':
./pcap-usb-linux.c:419:41: error: 'NAME_MAX' undeclared (first use in this function); did you mean 'AF_MAX'?
  char buf[sizeof("/dev/bus/usb/000/") + NAME_MAX];
                                         ^~~~~~~~
                                         AF_MAX
make: *** [Makefile:86: pcap-usb-linux.o] Error 1
make: *** Waiting for unfinished jobs....
```