### PR TITLE
DPDK: Fix compilation.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -162,6 +162,7 @@ before_install:
   - uname -a
   - date
   - eval "${MATRIX_EVAL}"
+  - env
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,22 @@
 sudo: false
 language: c
 
-os:
-  - linux
-  - osx
-
-compiler:
-  - gcc
-  - clang
+#
+# On macOS:
+#
+#  gcc is an alias for clang;
+#  the "distribution" doesn't matter;
+#
+# so we set up a ccustom matrix to avoid redundant builds.
+#
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      compiler: gcc
+      env: REMOTE=disable CMAKE=yes
 
 env:
   global:
@@ -20,11 +29,6 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
-  matrix:
-    - REMOTE=disable CMAKE=no
-    - ENABLE_REMOTE="" CMAKE=yes
-    - REMOTE=enable CMAKE=no
-    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 matrix:
   fast_finish: true
@@ -67,6 +71,7 @@ git:
 before_install:
   - uname -a
   - date
+  - eval "${MATRIX_EVAL}"
   - env
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,269 +1,13 @@
 sudo: false
 language: c
 
-#
-# On macOS:
-#
-#  gcc is an alias for clang;
-#  the "distribution" doesn't matter;
-#
-# so we set up a custom matrix to avoid redundant builds.
-#
-# We build on:
-#
-#    Ubuntu Trusty, with the default GCC and clang, and with APT
-#    developer packages for libusb-1.0-0, libdbus-glib-1, libbluetooth,
-#    libnl-genl-3, libibverbs, and libnuma;
-#
-#    Ubuntu Xenial, with the default GCC and clang, and with APT
-#    developer packages for libusb-1.0-0, libdbus-glib-1, libbluetooth,
-#    libnl-genl-3, libibverbs, libnuma, and DPDK;
-#
-#    the default macOS, with the default clang.
-#
-# (We can't use dpdk-dev with trusty, only in xenial; Trusty didn't
-# have DPDK support.)
-#
-matrix:
-  fast_finish: true
-  include:
-    # autotools, no remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: REMOTE=disable CMAKE=no
-    - os: osx
-      compiler: clang
-      env: REMOTE=disable CMAKE=no
+os:
+  - linux
+  - osx
 
-    # CMake, no remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: osx
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
-
-    # autotools, remote capture support
-    # This is the only configuration for which we do Coverity scan stuff
-    # and we only do that on Xenial with GCC.
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: REMOTE=enable CMAKE=no
-    - os: osx
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-
-    # CMake, remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - libusb-1.0-0-dev
-            - libdbus-glib-1-dev
-            - libbluetooth-dev
-            - libnl-genl-3-dev
-            - libibverbs-dev
-            - libnuma-dev
-            - dpdk-dev
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: osx
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+compiler:
+  - gcc
+  - clang
 
 env:
   global:
@@ -276,6 +20,14 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
+  matrix:
+    - REMOTE=disable CMAKE=no
+    - ENABLE_REMOTE="" CMAKE=yes
+    - REMOTE=enable CMAKE=no
+    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+
+matrix:
+  fast_finish: true
 
 addons:
   coverity_scan:
@@ -295,6 +47,18 @@ addons:
     build_command: make
     # Pattern to match selecting branches that will run analysis
     branch_pattern: coverity_scan
+  apt:
+    #
+    # We can't use dpdk-dev with trusty, only in xenial; Trusty didn't
+    # have DPDK support.
+    #
+    packages:
+      - libusb-1.0-0-dev
+      - libdbus-glib-1-dev
+      - libbluetooth-dev
+      - libnl-genl-3-dev
+      - libibverbs-dev
+      - libnuma-dev
 
 git:
   quiet: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
   - linux
   - osx
 
-dist:
-  - trusty
-  - xenial
+#dist:
+#  - trusty
+#  - xenial
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,102 +11,82 @@ language: c
 #
 matrix:
   include:
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
+    - os: macos
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: macos
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+    - os: macos
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: macos
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,269 @@
 sudo: false
 language: c
 
