### PR TITLE
Report the DLT description in error messages

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -612,6 +612,9 @@ install: install-shared install-archive libpcap.pc pcap-config @INSTALL_RPCAPD@
 	rm -f pcap_datalink_val_to_description.3pcap && \
 	$(LN_S) pcap_datalink_val_to_name.3pcap \
 		 pcap_datalink_val_to_description.3pcap && \
+	rm -f pcap_datalink_val_to_description_or_dlt.3pcap && \
+	$(LN_S) pcap_datalink_val_to_name.3pcap \
+		 pcap_datalink_val_to_description_or_dlt.3pcap && \
 	rm -f pcap_dump_fopen.3pcap && \
 	$(LN_S) pcap_dump_open.3pcap pcap_dump_fopen.3pcap && \
 	rm -f pcap_freealldevs.3pcap && \

--- a/gencode.c
+++ b/gencode.c
@@ -3625,14 +3625,9 @@ gen_linktype(compiler_state_t *cstate, bpf_u_int32 ll_proto)
 			/*
 			 * No; report an error.
 			 */
-			description = pcap_datalink_val_to_description(cstate->linktype);
-			if (description != NULL) {
-				bpf_error(cstate, "%s link-layer type filtering not implemented",
-				    description);
-			} else {
-				bpf_error(cstate, "DLT %u link-layer type filtering not implemented",
-				    cstate->linktype);
-			}
+			description = pcap_datalink_val_to_description_or_dlt(cstate->linktype);
+			bpf_error(cstate, "%s link-layer type filtering not implemented",
+			    description);
 			/*NOTREACHED */
 		}
 	}
@@ -3730,7 +3725,8 @@ gen_llc_internal(compiler_state_t *cstate)
 		return b0;
 
 	default:
-		bpf_error(cstate, "'llc' not supported for linktype %d", cstate->linktype);
+		bpf_error(cstate, "'llc' not supported for %s",
+			  pcap_datalink_val_to_description_or_dlt(cstate->linktype));
 		/*NOTREACHED*/
 	}
 }
@@ -8312,8 +8308,8 @@ gen_inbound(compiler_state_t *cstate, int dir)
 		 */
 		if (cstate->bpf_pcap->rfile != NULL) {
 			/* We have a FILE *, so this is a savefile */
-			bpf_error(cstate, "inbound/outbound not supported on linktype %d when reading savefiles",
-			    cstate->linktype);
+			bpf_error(cstate, "inbound/outbound not supported on %s when reading savefiles",
+			    pcap_datalink_val_to_description_or_dlt(cstate->linktype));
 			b0 = NULL;
 			/*NOTREACHED*/
 		}
@@ -8325,8 +8321,8 @@ gen_inbound(compiler_state_t *cstate, int dir)
 			gen_not(b0);
 		}
 #else /* defined(linux) && defined(PF_PACKET) && defined(SO_ATTACH_FILTER) */
-		bpf_error(cstate, "inbound/outbound not supported on linktype %d",
-		    cstate->linktype);
+		bpf_error(cstate, "inbound/outbound not supported on %s",
+		    pcap_datalink_val_to_description_or_dlt(cstate->linktype));
 		/*NOTREACHED*/
 #endif /* defined(linux) && defined(PF_PACKET) && defined(SO_ATTACH_FILTER) */
 	}
@@ -8990,8 +8986,8 @@ gen_vlan(compiler_state_t *cstate, bpf_u_int32 vlan_num, int has_vlan_tag)
 		break;
 
 	default:
-		bpf_error(cstate, "no VLAN support for data link type %d",
-		      cstate->linktype);
+		bpf_error(cstate, "no VLAN support for %s",
+		      pcap_datalink_val_to_description_or_dlt(cstate->linktype));
 		/*NOTREACHED*/
 	}
 
@@ -9047,8 +9043,8 @@ gen_mpls(compiler_state_t *cstate, bpf_u_int32 label_num_arg,
                      * leave it for now */
 
             default:
-                    bpf_error(cstate, "no MPLS support for data link type %d",
-                          cstate->linktype);
+                    bpf_error(cstate, "no MPLS support for %s",
+                          pcap_datalink_val_to_description_or_dlt(cstate->linktype));
                     /*NOTREACHED*/
             }
         }

--- a/pcap.c
+++ b/pcap.c
@@ -3152,6 +3152,21 @@ pcap_datalink_val_to_description(int dlt)
 	return (NULL);
 }
 
+const char *
+pcap_datalink_val_to_description_or_dlt(int dlt)
+{
+        static char unkbuf[40];
+        const char *description;
+
+        description = pcap_datalink_val_to_description(dlt);
+        if (description != NULL) {
+                return description;
+        } else {
+                (void)pcap_snprintf(unkbuf, sizeof(unkbuf), "DLT %u", dlt);
+                return unkbuf;
+        }
+}
+
 struct tstamp_type_choice {
 	const char *name;
 	const char *description;

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -471,6 +471,7 @@ PCAP_API void	pcap_free_datalinks(int *);
 PCAP_API int	pcap_datalink_name_to_val(const char *);
 PCAP_API const char *pcap_datalink_val_to_name(int);
 PCAP_API const char *pcap_datalink_val_to_description(int);
+PCAP_API const char *pcap_datalink_val_to_description_or_dlt(int);
 PCAP_API int	pcap_snapshot(pcap_t *);
 PCAP_API int	pcap_is_swapped(pcap_t *);
 PCAP_API int	pcap_major_version(pcap_t *);

--- a/pcap_datalink_val_to_name.3pcap
+++ b/pcap_datalink_val_to_name.3pcap
@@ -19,7 +19,8 @@
 .\"
 .TH PCAP_DATALINK_VAL_TO_NAME 3PCAP "12 October 2016"
 .SH NAME
-pcap_datalink_val_to_name, pcap_datalink_val_to_description \- get a
+pcap_datalink_val_to_name, pcap_datalink_val_to_description,
+pcap_datalink_val_to_description_or_dlt \- get a
 name or description for a link-layer header type value
 .SH SYNOPSIS
 .nf
@@ -30,6 +31,7 @@ name or description for a link-layer header type value
 .ft B
 const char *pcap_datalink_val_to_name(int dlt);
 const char *pcap_datalink_val_to_description(int dlt);
+const char *pcap_datalink_val_to_description_or_dlt(int dlt);
 .ft
 .fi
 .SH DESCRIPTION
@@ -52,5 +54,13 @@ link-layer header type.
 is returned if the type value does not correspond to a known
 .B DLT_
 value.
+.PP
+.B pcap_datalink_val_to_description_or_dlt()
+translates a link-layer header type value to a short description of that
+link-layer header type just like pcap_datalink_val_to_description.
+If the type value does not correspond to a known
+.B DLT_
+value, the string "DLT n" is returned, where n is the value of
+the dlt argument.
 .SH SEE ALSO
 pcap(3PCAP)


### PR DESCRIPTION
Introduce pcap_datalink_val_to_description_or_dlt, and
use that when reporting an error.  This was inspired by
seeing `tcpdump: no VLAN support for data link type 113`.
The new equivalent message is
`tcpdump: no VLAN support for Linux cooked`.