### PR TITLE
Cleanly avoid warnings in grammar.y

### DIFF
--- a/grammar.y
+++ b/grammar.y
@@ -19,6 +19,14 @@
 %lex-param   {void *yyscanner}
 
 /*
+ * According to bison documentation, shift/reduce conflicts are not an issue
+ * in most parsers as long as the number does not evolve over time:
+ * https://www.gnu.org/software/bison/manual/html_node/Expect-Decl.html
+ * So, following the advice use %expect to check the amount of shift/reduce
+ * warnings.
+ */
+%expect 38
+/*
  * And we need to pass the compiler state to the scanner.
  */
 %parse-param { compiler_state_t *cstate }


### PR DESCRIPTION
Fixes #753 
While looking for a way to pass *-Wno-conflicts-sr* from our build framework, I stumbled on something I missed last time I looked at this in the [bison documentation](https://www.gnu.org/software/bison/manual/html_node/Expect-Decl.html) which explains what they suggest is the proper way to fix these warnings.

So here is a patch using just that suggested *expect* in the case of *grammar.y*.

### Commitlog
Shift/reduce warnings are apparently mostly harmless:
https://www.gnu.org/software/bison/manual/html_node/Expect-Decl.html

The suggested way to handle them in bison documentation is to monitor
the amount isn't changing over time.

The usual output is:
grammar.y: warning: 38 shift/reduce conflicts [-Wconflicts-sr]

So I added the %expect 38 in grammar.y to avoid warnings.