-os:
-  - linux
-  - osx
+#
+# On macOS:
+#
+#  gcc is an alias for clang;
+#  the "distribution" doesn't matter;
+#
+# so we set up a custom matrix to avoid redundant builds.
+#
+# We build on:
+#
+#    Ubuntu Trusty, with the default GCC and clang, and with APT
+#    developer packages for libusb-1.0-0, libdbus-glib-1, libbluetooth,
+#    libnl-genl-3, libibverbs, and libnuma;
+#
+#    Ubuntu Xenial, with the default GCC and clang, and with APT
+#    developer packages for libusb-1.0-0, libdbus-glib-1, libbluetooth,
+#    libnl-genl-3, libibverbs, libnuma, and DPDK;
+#
+#    the default macOS, with the default clang.
+#
+# (We can't use dpdk-dev with trusty, only in xenial; Trusty didn't
+# have DPDK support.)
+#
+matrix:
+  fast_finish: true
+  include:
+    # autotools, no remote capture support
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: REMOTE=disable CMAKE=no
+    - os: osx
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
 
-dist:
-  - trusty
-  - xenial
+    # CMake, no remote capture support
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: osx
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
 
-compiler:
-  - gcc
-  - clang
+    # autotools, remote capture support
+    # This is the only configuration for which we do Coverity scan stuff
+    # and we only do that on Xenial with GCC.
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: REMOTE=enable CMAKE=no
+    - os: osx
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+
+    # CMake, remote capture support
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: clang
+      addons:
+        apt:
+          packages:
+            - libusb-1.0-0-dev
+            - libdbus-glib-1-dev
+            - libbluetooth-dev
+            - libnl-genl-3-dev
+            - libibverbs-dev
+            - libnuma-dev
+            - dpdk-dev
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: osx
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 env:
   global:
@@ -24,14 +276,6 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
-  matrix:
-    - REMOTE=disable CMAKE=no
-    - ENABLE_REMOTE="" CMAKE=yes
-    - REMOTE=enable CMAKE=no
-    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-
-matrix:
-  fast_finish: true
 
 addons:
   coverity_scan:
@@ -51,18 +295,6 @@ addons:
     build_command: make
     # Pattern to match selecting branches that will run analysis
     branch_pattern: coverity_scan
-  apt:
-    #
-    # We can't use dpdk-dev with trusty, only in xenial; Trusty didn't
-    # have DPDK support.
-    #
-    packages:
-      - libusb-1.0-0-dev
-      - libdbus-glib-1-dev
-      - libbluetooth-dev
-      - libnl-genl-3-dev
-      - libibverbs-dev
-      - libnuma-dev
 
 git:
   quiet: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,10 +30,18 @@ matrix:
     - os: linux
       dist: xenial
       compiler: gcc
+      addons:
+        apt:
+          packages:
+            - dpdk-dev
       env: REMOTE=disable CMAKE=no
     - os: linux
       dist: xenial
       compiler: clang
+      addons:
+        apt:
+          packages:
+            - dpdk-dev
       env: REMOTE=disable CMAKE=no
     - os: osx
       compiler: clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,92 +1,13 @@
 sudo: false
 language: c
 
-#
-# On macOS:
-#
-#  gcc is an alias for clang;
-#  the "distribution" doesn't matter;
-#
-# so we set up a ccustom matrix to avoid redundant builds.
-#
-matrix:
-  include:
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: REMOTE=disable CMAKE=no
-    - os: macos
-      compiler: clang
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: macos
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-    - os: macos
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: macos
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
 
 env:
   global:
@@ -99,6 +20,11 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
+  matrix:
+    - REMOTE=disable CMAKE=no
+    - ENABLE_REMOTE="" CMAKE=yes
+    - REMOTE=enable CMAKE=no
+    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 matrix:
   fast_finish: true
@@ -141,7 +67,6 @@ git:
 before_install:
   - uname -a
   - date
