### PR TITLE
Ignore net only on root directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,7 @@ libpcap.sl
 libpcap.so
 libpcap.so.*
 libpcap-*.tar.gz
-net
+/net
 os-proto.h
 pcap-config
 pcap-filter.manmisc


### PR DESCRIPTION
There are `/bpf/net` and `/Win32/Include/net` which are part of the repository.