### PR TITLE
Avoids integer overflow in bpf optimization

### DIFF
--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -58,7 +58,6 @@
 #include <pcap-int.h>
 
 #include <stdlib.h>
-#include <limits.h>
 
 #ifdef __linux__
 #include <linux/types.h>
@@ -362,7 +361,7 @@ pcap_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			 * can't be unsigned; throw some casts to
 			 * specify what we're trying to do.
 			 */
-			if (A > INT_MAX) {
+			if (A == 0x80000000) {
 				return 0;
 			}
 			A = (uint32_t)(-(int32_t)A);

--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -361,10 +361,7 @@ pcap_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			 * can't be unsigned; throw some casts to
 			 * specify what we're trying to do.
 			 */
-			if (A == 0x80000000) {
-				return 0;
-			}
-			A = (uint32_t)(-(int32_t)A);
+			A = 0U - A;
 			continue;
 
 		case BPF_MISC|BPF_TAX:

--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -58,6 +58,7 @@
 #include <pcap-int.h>
 
 #include <stdlib.h>
+#include <limits.h>
 
 #ifdef __linux__
 #include <linux/types.h>
@@ -361,6 +362,9 @@ pcap_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			 * can't be unsigned; throw some casts to
 			 * specify what we're trying to do.
 			 */
+			if (A > INT_MAX) {
+				return 0;
+			}
 			A = (uint32_t)(-(int32_t)A);
 			continue;
 

--- a/optimize.c
+++ b/optimize.c
@@ -31,7 +31,6 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <string.h>
-#include <limits.h>
 
 #include <errno.h>
 
@@ -1143,7 +1142,7 @@ opt_stmt(opt_state_t *opt_state, struct stmt *s, int val[], int alter)
 	case BPF_ALU|BPF_NEG:
 		if (alter && opt_state->vmap[val[A_ATOM]].is_const) {
 			s->code = BPF_LD|BPF_IMM;
-			if (opt_state->vmap[val[A_ATOM]].const_val > INT_MAX) {
+			if (opt_state->vmap[val[A_ATOM]].const_val == 0x80000000) {
 				opt_error(opt_state, "integer overflow");
 				break;
 			}

--- a/optimize.c
+++ b/optimize.c
@@ -1144,7 +1144,7 @@ opt_stmt(opt_state_t *opt_state, struct stmt *s, int val[], int alter)
 		if (alter && opt_state->vmap[val[A_ATOM]].is_const) {
 			s->code = BPF_LD|BPF_IMM;
 			if (opt_state->vmap[val[A_ATOM]].const_val > INT_MAX) {
-				opt_error(cstate, opt_state, "integer overflow");
+				opt_error(opt_state, "integer overflow");
 				break;
 			}
 			s->k = -opt_state->vmap[val[A_ATOM]].const_val;

--- a/optimize.c
+++ b/optimize.c
@@ -1142,11 +1142,7 @@ opt_stmt(opt_state_t *opt_state, struct stmt *s, int val[], int alter)
 	case BPF_ALU|BPF_NEG:
 		if (alter && opt_state->vmap[val[A_ATOM]].is_const) {
 			s->code = BPF_LD|BPF_IMM;
-			if (opt_state->vmap[val[A_ATOM]].const_val == 0x80000000) {
-				opt_error(opt_state, "integer overflow");
-				break;
-			}
-			s->k = -opt_state->vmap[val[A_ATOM]].const_val;
+			s->k = 0U - (uint32_t)opt_state->vmap[val[A_ATOM]].const_val;
 			val[A_ATOM] = K(s->k);
 		}
 		else

--- a/optimize.c
+++ b/optimize.c
@@ -31,6 +31,7 @@
 #include <stdlib.h>
 #include <memory.h>
 #include <string.h>
+#include <limits.h>
 
 #include <errno.h>
 
@@ -1142,6 +1143,10 @@ opt_stmt(opt_state_t *opt_state, struct stmt *s, int val[], int alter)
 	case BPF_ALU|BPF_NEG:
 		if (alter && opt_state->vmap[val[A_ATOM]].is_const) {
 			s->code = BPF_LD|BPF_IMM;
+			if (opt_state->vmap[val[A_ATOM]].const_val > INT_MAX) {
+				opt_error(cstate, opt_state, "integer overflow");
+				break;
+			}
 			s->k = -opt_state->vmap[val[A_ATOM]].const_val;
 			val[A_ATOM] = K(s->k);
 		}


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=11106

We cannot minus an unsigned integer greater than 0x80000000 so we report an error