-  - eval "${MATRIX_EVAL}"
   - env
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,102 +11,102 @@ language: c
 #
 matrix:
   include:
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-  - os: linux
-    dist: trusty
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-  - os: linux
-    dist: trusty
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: gcc
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-  - os: linux
-    dist: xenial
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-  - os: macos
-    compiler: clang
-    env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env:
+        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+    - os: macos
+      compiler: clang
+      env:
+        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+    - os: macos
+      compiler: clang
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env:
+        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+    - os: macos
+      compiler: clang
+      env:
+        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+   - os: macos
+      compiler: clang
+      env:
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ os:
   - linux
   - osx
 
-#dist:
-#  - trusty
-#  - xenial
+dist:
+  - trusty
+  - xenial
 
 compiler:
   - gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,92 @@
 sudo: false
 language: c
 
-os:
-  - linux
-  - osx
-
-compiler:
-  - gcc
-  - clang
+#
+# On macOS:
+#
+#  gcc is an alias for clang;
+#  the "distribution" doesn't matter;
+#
+# so we set up a ccustom matrix to avoid redundant builds.
+#
+matrix:
+  include:
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env: REMOTE=disable CMAKE=no
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env: REMOTE=disable CMAKE=no
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env: REMOTE=disable CMAKE=no
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env: REMOTE=disable CMAKE=no
+  - os: macos
+    compiler: clang
+    env: REMOTE=disable CMAKE=no
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env: ENABLE_REMOTE="" CMAKE=yes
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env: ENABLE_REMOTE="" CMAKE=yes
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env: ENABLE_REMOTE="" CMAKE=yes
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env: ENABLE_REMOTE="" CMAKE=yes
+  - os: macos
+    compiler: clang
+    env: ENABLE_REMOTE="" CMAKE=yes
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env: REMOTE=enable CMAKE=no
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env: REMOTE=enable CMAKE=no
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env: REMOTE=enable CMAKE=no
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env: REMOTE=enable CMAKE=no
+  - os: macos
+    compiler: clang
+    env: REMOTE=enable CMAKE=no
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+  - os: macos
+    compiler: clang
+    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 env:
   global:
@@ -20,11 +99,6 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
-  matrix:
-    - REMOTE=disable CMAKE=no
-    - ENABLE_REMOTE="" CMAKE=yes
-    - REMOTE=enable CMAKE=no
-    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -161,6 +161,7 @@ git:
 before_install:
   - uname -a
   - date
+  - eval "${MATRIX_EVAL}"
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,98 +15,98 @@ matrix:
     dist: trusty
     compiler: gcc
     env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
   - os: linux
     dist: trusty
     compiler: clang
     env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
   - os: macos
     compiler: clang
     env:
-      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
   - os: linux
     dist: trusty
     compiler: clang
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
   - os: macos
     compiler: clang
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
   - os: linux
     dist: trusty
     compiler: clang
     env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
   - os: macos
     compiler: clang
     env:
-      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+      - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
   - os: linux
     dist: trusty
     compiler: gcc
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
   - os: linux
     dist: trusty
     compiler: clang
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: gcc
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: clang
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
   - os: macos
     compiler: clang
     env:
-      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,87 @@ language: c
 #  gcc is an alias for clang;
 #  the "distribution" doesn't matter;
 #
-# so we set up a ccustom matrix to avoid redundant builds.
+# so we set up a custom matrix to avoid redundant builds.
 #
 matrix:
+  fast_finish: true
   include:
     - os: linux
+      dist: trusty
       compiler: gcc
       env: REMOTE=disable CMAKE=no
     - os: linux
+      dist: trusty
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: xenial
       compiler: gcc
-      env: REMOTE=disable CMAKE=yes
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
+    - os: macos
+      compiler: clang
+      env: REMOTE=disable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: macos
+      compiler: clang
+      env: ENABLE_REMOTE="" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+    - os: macos
+      compiler: clang
+      env: REMOTE=enable CMAKE=no
+    - os: linux
+      dist: trusty
+      compiler: gcc
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: trusty
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: gcc
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: linux
+      dist: xenial
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - os: macos
+      compiler: clang
+      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
 env:
   global:
