### PR TITLE
Initializing np value to NULL

### DIFF
--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -239,7 +239,7 @@ pcap_nametonetaddr(const char *name)
 	/*
 	 * UN*X.
 	 */
-	struct netent *np;
+	struct netent *np = NULL;
   #if defined(HAVE_LINUX_GETNETBYNAME_R)
 	/*
 	 * We have Linux's reentrant getnetbyname_r().


### PR DESCRIPTION
Found by oss-fuzz :
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10919

Apparently, we cannot trust libc to assign value in `getnetbyname_r` even when it returns no error

So, the fix is simple

PS : @guyharris 👍 for all the fixes so far