### PR TITLE
Add support for DSA link-layer types

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1141,7 +1141,13 @@
  */
 #define LINKTYPE_VPP_DISPATCH	280
 
-#define LINKTYPE_MATCHING_MAX	280		/* highest value in the "matching" range */
+/*
+ * Broadcom Ethernet switches (ROBO switch) 4 bytes proprietary tagging format.
+ */
+#define LINKTYPE_DSA_TAG_BRCM	281
+#define LINKTYPE_DSA_TAG_BRCM_PREPEND	282
+
+#define LINKTYPE_MATCHING_MAX	282		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3002,6 +3002,8 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(LINUX_SLL2, "Linux cooked v2"),
 	DLT_CHOICE(OPENVIZSLA, "OpenVizsla USB"),
 	DLT_CHOICE(EBHSCR, "Elektrobit High Speed Capture and Replay (EBHSCR)"),
+	DLT_CHOICE(DSA_TAG_BRCM, "Broadcom tag"),
+	DLT_CHOICE(DSA_TAG_BRCM_PREPEND, "Broadcom tag (prepended)"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1427,6 +1427,12 @@
 #define DLT_VPP_DISPATCH	280
 
 /*
+ * Broadcom Ethernet switches (ROBO switch) 4 bytes proprietary tagging format.
+ */
+#define DLT_DSA_TAG_BRCM	281
+#define DLT_DSA_TAG_BRCM_PREPEND	282
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1436,7 +1442,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	280	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	282	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
Linux kernel 4.20 and greater can report what type of Distributed Switch
Architecture tagging protocol is used on the DSA master/management
interface. We need to map the protocol to a specific DLT and linktype
value in the pcap file because these protocols typically cannot be
decoded simply by making use of heuristics. The sysfs attribute that is
being checked and parsed is documented in this commit:

https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a3d7e01da06013dc580641a1da57c3b482d58157