@@ -29,9 +100,6 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
-
-matrix:
-  fast_finish: true
 
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,79 +14,99 @@ matrix:
   - os: linux
     dist: trusty
     compiler: gcc
-    env: REMOTE=disable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
   - os: linux
     dist: trusty
     compiler: clang
-    env: REMOTE=disable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
   - os: linux
     dist: xenial
     compiler: gcc
-    env: REMOTE=disable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
   - os: linux
     dist: xenial
     compiler: clang
-    env: REMOTE=disable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
   - os: macos
     compiler: clang
-    env: REMOTE=disable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
   - os: linux
     dist: trusty
     compiler: gcc
-    env: ENABLE_REMOTE="" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
   - os: linux
     dist: trusty
     compiler: clang
-    env: ENABLE_REMOTE="" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: gcc
-    env: ENABLE_REMOTE="" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: clang
-    env: ENABLE_REMOTE="" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
   - os: macos
     compiler: clang
-    env: ENABLE_REMOTE="" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
   - os: linux
     dist: trusty
     compiler: gcc
-    env: REMOTE=enable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
   - os: linux
     dist: trusty
     compiler: clang
-    env: REMOTE=enable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
   - os: linux
     dist: xenial
     compiler: gcc
-    env: REMOTE=enable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
   - os: linux
     dist: xenial
     compiler: clang
-    env: REMOTE=enable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
   - os: macos
     compiler: clang
-    env: REMOTE=enable CMAKE=no
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
   - os: linux
     dist: trusty
     compiler: gcc
-    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
   - os: linux
     dist: trusty
     compiler: clang
-    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: gcc
-    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
   - os: linux
     dist: xenial
     compiler: clang
-    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
   - os: macos
     compiler: clang
-    env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,16 @@ language: c
 #
 # so we set up a custom matrix to avoid redundant builds.
 #
+# We build on:
+#
+#    Ubuntu Trusty, with the default GCC and clang;
+#    Ubuntu Xenial, with the default GCC and clang;
+#    the default macOS, with the default clang.
+#
 matrix:
   fast_finish: true
   include:
+    # autotools, no remote capture support
     - os: linux
       dist: trusty
       compiler: gcc
@@ -28,9 +35,11 @@ matrix:
       dist: xenial
       compiler: clang
       env: REMOTE=disable CMAKE=no
-    - os: macos
+    - os: osx
       compiler: clang
       env: REMOTE=disable CMAKE=no
+
+    # CMake, no remote capture support
     - os: linux
       dist: trusty
       compiler: gcc
@@ -47,9 +56,11 @@ matrix:
       dist: xenial
       compiler: clang
       env: ENABLE_REMOTE="" CMAKE=yes
-    - os: macos
+    - os: osx
       compiler: clang
       env: ENABLE_REMOTE="" CMAKE=yes
+
+    # autotools, remote capture support
     - os: linux
       dist: trusty
       compiler: gcc
@@ -66,9 +77,11 @@ matrix:
       dist: xenial
       compiler: clang
       env: REMOTE=enable CMAKE=no
-    - os: macos
+    - os: osx
       compiler: clang
       env: REMOTE=enable CMAKE=no
+
+    # CMake, remote capture support
     - os: linux
       dist: trusty
       compiler: gcc
@@ -85,7 +98,7 @@ matrix:
       dist: xenial
       compiler: clang
       env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: macos
+    - os: osx
       compiler: clang
       env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
 
@@ -139,8 +152,6 @@ git:
 before_install:
   - uname -a
   - date
-  - eval "${MATRIX_EVAL}"
-  - env
 
 install:
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,114 +1,17 @@
 sudo: false
 language: c
 
