### PR TITLE
Check only VID in VLAN test (issue #461)

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -8234,12 +8234,15 @@ gen_vlan_patch_vid_test(compiler_state_t *cstate, struct block *b_vid)
 	sappend(s, s2);
 	sjeq->s.jt = s2;
 
-	/* jump to the test in b_vid (bypass loading VID from packet data) */
+	/* Jump to the test in b_vid. We need to jump one instruction before
+	 * the end of the b_vid block so that we only skip loading the TCI
+	 * from packet data and not the 'and' instruction extractging VID.
+	 */
 	cnt = 0;
 	for (s2 = b_vid->stmts; s2; s2 = s2->next)
 		cnt++;
 	s2 = new_stmt(cstate, JMP(BPF_JA));
-	s2->s.k = cnt;
+	s2->s.k = cnt - 1;
 	sappend(s, s2);
 
 	/* insert our statements at the beginning of b_vid */


### PR DESCRIPTION
The SKF_AD_VLAN_TAG value in metadata contains the whole TCI so that if we
want to use it for "vlan <id>" test, we need to apply 0xfff mask to compare
only VID.

Rather than adding another 'and' instruction, use existing one we already
have for the "not offloaded" case so that when patching block like e.g.

  (010) ldh      [14]
  (011) and      #0xfff
  (012) jeq      #0xb             jt 13   jf 14

we jump to (011) instead of (012).

Fixes: 04660eb1e561 ("Use BPF extensions in compiled filters")