### PR TITLE
Make CMake work for an installed DPDK on Ubuntu.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1427,34 +1427,14 @@ endif()
 
 # Check for DPDK sniffing support
 if (NOT DISABLE_DPDK)
-	if (NOT DEFINED DPDK_DIR)
-		set(DPDK_INC_DIR /usr/local/include/dpdk)
-		set(DPDK_LIB_DIR /usr/local/lib)
-	else()
-		set(DPDK_INC_DIR ${DPDK_DIR}/include)
-		set(DPDK_LIB_DIR ${DPDK_DIR}/lib)
-	endif()
-	set(DPDK_C_FLAGS "-march=native")
-	set(DPDK_LIB dpdk rt m numa dl)
-	
-	cmake_push_check_state()
-	set(CMAKE_REQUIRED_FLAGS "-L${DPDK_LIB_DIR}")
-	set(CMAKE_REQUIRED_INCLUDES ${DPDK_INC_DIR})
-	set(CMAKE_REQUIRED_LIBRARIES ${DPDK_LIB})
-	check_c_source_compiles(
-"
-#include <rte_common.h>
-int main(){
-    return 0;
-}
-"	
-	PCAP_SUPPORT_DPDK)
-	cmake_pop_check_state()
-	if (PCAP_SUPPORT_DPDK)
+	find_package(dpdk)
+	if (dpdk_FOUND)
+                set(DPDK_C_FLAGS "-march=native")
+                set(DPDK_LIB dpdk rt m numa dl)
 		set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} ${DPDK_C_FLAGS})
-		include_directories(AFTER ${DPDK_INC_DIR})
-		link_directories(AFTER ${DPDK_LIB_DIR})
-		set(PCAP_LINK_LIBRARIES ${PCAP_LINK_LIBRARIES} ${DPDK_LIB})
+		include_directories(AFTER ${dpdk_INCLUDE_DIRS})
+		link_directories(AFTER ${dpdk_LIBRARIES})
+		set(PCAP_LINK_LIBRARIES ${PCAP_LINK_LIBRARIES} ${dpdk_LIBRARIES})
 		set(PROJECT_SOURCE_LIST_C ${PROJECT_SOURCE_LIST_C} pcap-dpdk.c)
 	endif()
 endif()
@@ -1509,7 +1489,6 @@ if(NOT DISABLE_DBUS)
     if(APPLE)
         message(FATAL_ERROR "Due to freedesktop.org bug 74029, D-Bus capture support is not available on macOS")
     endif(APPLE)
-    include(FindPkgConfig)
     pkg_check_modules(DBUS dbus-1)
     if(DBUS_FOUND)
         set(PCAP_SUPPORT_DBUS TRUE)

--- a/Makefile.in
+++ b/Makefile.in
@@ -250,6 +250,7 @@ EXTRA_DIST = \
 	cmake_uninstall.cmake.in \
 	cmakeconfig.h.in \
 	cmake/Modules/FindDAG.cmake \
+	cmake/Modules/Finddpdk.cmake \
 	cmake/Modules/FindFseeko.cmake \
 	cmake/Modules/FindLFS.cmake \
 	cmake/Modules/FindPacket.cmake \