-#
-# On macOS:
-#
-#  gcc is an alias for clang;
-#  the "distribution" doesn't matter;
-#
-# so we set up a custom matrix to avoid redundant builds.
-#
-# We build on:
-#
-#    Ubuntu Trusty, with the default GCC and clang;
-#    Ubuntu Xenial, with the default GCC and clang;
-#    the default macOS, with the default clang.
-#
-matrix:
-  fast_finish: true
-  include:
-    # autotools, no remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - dpdk-dev
-      env: REMOTE=disable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: clang
-      addons:
-        apt:
-          packages:
-            - dpdk-dev
-      env: REMOTE=disable CMAKE=no
-    - os: osx
-      compiler: clang
-      env: REMOTE=disable CMAKE=no
+os:
+  - linux
+  - osx
 
-    # CMake, no remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
-    - os: osx
-      compiler: clang
-      env: ENABLE_REMOTE="" CMAKE=yes
+dist:
+  - trusty
+  - xenial
 
-    # autotools, remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: REMOTE=enable CMAKE=no
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-    - os: osx
-      compiler: clang
-      env: REMOTE=enable CMAKE=no
-
-    # CMake, remote capture support
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
-    - os: osx
-      compiler: clang
-      env: ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+compiler:
+  - gcc
+  - clang
 
 env:
   global:
@@ -121,6 +24,14 @@ env:
     # Coverity script test mode (if true no uploading, avoid reaching the quota)
     # usual processing: false.
     - coverity_scan_script_test_mode=false
+  matrix:
+    - REMOTE=disable CMAKE=no
+    - ENABLE_REMOTE="" CMAKE=yes
+    - REMOTE=enable CMAKE=no
+    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+
+matrix:
+  fast_finish: true
 
 addons:
   coverity_scan:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,98 +15,98 @@ matrix:
       dist: trusty
       compiler: gcc
       env:
-        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
     - os: linux
       dist: trusty
       compiler: clang
       env:
-        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
     - os: linux
       dist: xenial
       compiler: gcc
       env:
-        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
     - os: linux
       dist: xenial
       compiler: clang
       env:
-        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
     - os: macos
       compiler: clang
       env:
-        - MATRIX_EVAL="REMOTE=disable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
     - os: linux
       dist: trusty
       compiler: gcc
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
     - os: linux
       dist: trusty
       compiler: clang
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
     - os: linux
       dist: xenial
       compiler: gcc
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
     - os: linux
       dist: xenial
       compiler: clang
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
     - os: macos
       compiler: clang
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
     - os: linux
       dist: trusty
       compiler: gcc
       env:
-        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
     - os: linux
       dist: trusty
       compiler: clang
       env:
-        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
     - os: linux
       dist: xenial
       compiler: gcc
       env:
-        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
     - os: linux
       dist: xenial
       compiler: clang
       env:
-        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
     - os: macos
       compiler: clang
       env:
-        - MATRIX_EVAL="REMOTE=enable && CMAKE=no"
+        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
     - os: linux
       dist: trusty
       compiler: gcc
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
     - os: linux
       dist: trusty
       compiler: clang
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
     - os: linux
       dist: xenial
       compiler: gcc
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
     - os: linux
       dist: xenial
       compiler: clang
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
    - os: macos
       compiler: clang
       env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" && CMAKE=yes"
+        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,102 +11,102 @@ language: c
 #
 matrix:
   include:
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env:
-        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env:
-        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-    - os: macos
-      compiler: clang
-      env:
-        - MATRIX_EVAL="REMOTE=disable CMAKE=no"
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-    - os: macos
-      compiler: clang
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env:
-        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env:
-        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-    - os: macos
-      compiler: clang
-      env:
-        - MATRIX_EVAL="REMOTE=enable CMAKE=no"
-    - os: linux
-      dist: trusty
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-    - os: linux
-      dist: trusty
-      compiler: clang
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-    - os: linux
-      dist: xenial
-      compiler: gcc
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-    - os: linux
-      dist: xenial
-      compiler: clang
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
-   - os: macos
-      compiler: clang
-      env:
-        - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+  - os: macos
+    compiler: clang
+    env:
+      - MATRIX_EVAL="REMOTE=disable CMAKE=no"
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+  - os: macos
+    compiler: clang
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"\" CMAKE=yes"
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+  - os: macos
+    compiler: clang
+    env:
+      - MATRIX_EVAL="REMOTE=enable CMAKE=no"
+  - os: linux
+    dist: trusty
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+  - os: linux
+    dist: trusty
+    compiler: clang
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+  - os: linux
+    dist: xenial
+    compiler: gcc
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+  - os: linux
+    dist: xenial
+    compiler: clang
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
+  - os: macos
+    compiler: clang
+    env:
+      - MATRIX_EVAL="ENABLE_REMOTE=\"-DENABLE_REMOTE=ON\" CMAKE=yes"
 
 env:
   global:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1433,18 +1433,28 @@ main(void)
 endif()
 
 # Check for DPDK sniffing support
