### PR TITLE
bt-typo: Extra word existed in comment and minor message fix-ups

### DIFF
--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -81,7 +81,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 	sock  = socket(AF_BLUETOOTH, SOCK_RAW, BTPROTO_HCI);
 	if (sock < 0)
 	{
-		/* if bluetooth is not supported this this is not fatal*/
+		/* if bluetooth is not supported this is not fatal*/
 		if (errno == EAFNOSUPPORT)
 			return 0;
 		pcap_fmt_errmsg_for_errno(err_str, PCAP_ERRBUF_SIZE,
@@ -380,8 +380,8 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 static int
 bt_inject_linux(pcap_t *handle, const void *buf _U_, int size _U_)
 {
-	pcap_snprintf(handle->errbuf, PCAP_ERRBUF_SIZE, "inject not supported on "
-    		"bluetooth devices");
+	pcap_snprintf(handle->errbuf, PCAP_ERRBUF_SIZE, "Inject not supported on "
+    		"Bluetooth devices");
 	return (-1);
 }
 


### PR DESCRIPTION
Minor typo in the comments for error checking if a Bluetooth socket was opened.
One minor consistency fix-up in `pcap_snprintf()`.