### PR TITLE
add pcap stats reset

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -126,6 +126,7 @@ typedef int	(*set_datalink_op_t)(pcap_t *, int);
 typedef int	(*getnonblock_op_t)(pcap_t *);
 typedef int	(*setnonblock_op_t)(pcap_t *, int);
 typedef int	(*stats_op_t)(pcap_t *, struct pcap_stat *);
+typedef int	(*stats_op_reset_t)(pcap_t *);
 #ifdef _WIN32
 typedef struct pcap_stat *(*stats_ex_op_t)(pcap_t *, int *);
 typedef int	(*setbuff_op_t)(pcap_t *, int);
@@ -265,6 +266,7 @@ struct pcap {
 	getnonblock_op_t getnonblock_op;
 	setnonblock_op_t setnonblock_op;
 	stats_op_t stats_op;
+	stats_op_reset_t stats_op_reset;
 
 	/*
 	 * Routine to use as callback for pcap_next()/pcap_next_ex().

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -351,6 +351,7 @@ static int pcap_read_linux(pcap_t *, int, pcap_handler, u_char *);
 static int pcap_read_packet(pcap_t *, pcap_handler, u_char *);
 static int pcap_inject_linux(pcap_t *, const void *, size_t);
 static int pcap_stats_linux(pcap_t *, struct pcap_stat *);
+static int pcap_stats_reset_linux(pcap_t *);
 static int pcap_setfilter_linux(pcap_t *, struct bpf_program *);
 static int pcap_setdirection_linux(pcap_t *, pcap_direction_t);
 static int pcap_set_datalink_linux(pcap_t *, int);
@@ -1518,6 +1519,7 @@ pcap_activate_linux(pcap_t *handle)
 	handle->cleanup_op = pcap_cleanup_linux;
 	handle->read_op = pcap_read_linux;
 	handle->stats_op = pcap_stats_linux;
+	handle->stats_op_reset = pcap_stats_reset_linux;
 
 	/*
 	 * The "any" device is a special device which causes us not
@@ -2150,6 +2152,16 @@ pcap_inject_linux(pcap_t *handle, const void *buf, size_t size)
 		return (-1);
 	}
 	return (ret);
+}
+
+static int
+pcap_stats_reset_linux(pcap_t *handle)
+{
+       struct pcap_linux *handlep = handle->priv;
+       handlep->stat.ps_ifdrop = 0;
+       handlep->stat.ps_recv  = 0;
+       handlep->stat.ps_drop = 0;
+       return 0;
 }
 
 /*

--- a/pcap.c
+++ b/pcap.c
@@ -2084,6 +2084,7 @@ initialize_ops(pcap_t *p)
 	p->set_datalink_op = (set_datalink_op_t)pcap_not_initialized;
 	p->getnonblock_op = (getnonblock_op_t)pcap_not_initialized;
 	p->stats_op = (stats_op_t)pcap_not_initialized;
+	p->stats_op_reset = (stats_op_reset_t)pcap_not_initialized;
 #ifdef _WIN32
 	p->stats_ex_op = (stats_ex_op_t)pcap_not_initialized_ptr;
 	p->setbuff_op = (setbuff_op_t)pcap_not_initialized;
@@ -3380,6 +3381,12 @@ pcap_setdirection(pcap_t *p, pcap_direction_t d)
 }
 
 int
+pcap_stats_reset(pcap_t *p)
+{
+       return (p->stats_op_reset(p));
+}
+
+int
 pcap_stats(pcap_t *p, struct pcap_stat *ps)
 {
 	return (p->stats_op(p, ps));
@@ -3752,6 +3759,14 @@ pcap_setnonblock_dead(pcap_t *p, int nonblock _U_)
 }
 
 static int
+pcap_stats_reset_dead(pcap_t *p)
+{
+	pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+	    "Statistics aren't available from a pcap_open_dead pcap_t");
+	return (-1);
+}
+
+static int
 pcap_stats_dead(pcap_t *p, struct pcap_stat *ps _U_)
 {
 	pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
@@ -3900,6 +3915,7 @@ pcap_open_dead_with_tstamp_precision(int linktype, int snaplen, u_int precision)
 	p->getnonblock_op = pcap_getnonblock_dead;
 	p->setnonblock_op = pcap_setnonblock_dead;
 	p->stats_op = pcap_stats_dead;
+	p->stats_op_reset = pcap_stats_reset_dead;
 #ifdef _WIN32
 	p->stats_ex_op = pcap_stats_ex_dead;
 	p->setbuff_op = pcap_setbuff_dead;

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -443,6 +443,7 @@ PCAP_API const u_char *pcap_next(pcap_t *, struct pcap_pkthdr *);
 PCAP_API int 	pcap_next_ex(pcap_t *, struct pcap_pkthdr **, const u_char **);
 PCAP_API void	pcap_breakloop(pcap_t *);
 PCAP_API int	pcap_stats(pcap_t *, struct pcap_stat *);
+PCAP_API int	pcap_stats_reset(pcap_t *);
 PCAP_API int	pcap_setfilter(pcap_t *, struct bpf_program *);
 PCAP_API int 	pcap_setdirection(pcap_t *, pcap_direction_t);
 PCAP_API int	pcap_getnonblock(pcap_t *, char *);


### PR DESCRIPTION
pcap_stats function get a stastic of pcap, but ps_recv, ps_drop, ps_ifdrop can be overflowed, so I add this api for pcap stats reset.