-if (NOT DISABLE_DPDK)
-	find_package(dpdk)
-	if (dpdk_FOUND)
-                set(DPDK_C_FLAGS "-march=native")
-                set(DPDK_LIB dpdk rt m numa dl)
-		set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} ${DPDK_C_FLAGS})
-		include_directories(AFTER ${dpdk_INCLUDE_DIRS})
-		link_directories(AFTER ${dpdk_LIBRARIES})
-		set(PCAP_LINK_LIBRARIES ${PCAP_LINK_LIBRARIES} ${dpdk_LIBRARIES})
-		set(PROJECT_SOURCE_LIST_C ${PROJECT_SOURCE_LIST_C} pcap-dpdk.c)
-		set(PCAP_SUPPORT_DPDK TRUE)
-	endif()
+if(NOT DISABLE_DPDK)
+    find_package(dpdk)
+    if(dpdk_FOUND)
+        #
+        # We use rte_delay_us_block(), and older versions of DPDK
+        # didn't have it, so check for it.
+        #
+        cmake_push_check_state()
+        set(CMAKE_REQUIRED_LIBRARIES ${dpdk_LIBRARIES})
+        check_function_exists(rte_delay_us_block HAVE_RTE_DELAY_US_BLOCK)
+        cmake_pop_check_state()
+        if(HAVE_RTE_DELAY_US_BLOCK)
+            set(DPDK_C_FLAGS "-march=native")
+            set(DPDK_LIB dpdk rt m numa dl)
+            set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} ${DPDK_C_FLAGS})
+            include_directories(AFTER ${dpdk_INCLUDE_DIRS})
+            link_directories(AFTER ${dpdk_LIBRARIES})
+            set(PCAP_LINK_LIBRARIES ${PCAP_LINK_LIBRARIES} ${dpdk_LIBRARIES})
+            set(PROJECT_SOURCE_LIST_C ${PROJECT_SOURCE_LIST_C} pcap-dpdk.c)
+            set(PCAP_SUPPORT_DPDK TRUE)
+        endif()
+    endif()
 endif()
 
 # Check for Bluetooth sniffing support

--- a/configure
+++ b/configure
@@ -10577,11 +10577,10 @@ if test "${with_dpdk+set}" = set; then :
 		# User wants DPDK support but hasn't specified a directory.
 		want_dpdk=yes
 	else
-		# User wants DPDK support and has specified a directory, so use the provided value.
+		# User wants DPDK support and has specified a directory,
+		# so use the provided value.
 		want_dpdk=yes
 		dpdk_dir=$withval
-		dpdk_inc_dir="$dpdk_dir/include"
-		dpdk_lib_dir="$dpdk_dir/lib"
 	fi
 
 else
@@ -10606,9 +10605,31 @@ fi
 
 if test "$want_dpdk" != no; then
 	if test -z "$dpdk_dir"; then
-		dpdk_inc_dir="/usr/local/include/dpdk"
-		dpdk_lib_dir="/usr/local/lib"
+		#
+		# The user didn't specify a directory containing
+		# the DPDK headers and libraries.  If we find
+		# a /usr/local/include/dpdk directory, assume
+		# it's /usr/local, otherwise assume it's /usr.
+		#
+		if test -d "/usr/local/include/dpdk"; then
+			dpdk_dir="/usr/local"
+		else
+			dpdk_dir="/usr"
+		fi
 	fi
