### PR TITLE
Add support for (Ethertype) DSA data link types

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1164,7 +1164,13 @@
  */
 #define LINKTYPE_IEEE802_15_4_TAP       283
 
-#define LINKTYPE_MATCHING_MAX	283		/* highest value in the "matching" range */
+/*
+ * Marvell (Ethertype) Distributed Switch Architecture proprietary tagging format.
+ */
+#define LINKTYPE_DSA_TAG_DSA	284
+#define LINKTYPE_DSA_TAG_EDSA	285
+
+#define LINKTYPE_MATCHING_MAX	285		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -6934,6 +6934,8 @@ static struct dsa_proto {
 	{ "none", DLT_EN10MB },
 	{ "brcm", DLT_DSA_TAG_BRCM },
 	{ "brcm-prepend", DLT_DSA_TAG_BRCM_PREPEND },
+	{ "dsa", DLT_DSA_TAG_DSA },
+	{ "edsa", DLT_DSA_TAG_EDSA },
 };
 
 static int

--- a/pcap.c
+++ b/pcap.c
@@ -3113,6 +3113,8 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(EBHSCR, "Elektrobit High Speed Capture and Replay (EBHSCR)"),
 	DLT_CHOICE(DSA_TAG_BRCM, "Broadcom tag"),
 	DLT_CHOICE(DSA_TAG_BRCM_PREPEND, "Broadcom tag (prepended)"),
+	DLT_CHOICE(DSA_TAG_DSA, "Marvell DSA"),
+	DLT_CHOICE(DSA_TAG_EDSA, "Marvell EDSA"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1450,6 +1450,12 @@
 #define DLT_IEEE802_15_4_TAP    283
 
 /*
+ * Marvell (Ethertype) Distributed Switch Architecture proprietary tagging format.
+ */
+#define DLT_DSA_TAG_DSA		284
+#define DLT_DSA_TAG_EDSA	285
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1459,7 +1465,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	283	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	285	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
Following @ffainelli's [work](https://github.com/the-tcpdump-group/libpcap/pull/796) on adding DLT support for DSA tagged master interfaces, this PR adds support for the Marvell DSA and EDSA tagging formats.