### PR TITLE
Add DLT_/LINKTYPE_ values for IEEE802_15_4_TAP

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -3580,6 +3580,7 @@ gen_linktype(compiler_state_t *cstate, bpf_u_int32 ll_proto)
 	case DLT_IEEE802_15_4_LINUX:
 	case DLT_IEEE802_15_4_NONASK_PHY:
 	case DLT_IEEE802_15_4_NOFCS:
+	case DLT_IEEE802_15_4_TAP:
 		bpf_error(cstate, "IEEE 802.15.4 link-layer type filtering not implemented");
 
 	case DLT_IEEE802_16_MAC_CPS_RADIO:

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1147,7 +1147,15 @@
 #define LINKTYPE_DSA_TAG_BRCM	281
 #define LINKTYPE_DSA_TAG_BRCM_PREPEND	282
 
-#define LINKTYPE_MATCHING_MAX	282		/* highest value in the "matching" range */
+/*
+ * IEEE 802.15.4 with pseudo-header and optional meta-data TLVs, PHY payload
+ * exactly as it appears in the spec (no padding, no nothing), and FCS if
+ * specified by FCS Type TLV;  requested by James Ko <jck@exegin.com>.
+ * Specification at https://github.com/jkcko/ieee802.15.4-tap
+ */
+#define LINKTYPE_IEEE802_15_4_TAP       283
+
+#define LINKTYPE_MATCHING_MAX	283		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1433,6 +1433,14 @@
 #define DLT_DSA_TAG_BRCM_PREPEND	282
 
 /*
+ * IEEE 802.15.4 with pseudo-header and optional meta-data TLVs, PHY payload
+ * exactly as it appears in the spec (no padding, no nothing), and FCS if
+ * specified by FCS Type TLV;  requested by James Ko <jck@exegin.com>.
+ * Specification at https://github.com/jkcko/ieee802.15.4-tap
+ */
+#define DLT_IEEE802_15_4_TAP    283
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1442,7 +1450,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	282	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	283	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
Link type value to go with 
https://github.com/the-tcpdump-group/tcpdump/pull/734
and
https://bugs.wireshark.org/bugzilla/show_bug.cgi?id=15429