+	#
+	# The convention appears to be that 1) there's a "dpdk"
+	# subdirectory of the include directory, containing DPDK
+	# headers (at least in the installation on Ubuntu with
+	# the system DPDK packages) and 2) includes of DPDK
+	# headers don't use "dpdk/{header}" (at least from the
+	# way the DPDK documentation is written).
+	#
+	# So we add "/dpdk" to the include directory, and always
+	# add that to the list of include directories to search.
+	#
+	dpdk_inc_dir="$dpdk_dir/include/dpdk"
+	dpdk_lib_dir="$dpdk_dir/lib"
 	DPDK_MACHINE_CFLAGS="-march=native"
 	DPDK_CFLAGS="$DPDK_MACHINE_CFLAGS -I$dpdk_inc_dir"
 	DPDK_LDFLAGS="-L$dpdk_lib_dir -ldpdk -lrt -lm -lnuma -ldl -pthread"

--- a/configure
+++ b/configure
@@ -10670,11 +10670,23 @@ fi
 	{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_dpdk_can_compile" >&5
 $as_echo "$ac_cv_dpdk_can_compile" >&6; }
 
+	#
+	# We use rte_delay_us_block(), and older versions of DPDK
+	# didn't have it, so check for it.
+	#
+	if test "$ac_cv_dpdk_can_compile" = yes; then
+		ac_fn_c_check_func "$LINENO" "rte_delay_us_block" "ac_cv_func_rte_delay_us_block"
+if test "x$ac_cv_func_rte_delay_us_block" = xyes; then :
+
+fi
+
+	fi
+
 	CFLAGS="$save_CFLAGS"
 	LIBS="$save_LIBS"
 	LDFLAGS="$save_LDFLAGS"
 
-	if test "$ac_cv_dpdk_can_compile" = yes; then
+	if test "$ac_cv_func_rte_delay_us_block" = yes; then
 		CFLAGS="$CFLAGS $DPDK_CFLAGS"
 		LIBS="$LIBS $DPDK_LDFLAGS"
 		LDFLAGS="$LDFLAGS $DPDK_LDFLAGS"

