### PR TITLE
pcap_dump_fopen differing Windows CRTs work-around 

### DIFF
--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -110,6 +110,20 @@
 
 static int pcap_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **datap);
 
+#ifdef _WIN32
+/*
+ * This isn't exported on Windows, because it would only work if both
+ * libpcap and the code using it were using the same C runtime; otherwise they
+ * would be using different definitions of a FILE structure.
+ *
+ * Instead we define this as a macro in pcap/pcap.h that wraps the hopen
+ * version that we do export, passing it a raw OS HANDLE, as defined by the
+ * Win32 / Win64 ABI, obtained from the _fileno() and _get_osfhandle()
+ * functions of the appropriate CRT.
+ */
+static pcap_dumper_t *pcap_dump_fopen(pcap_t *p, FILE *f);
+#endif /* _WIN32 */
+
 /*
  * Private data for reading pcap savefiles.
  */
@@ -834,9 +848,43 @@ pcap_dump_open(pcap_t *p, const char *fname)
 	return (pcap_setup_dump(p, linktype, f, fname));
 }
 
+#ifdef _WIN32
+/*
+ * Initialize so that sf_write() will output to a stream wrapping the given raw
+ * OS file HANDLE.
+ */
+pcap_dumper_t *
+pcap_dump_hopen(pcap_t *p, intptr_t osfd)
+{
+	int fd;
+	FILE *file;
+
+	fd = _open_osfhandle( osfd, _O_APPEND );
+	if ( fd < 0 )
+	{
+		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "_openosfhandle");
+		return NULL;
+	}
+
+	file = _fdopen(fd, "wb");
+	if ( file == NULL )
+	{
+		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "_fdopen");
+		return NULL;
+	}
+
+	return pcap_dump_fopen(p, file);
+}
+#endif /* _WIN32 */
+
 /*
  * Initialize so that sf_write() will output to the given stream.
  */
+#ifdef _WIN32
+static
+#endif /* _WIN32 */
 pcap_dumper_t *
 pcap_dump_fopen(pcap_t *p, FILE *f)
 {

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -859,17 +859,15 @@ pcap_dump_hopen(pcap_t *p, intptr_t osfd)
 	int fd;
 	FILE *file;
 
-	fd = _open_osfhandle( osfd, _O_APPEND );
-	if ( fd < 0 )
-	{
+	fd = _open_osfhandle(osfd, _O_APPEND);
+	if (fd < 0) {
 		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "_openosfhandle");
 		return NULL;
 	}
 
 	file = _fdopen(fd, "wb");
-	if ( file == NULL )
-	{
+	if (file == NULL) {
 		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "_fdopen");
 		return NULL;

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -862,7 +862,7 @@ pcap_dump_hopen(pcap_t *p, intptr_t osfd)
 	fd = _open_osfhandle(osfd, _O_APPEND);
 	if (fd < 0) {
 		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
-		    errno, "_openosfhandle");
+		    errno, "_open_osfhandle");
 		return NULL;
 	}
 

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -861,14 +861,14 @@ pcap_dump_hopen(pcap_t *p, intptr_t osfd)
 
 	fd = _open_osfhandle(osfd, _O_APPEND);
 	if (fd < 0) {
-		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
+		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "_open_osfhandle");
 		return NULL;
 	}
 
 	file = _fdopen(fd, "wb");
 	if (file == NULL) {
-		pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
+		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "_fdopen");
 		return NULL;
 	}

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -870,6 +870,7 @@ pcap_dump_hopen(pcap_t *p, intptr_t osfd)
 	if (file == NULL) {
 		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "_fdopen");
+		_close(fd);
 		return NULL;
 	}
 


### PR DESCRIPTION
#805
Make `pcap_dump_fopen()` a macro on Windows, wrapping the caller's CRT
functions for getting the raw OS file `HANDLE` and calling the exported
hopen variant. `pcap_dump_hopen()` creates a stream from that using
libpcap's CRT and passes that stream to the real `pcap_dump_fopen()`. This
mirrors what was done for `pcap_fopen_offline()`.