### PR TITLE
Fix leak in rpcap

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -763,6 +763,8 @@ static void pcap_cleanup_rpcap(pcap_t *fp)
 		pr->currentfilter = NULL;
 	}
 
+	pcap_cleanup_live_common(fp);
+
 	/* To avoid inconsistencies in the number of sock_init() */
 	sock_cleanup();
 }


### PR DESCRIPTION
Hi there,

I got two leaks reported by [AddressSanitizer](https://clang.llvm.org/docs/AddressSanitizer.html) from an internal build while communicating with `rpcapd`.

The first from: https://github.com/the-tcpdump-group/libpcap/blob/1fb8e6197ec326da1a5e046c17aee6131f077202/pcap-rpcap.c#L1322
The second from: https://github.com/the-tcpdump-group/libpcap/blob/1fb8e6197ec326da1a5e046c17aee6131f077202/optimize.c#L2375

I gave a quick look around at other back-ends which seem to override `cleanup_op`: https://github.com/the-tcpdump-group/libpcap/blob/1fb8e6197ec326da1a5e046c17aee6131f077202/pcap-int.h#L293

Most of the time, they seem to call `pcap_cleanup_live_common`: https://github.com/the-tcpdump-group/libpcap/blob/1fb8e6197ec326da1a5e046c17aee6131f077202/pcap.c#L3618

Which, in turn, calls `pcap_freecode`: https://github.com/the-tcpdump-group/libpcap/blob/1fb8e6197ec326da1a5e046c17aee6131f077202/gencode.c#L805

This pull request fixes the two leaks I saw as the two functions above free the allocated resources. Of course, I only gave a quick glance so I'm probably wrong, but this seemed to fit into the design.

Regards.