--- a/configure.ac
+++ b/configure.ac
@@ -2240,11 +2240,10 @@ AC_HELP_STRING([--with-dpdk@<:@=DIR@:>@],[include DPDK support (located in direc
 		# User wants DPDK support but hasn't specified a directory.
 		want_dpdk=yes
 	else
-		# User wants DPDK support and has specified a directory, so use the provided value.
+		# User wants DPDK support and has specified a directory,
+		# so use the provided value.
 		want_dpdk=yes
 		dpdk_dir=$withval
-		dpdk_inc_dir="$dpdk_dir/include"
-		dpdk_lib_dir="$dpdk_dir/lib"
 	fi
 ],[
 	if test "$V_PCAP" = dpdk; then
@@ -2265,9 +2264,31 @@ AC_HELP_STRING([--with-dpdk@<:@=DIR@:>@],[include DPDK support (located in direc
 
 if test "$want_dpdk" != no; then
 	if test -z "$dpdk_dir"; then
-		dpdk_inc_dir="/usr/local/include/dpdk"
-		dpdk_lib_dir="/usr/local/lib"
+		#
+		# The user didn't specify a directory containing
+		# the DPDK headers and libraries.  If we find
+		# a /usr/local/include/dpdk directory, assume
+		# it's /usr/local, otherwise assume it's /usr.
+		#
+		if test -d "/usr/local/include/dpdk"; then
+			dpdk_dir="/usr/local"
+		else
+			dpdk_dir="/usr"
+		fi
 	fi
+	#
+	# The convention appears to be that 1) there's a "dpdk"
+	# subdirectory of the include directory, containing DPDK
+	# headers (at least in the installation on Ubuntu with
+	# the system DPDK packages) and 2) includes of DPDK
+	# headers don't use "dpdk/{header}" (at least from the
+	# way the DPDK documentation is written).
+	#
+	# So we add "/dpdk" to the include directory, and always
+	# add that to the list of include directories to search.
+	#
+	dpdk_inc_dir="$dpdk_dir/include/dpdk"
+	dpdk_lib_dir="$dpdk_dir/lib"
 	DPDK_MACHINE_CFLAGS="-march=native"
 	DPDK_CFLAGS="$DPDK_MACHINE_CFLAGS -I$dpdk_inc_dir"
 	DPDK_LDFLAGS="-L$dpdk_lib_dir -ldpdk -lrt -lm -lnuma -ldl -pthread"

--- a/configure.ac
+++ b/configure.ac
@@ -2310,11 +2310,19 @@ AC_INCLUDES_DEFAULT
 	    ac_cv_dpdk_can_compile=no))
 	AC_MSG_RESULT($ac_cv_dpdk_can_compile)
 
+	#
+	# We use rte_delay_us_block(), and older versions of DPDK
+	# didn't have it, so check for it.
+	#
+	if test "$ac_cv_dpdk_can_compile" = yes; then
+		AC_CHECK_FUNC(rte_delay_us_block)
+	fi
+
 	CFLAGS="$save_CFLAGS"
 	LIBS="$save_LIBS"
 	LDFLAGS="$save_LDFLAGS"
 
-	if test "$ac_cv_dpdk_can_compile" = yes; then
+	if test "$ac_cv_func_rte_delay_us_block" = yes; then
 		CFLAGS="$CFLAGS $DPDK_CFLAGS"
 		LIBS="$LIBS $DPDK_LDFLAGS"
 		LDFLAGS="$LDFLAGS $DPDK_LDFLAGS"

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -190,6 +190,9 @@ static struct rte_eth_conf port_conf = {
 	},
 };
 
+static void	dpdk_fmt_errmsg_for_rte_errno(char *, size_t, int,
+    PCAP_FORMAT_STRING(const char *), ...) PCAP_PRINTFLIKE(4, 5);
+
 /*
  * Generate an error message based on a format, arguments, and an
  * rte_errno, with a message for the rte_errno after the formatted output.
@@ -710,7 +713,8 @@ error:
 			// as an error.
 			//
 			dpdk_fmt_errmsg_for_rte_errno(ebuf,
-			    PCAP_ERRBUF_SIZE, -is_dpdk_pre_inited);
+			    PCAP_ERRBUF_SIZE, -is_dpdk_pre_inited,
+			    "dpdk error: dpdk_pre_init failed");
 			break;
 	}
 	// Error.

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -93,6 +93,7 @@ env DPDK_CFG="--log-level=debug -l0 -dlibrte_pmd_e1000.so -dlibrte_pmd_ixgbe.so 
 //header for calling dpdk
 #include <rte_config.h>
 #include <rte_common.h>
+#include <rte_errno.h>
 #include <rte_log.h>
 #include <rte_malloc.h>
 #include <rte_memory.h>

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -91,6 +91,7 @@ env DPDK_CFG="--log-level=debug -l0 -dlibrte_pmd_e1000.so -dlibrte_pmd_ixgbe.so 
 #include <sys/time.h>
 
 //header for calling dpdk
+#include <rte_config.h>
 #include <rte_common.h>
 #include <rte_log.h>
 #include <rte_malloc.h>


### PR DESCRIPTION
I'm not sure this works as it should. I have installed DPDK on my system but are struggling to configure it properly. So in this state when doing:
/build-pcap$ dumpcap -D
USER1: permission denied, DPDK needs root permission
dumpcap: Can't get list of interfaces: 

Isn't this supposed to print the other interfaces?
This also fais:
uild-pcap$ sudo dumpcap -D
EAL: Cannot obtain physical addresses: No such file or directory. Only vfio will function.
error allocating rte services array
EAL: FATAL: rte_service_init() failed
EAL: rte_service_init() failed
dumpcap: Can't get list of interfaces: 