--- a/cmake/Modules/Finddpdk.cmake
+++ b/cmake/Modules/Finddpdk.cmake
@@ -1,0 +1,117 @@
+# Try to find dpdk
+#
+# Once done, this will define
+#
+# dpdk_FOUND
+# dpdk_INCLUDE_DIRS
+# dpdk_LIBRARIES
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(dpdk QUIET libdpdk)
+endif()
+
+message(STATUS "Executing Finddpdk")
+if(NOT dpdk_INCLUDE_DIRS)
+  message(STATUS "Executing find_path")
+  find_path(dpdk_config_INCLUDE_DIR rte_config.h
+    HINTS
+      ENV DPDK_DIR
+    PATH_SUFFIXES
+      dpdk
+      include
+)
+  find_path(dpdk_common_INCLUDE_DIR rte_common.h
+    HINTS
+      ENC DPDK_DIR
+    PATH_SUFFIXES
+      dpdk
+      include
+)
+  set(dpdk_INCLUDE_DIRS "${dpdk_config_INCLUDE_DIR}")
+  if(NOT dpdk_config_INCLUDE_DIR EQUAL dpdk_common_INCLUDE_DIR)
+    list(APPEND dpdk_INCLUDE_DIRS "${dpdk_common_INCLUDE_DIR}")
+  endif()
+endif()
+
+set(components
+  bus_pci
+  cmdline
+  eal
+  ethdev
+  hash
+  kvargs
+  mbuf
+  mempool
+  mempool_ring
+  mempool_stack
+  pci
+  pmd_af_packet
+  pmd_bond
+  pmd_i40e
+  pmd_ixgbe
+  pmd_mlx5
+  pmd_ring
+  pmd_vmxnet3_uio
+  ring)
+
+set(dpdk_LIBRARIES)
+
+foreach(c ${components})
+  find_library(DPDK_rte_${c}_LIBRARY rte_${c}
+    HINTS
+      ENV DPDK_DIR
+      ${dpdk_LIBRARY_DIRS}
+    PATH_SUFFIXES lib)
+  if(DPDK_rte_${c}_LIBRARY)
+    set(dpdk_lib dpdk::${c})
+    if (NOT TARGET ${dpdk_lib})
+      add_library(${dpdk_lib} UNKNOWN IMPORTED)
+      set_target_properties(${dpdk_lib} PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${dpdk_INCLUDE_DIRS}"
+        IMPORTED_LOCATION "${DPDK_rte_${c}_LIBRARY}")
+      if(c STREQUAL pmd_mlx5)
+        find_package(verbs QUIET)
+        if(verbs_FOUND)
+          target_link_libraries(${dpdk_lib} INTERFACE IBVerbs::verbs)
+        endif()
+      endif()
+    endif()
+    list(APPEND dpdk_LIBRARIES ${dpdk_lib})
+  endif()
+endforeach()
+
+mark_as_advanced(dpdk_INCLUDE_DIRS ${dpdk_LIBRARIES})
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(dpdk DEFAULT_MSG
+  dpdk_INCLUDE_DIRS
+  dpdk_LIBRARIES)
+
+if(dpdk_FOUND)
+  if(NOT TARGET dpdk::cflags)
+     if(CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64|AMD64")
+      set(rte_cflags "-march=core2")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "arm|ARM")
+      set(rte_cflags "-march=armv7-a")
+    elseif(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64|AARCH64")
+      set(rte_cflags "-march=armv8-a+crc")
+    endif()
+    add_library(dpdk::cflags INTERFACE IMPORTED)
+    if (rte_cflags)
+      set_target_properties(dpdk::cflags PROPERTIES
+        INTERFACE_COMPILE_OPTIONS "${rte_cflags}")
+    endif()
+  endif()
+
+  if(NOT TARGET dpdk::dpdk)
+    add_library(dpdk::dpdk INTERFACE IMPORTED)
+    find_package(Threads QUIET)
+    list(APPEND dpdk_LIBRARIES
+      Threads::Threads
+      dpdk::cflags)
+    set_target_properties(dpdk::dpdk PROPERTIES
+      INTERFACE_LINK_LIBRARIES "${dpdk_LIBRARIES}"
+      INTERFACE_INCLUDE_DIRECTORIES "${dpdk_INCLUDE_DIRS}")
+  endif()
+endif()


### PR DESCRIPTION
DPDK (EAL: RTE Version: 'DPDK 18.11.0')can be installed on Ubuntu 18.04 by adding this line
 to /etc/apt/sources.list
deb [trusted=yes] http://ftp.se.debian.org/debian/ testing main contrib
and doing sudo apt-get install dpdk dpdk-dev