### PR TITLE
Avois integer multiplication overflow

### DIFF
--- a/scanner.l
+++ b/scanner.l
@@ -23,6 +23,7 @@
  * <inttypes.h> if we have it.
  */
 #include <pcap/pcap-inttypes.h>
+#include <limits.h>
 
 #include "diag-control.h"
 }
@@ -520,8 +521,12 @@ stoi(char *s)
 			s += 1;
 		}
 	}
-	while (*s)
+	while (*s) {
+		if (n > (INT_MAX - 0xFF)/base) {
+			return 0;
+		}
 		n = n * base + xdtoi(*s++);
+	}
 
 	return n;
 }


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=10921

Just use filter "9999999999999999" ro reproduce