### PR TITLE
pcap 1.9.0 does not work on AIX

### DIFF
--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -1366,8 +1366,8 @@ bpf_load(char *errbuf)
 
 	/* Check if the driver is loaded */
 	memset(&cfg_ld, 0x0, sizeof(cfg_ld));
+	pcap_snprintf(buf, sizeof(buf), "%s/%s", DRIVER_PATH, BPF_NAME);
 	cfg_ld.path = buf;
-	pcap_snprintf(cfg_ld.path, sizeof(cfg_ld.path), "%s/%s", DRIVER_PATH, BPF_NAME);
 	if ((sysconfig(SYS_QUERYLOAD, (void *)&cfg_ld, sizeof(cfg_ld)) == -1) ||
 	    (cfg_ld.kmid == 0)) {
 		/* Driver isn't loaded, load it now */


### PR DESCRIPTION
**Steps to reproduce:**
1. Invoke `pcap_open_live("en3", ...)`.

**Expected result:**
1. pcap handle opened successfully.

**Actual result:**
1. `pcap_open_live()` result is NULL, error string is "en3: bpf_load: could not load driver: No such file or directory".

**Analysis**
`sysconfig` called with an invalid kernel extension path. Reason: invalid usage of `sizeof` on a pointer in `bpf_load()` while generating path.
Regression introduced in commit 2d6437c54b9baa77562fc2ae7fc46fb329893441.