### PR TITLE
Add DLT/LINK_TYPE for Marvell Ethernet Switch DSA TAG

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1155,7 +1155,12 @@
  */
 #define LINKTYPE_IEEE802_15_4_TAP       283
 
-#define LINKTYPE_MATCHING_MAX	283		/* highest value in the "matching" range */
+/*
+ * Marvell Ethernet switches mv88e6xxx 4 byte proprietary taggging format.
+ */
+#define LINKTYPE_DSA_TAG_MDSA	284
+
+#define LINKTYPE_MATCHING_MAX	284		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -6934,6 +6934,7 @@ static struct dsa_proto {
 	{ "none", DLT_EN10MB },
 	{ "brcm", DLT_DSA_TAG_BRCM },
 	{ "brcm-prepend", DLT_DSA_TAG_BRCM_PREPEND },
+	{ "dsa", DLT_DSA_TAG_MDSA },
 };
 
 static int

--- a/pcap.c
+++ b/pcap.c
@@ -3097,6 +3097,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(EBHSCR, "Elektrobit High Speed Capture and Replay (EBHSCR)"),
 	DLT_CHOICE(DSA_TAG_BRCM, "Broadcom tag"),
 	DLT_CHOICE(DSA_TAG_BRCM_PREPEND, "Broadcom tag (prepended)"),
+	DLT_CHOICE(DSA_TAG_MDSA, "Marvell tag"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1441,6 +1441,11 @@
 #define DLT_IEEE802_15_4_TAP    283
 
 /*
+ * Marvell Ethernet switches mv88e6xxx 4 byte proprietary taggging format.
+ */
+#define DLT_DSA_TAG_MDSA	284
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1450,7 +1455,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	283	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	284	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
Make use of the newly added infrastructure for DSA Ethernet
switches to support Marvell DSA tags.