### PR TITLE
Set keepalives on rpcap's control socket

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -3531,9 +3531,9 @@ pcap_set_control_keepalive(pcap_t *p, int enable, int keepcnt, int keepidle, int
 		return 0;
 
 #if defined(TCP_KEEPCNT) && defined(TCP_KEEPIDLE) && defined(TCP_KEEPINTVL)
-	if (setsockopt(pr->rmt_sockctrl, SOL_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt)) < 0 ||
-	    setsockopt(pr->rmt_sockctrl, SOL_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0 ||
-	    setsockopt(pr->rmt_sockctrl, SOL_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0)
+	if (setsockopt(pr->rmt_sockctrl, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt)) < 0 ||
+	    setsockopt(pr->rmt_sockctrl, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0 ||
+	    setsockopt(pr->rmt_sockctrl, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0)
 	{
 		sock_geterror("setsockopt(): ", p->errbuf, PCAP_ERRBUF_SIZE);
 		return -1;

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -3523,7 +3523,7 @@ pcap_set_control_keepalive(pcap_t *p, int enable, int keepcnt, int keepidle, int
 	if (setsockopt(pr->rmt_sockctrl, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) < 0)
 	{
 		sock_geterror("setsockopt(): ", p->errbuf, PCAP_ERRBUF_SIZE);
-		return -1;
+		return PCAP_ERROR;
 	}
 
 	/* when SO_KEEPALIVE isn't active, the following options aren't used */
@@ -3536,14 +3536,14 @@ pcap_set_control_keepalive(pcap_t *p, int enable, int keepcnt, int keepidle, int
 	    setsockopt(pr->rmt_sockctrl, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0)
 	{
 		sock_geterror("setsockopt(): ", p->errbuf, PCAP_ERRBUF_SIZE);
-		return -1;
+		return PCAP_ERROR;
 	}
 #else
 	if (keepcnt || keepidle || keepintvl)
 	{
 		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 		    "TCP_KEEPCNT, TCP_KEEPIDLE or TCP_KEEPINTVL not supported on this platform");
-		return -1;
+		return PCAP_ERROR;
 	}
 #endif
 

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -3541,7 +3541,7 @@ pcap_set_control_keepalive(pcap_t *p, int enable, int keepcnt, int keepidle, int
 #else
 	if (keepcnt || keepidle || keepintvl)
 	{
-		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 		    "TCP_KEEPCNT, TCP_KEEPIDLE or TCP_KEEPINTVL not supported on this platform");
 		return -1;
 	}

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -432,6 +432,7 @@ PCAP_API int	pcap_get_tstamp_precision(pcap_t *);
 
 PCAP_AVAILABLE_1_0
 PCAP_API int	pcap_activate(pcap_t *);
+PCAP_API int	pcap_set_control_keepalive(pcap_t *, int, int, int, int);
 
 PCAP_AVAILABLE_1_2
 PCAP_API int	pcap_list_tstamp_types(pcap_t *, int **);


### PR DESCRIPTION
Would you be interested in the following extension of libpcap's API? It builds up on #772 and closes #766 (but doesn't hard-code anything in libpcap and leave it to the users, which seems to be a much more sensible approach).

Since #772 now verifies the integrity of the TCP control connection, optionally allowing keep-alives on it will allow to more efficiently react on a broken network connectivity (the data being transported over UDP or TCP).
If you prefer this commit to follow #772, feel free to close this pull request (but #772 is useful on its own for UDP-based data transport when the network is regarded as perfect).

On Linux, it seems the first keep-alive is sent after 2 hours of idling and a broken connection will be detected 20 minutes later (from `man 7 tcp`), if and only if `SO_KEEPALIVE` is set, so a libpcap application retrieving packets from a remote rpcapd may be stuck for quite a long while.

The usage is quite simple: `pcap_set_control_keepalive` (happy to get suggestions about a better name) needs to be called after a successful `pcap_open` with some values (for example, something more aggressive but still reasonable would be `pcap_set_control_keepalive(handle, 1, 5, 15, 5)` which would wait 15 seconds of idle time before sending a keep-alive, dropping the connection after 5 missed keep-alives each one spaced by 5 seconds).

The keep-alives settings probably only works on Linux.

If the idea is validated, I'll push another commit for the corresponding man pages.
