### PR TITLE
Do not subtract the SLL[2]_HDR_LEN if the location is negative.

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -7496,6 +7496,14 @@ fix_program(pcap_t *handle, struct sock_fprog *fcode, int is_mmapped)
 static int
 fix_offset(pcap_t *handle, struct bpf_insn *p)
 {
+	/*
+	 * Existing references to auxiliary data shouldn't be adjusted.
+	 *
+	 * Note that SKF_AD_OFF is negative, but p->k is unsigned, so
+	 * we use >= and cast SKF_AD_OFF to unsigned.
+	 */
+	if (p->k >= (bpf_u_int32)SKF_AD_OFF)
+		return 0;
 	if (handle->linktype == DLT_LINUX_SLL2) {
 		/*
 		 * What's the offset?


### PR DESCRIPTION
This fixes the offset issue [I mention](https://github.com/the-tcpdump-group/tcpdump/issues/480#issuecomment-486827278) in [tcpdump issue 480](https://github.com/the-tcpdump-group/tcpdump/issues/480) about dumping on multiple interfaces - fix_program() modifies even negative offsets to take the SLL header into account, so the special SKF_AD_ values are not usable directly when using the SLL DLTs.