### PR TITLE
Allow rpcapd to rebind more rapidly

### DIFF
--- a/sockutils.c
+++ b/sockutils.c
@@ -346,6 +346,18 @@ SOCKET sock_open(struct addrinfo *addrinfo, int server, int nconn, char *errbuf,
 	/* This is a server socket */
 	if (server)
 	{
+		/*
+		 * Allow a new server to bind the socket after the old one exited,
+		 * even if lingering sockets are still present.
+		 */
+		int optval = 1;
+		if (setsockopt(sock, SOL_SOCKET, SO_REUSEADDR, &optval, sizeof(optval)) < 0)
+		{
+			sock_geterror("socket(): ", errbuf, errbuflen);
+			/* dont treat an error as a failure */
+			SOCK_DEBUG_MESSAGE(errbuf);
+		}
+
 #if defined(IPV6_V6ONLY) || defined(IPV6_BINDV6ONLY)
 		/*
 		 * Force the use of IPv6-only addresses.


### PR DESCRIPTION
Sometimes rpcapd can't rebind due to lingering sockets, here is a basic patch to avoid some of the corner cases.

Closes #765.