### PR TITLE
add functions to force a cooked capture

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -170,6 +170,7 @@ struct pcap_opt {
 	int	nonblock;	/* non-blocking mode - don't wait for packets to be delivered, return "no packets available" */
 	int	tstamp_type;
 	int	tstamp_precision;
+	int	cook;
 
 	/*
 	 * Platform-dependent options.

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -2389,6 +2389,7 @@ activate_pf_packet(pcap_t *handle, int is_any_device)
 		}
 		map_arphrd_to_dlt(handle, arptype, device, 1);
 		if (handle->linktype == -1 ||
+		    handle->opt.cook ||
 		    handle->linktype == DLT_LINUX_SLL ||
 		    handle->linktype == DLT_LINUX_IRDA ||
 		    handle->linktype == DLT_LINUX_LAPD ||

--- a/pcap.c
+++ b/pcap.c
@@ -2704,6 +2704,11 @@ pcap_get_tstamp_precision(pcap_t *p)
         return (p->opt.tstamp_precision);
 }
 
+void pcap_cook(pcap_t *handle)
+{
+	handle->opt.cook = 1;
+}
+
 int
 pcap_activate(pcap_t *p)
 {

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -447,6 +447,7 @@ PCAP_API const char *pcap_tstamp_type_val_to_name(int);
 
 PCAP_AVAILABLE_1_2
 PCAP_API const char *pcap_tstamp_type_val_to_description(int);
+PCAP_API void	pcap_cook(pcap_t *);
 
 #ifdef __linux__
 PCAP_AVAILABLE_1_9


### PR DESCRIPTION
This is a prerequisite for tcpdump to show the packets direction