### PR TITLE
Proper breakloop for linux on pcap_dispatch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -387,6 +387,7 @@ main(void)
         # linux/if_bonding.h requires sys/socket.h.
         #
         check_include_files("sys/socket.h;linux/if_bonding.h" HAVE_LINUX_IF_BONDING_H)
+        check_include_files("sys/eventfd.h" HAVE_SYS_EVENTFD_H)
     endif()
 endif(NOT WIN32)
 

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -235,6 +235,9 @@
 /* Define to 1 if you have the <sys/dlpi.h> header file. */
 #cmakedefine HAVE_SYS_DLPI_H 1
 
+/* Define to 1 if you have the <sys/eventfd.h> header file. */
+#cmakedefine HAVE_SYS_EVENTFD_H 1
+
 /* Define to 1 if you have the <sys/ioccom.h> header file. */
 #cmakedefine HAVE_SYS_IOCCOM_H 1
 

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -126,6 +126,7 @@ typedef int	(*set_datalink_op_t)(pcap_t *, int);
 typedef int	(*getnonblock_op_t)(pcap_t *);
 typedef int	(*setnonblock_op_t)(pcap_t *, int);
 typedef int	(*stats_op_t)(pcap_t *, struct pcap_stat *);
+typedef void	(*breakloop_op_t)(pcap_t *);
 #ifdef _WIN32
 typedef struct pcap_stat *(*stats_ex_op_t)(pcap_t *, int *);
 typedef int	(*setbuff_op_t)(pcap_t *, int);
@@ -264,6 +265,7 @@ struct pcap {
 	getnonblock_op_t getnonblock_op;
 	setnonblock_op_t setnonblock_op;
 	stats_op_t stats_op;
+	breakloop_op_t breakloop_op;
 
 	/*
 	 * Routine to use as callback for pcap_next()/pcap_next_ex().
@@ -418,6 +420,7 @@ void	pcap_add_to_pcaps_to_close(pcap_t *);
 void	pcap_remove_from_pcaps_to_close(pcap_t *);
 void	pcap_cleanup_live_common(pcap_t *);
 int	pcap_check_activated(pcap_t *);
+void	pcap_breakloop_common(pcap_t *);
 
 /*
  * Internal interfaces for "pcap_findalldevs()".

--- a/pcap.c
+++ b/pcap.c
@@ -2111,6 +2111,13 @@ initialize_ops(pcap_t *p)
 	 * be used for pcap_next()/pcap_next_ex().
 	 */
 	p->oneshot_callback = pcap_oneshot;
+
+    /*
+     * Default breakloop operation - implementations can override
+     * this, but should call pcap_breakloop_common() before doing
+     * their own logic.
+     */
+    p->breakloop_op = pcap_breakloop_common;
 }
 
 static pcap_t *
@@ -2601,7 +2608,7 @@ pcap_loop(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 void
 pcap_breakloop(pcap_t *p)
 {
-	p->break_loop = 1;
+	p->breakloop_op(p);
 }
 
 int
@@ -3603,6 +3610,13 @@ pcap_remove_from_pcaps_to_close(pcap_t *p)
 		}
 	}
 }
+
+void
+pcap_breakloop_common(pcap_t *p)
+{
+	p->break_loop = 1;
+}
+
 
 void
 pcap_cleanup_live_common(pcap_t *p)


### PR DESCRIPTION
On platforms that support it use an eventfd to exit any polling.

This is meant to fix #734 . It does not currently handle `pcap_read_packet`, I could also add poll there so it wouldn't block. I probably didn't search enough, but I could not find any tests to run to check everything is in order, so any help in that direction would be helpful.