### PR TITLE
Fixing va_start/va_end usage

### DIFF
--- a/missing/snprintf.c
+++ b/missing/snprintf.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1995-1999 Kungliga Tekniska Högskolan
+ * Copyright (c) 1995-1999 Kungliga Tekniska HÃ¶gskolan
  * (Royal Institute of Technology, Stockholm, Sweden).
  * All rights reserved.
  *
@@ -525,6 +525,7 @@ pcap_asnprintf (char **ret, size_t max_sz, const char *format, ...)
 
   va_start(args, format);
   val = pcap_vasnprintf (ret, max_sz, format, args);
+  va_end(args);
 
 #ifdef PARANOIA
   {
@@ -534,14 +535,15 @@ pcap_asnprintf (char **ret, size_t max_sz, const char *format, ...)
     if (tmp == NULL)
       abort ();
 
+    va_start(args, format);
     ret2 = pcap_vsprintf (tmp, format, args);
+    va_end(args);
     if (val != ret2 || strcmp(*ret, tmp))
       abort ();
     free (tmp);
   }
 #endif
 
-  va_end(args);
   return val;
 }
 #endif


### PR DESCRIPTION
Per ISO/IEC 9899:201x and POSIX:

As the functions vfprintf, vfscanf, vprintf, vscanf, vsnprintf, vsprintf, and vsscanf invoke the va_arg macro, the value of [args] after the return is indeterminate.

What needs to be done instead is to wrap each invocation of pcap*snprintf with its own pair of va_start and va_end.