### PR TITLE
Detect Npcap's version.h in build tree and set HAVE_VERSION_H

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,7 @@ include_directories(
 
 include(CheckFunctionExists)
 include(CMakePushCheckState)
+include(CheckSymbolExists)
 
 if(WIN32)
 
@@ -309,6 +310,14 @@ if(WIN32)
         check_function_exists(PacketIsLoopbackAdapter HAVE_PACKET_IS_LOOPBACK_ADAPTER)
         cmake_pop_check_state()
     endif(PACKET_FOUND)
+
+    message(STATUS "checking for version.h")
+    check_symbol_exists(WINPCAP_PRODUCT_NAME "../../version.h" HAVE_VERSION_H)
+    if(HAVE_VERSION_H)
+	    message(STATUS "HAVE version.h")
+    else(HAVE_VERSION_H)
+	    message(STATUS "MISSING version.h")
+    endif(HAVE_VERSION_H)
 
 endif(WIN32)
 
@@ -429,7 +438,6 @@ check_function_exists(strtok_r HAVE_STRTOK_R)
 #
 set(PCAP_LINK_LIBRARIES "")
 include(CheckLibraryExists)
-include(CheckSymbolExists)
 if(WIN32)
     #
     # We need winsock2.h and ws2tcpip.h.

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -141,6 +141,9 @@
 /* Define to 1 if Packet32 API (WinPcap NPF driver) is available */
 #cmakedefine HAVE_PACKET32 1
 
+/* Define to 1 if NPcap's version.h is available */
+#cmakedefine HAVE_VERSION_H 1
+
 /* define if net/pfvar.h defines PF_NAT through PF_NORDR */
 #cmakedefine HAVE_PF_NAT_THROUGH_PF_NORDR 1
 


### PR DESCRIPTION
Npcap needs this to be set so that we can report the Npcap version (e.g. 0.992) via `pcap_lib_version()`.

I apparently based this change on the release branch; let me know if you need me to cherry-pick it to a branch off of master and open a new PR instead.