### PR TITLE
Fix multiple declaration of bpf_ functions

### DIFF
--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -254,9 +254,20 @@ struct bpf_aux_data {
 #define BPF_STMT(code, k) { (u_short)(code), 0, 0, k }
 #define BPF_JUMP(code, k, jt, jf) { (u_short)(code), jt, jf, k }
 
-PCAP_API int bpf_validate(const struct bpf_insn *, int);
-PCAP_API u_int bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
+/*
+ * On at least some versions of NetBSD and QNX, we don't want to declare
+ * bpf_filter() here, as it's also be declared in <net/bpf.h>, with a
+ * different signature, but, on other BSD-flavored UN*Xes, it's not
+ * declared in <net/bpf.h>, so we *do* want to declare it here, so it's
+ * declared when we build pcap-bpf.c.
+ */
+#if !defined(__NetBSD__) && !defined(__QNX__)
+  PCAP_API u_int	bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
+#endif
 extern u_int bpf_filter_with_aux_data(const struct bpf_insn *, const u_char *, u_int, u_int, const struct bpf_aux_data *);
+PCAP_API int	bpf_validate(const struct bpf_insn *f, int len);
+PCAP_API char	*bpf_image(const struct bpf_insn *, int);
+PCAP_API void	bpf_dump(const struct bpf_program *, int);
 
 /*
  * Number of scratch memory words (for BPF_LD|BPF_MEM and BPF_ST).

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -513,20 +513,6 @@ PCAP_API void	pcap_freealldevs(pcap_if_t *);
  */
 PCAP_API const char *pcap_lib_version(void);
 
-/*
- * On at least some versions of NetBSD and QNX, we don't want to declare
- * bpf_filter() here, as it's also be declared in <net/bpf.h>, with a
- * different signature, but, on other BSD-flavored UN*Xes, it's not
- * declared in <net/bpf.h>, so we *do* want to declare it here, so it's
- * declared when we build pcap-bpf.c.
- */
-#if !defined(__NetBSD__) && !defined(__QNX__)
-  PCAP_API u_int	bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
-#endif
-PCAP_API int	bpf_validate(const struct bpf_insn *f, int len);
-PCAP_API char	*bpf_image(const struct bpf_insn *, int);
-PCAP_API void	bpf_dump(const struct bpf_program *, int);
-
 #if defined(_WIN32)
 
   /*


### PR DESCRIPTION
This fixes #751.
I'm thinking this may be the proper way to do it, based  on my understanding. I tested a *tcpdump* compilation with this and it worked. If this isn't the right way to do it let me know.

### commit log
pcap.h will include pcap/pcap.h and pcap/bpf.h that both defines the
bpf_filter and bpf_validate functions.

In most cases this won't be an issue, most people are using the libpcap
as a system library, gcc preprocessor will therefore disable part of the
warnings according to the `3` in
https://gcc.gnu.org/onlinedocs/cpp/Preprocessor-Output.html

In case libpcap is included in a project that actually have more warning
(-Wredundant-decls), and also using local headers we end up having quite
a lot of warning.