### PR TITLE
IO plugins for libpcap

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -955,6 +955,7 @@ set(PROJECT_SOURCE_LIST_C
     optimize.c
     pcap-common.c
     pcap.c
+    pcap-ioplugin.c
     savefile.c
     sf-pcapng.c
     sf-pcap.c

--- a/Makefile.in
+++ b/Makefile.in
@@ -93,7 +93,7 @@ MODULE_C_SRC =		@MODULE_C_SRC@
 REMOTE_C_SRC =		@REMOTE_C_SRC@
 COMMON_C_SRC =	pcap.c gencode.c optimize.c nametoaddr.c etherent.c \
 		fmtutils.c \
-		savefile.c sf-pcap.c sf-pcapng.c pcap-common.c \
+		pcap-ioplugin.c savefile.c sf-pcap.c sf-pcapng.c pcap-common.c \
 		bpf_image.c bpf_filter.c bpf_dump.c
 GENERATED_C_SRC = scanner.c grammar.c
 LIBOBJS = @LIBOBJS@
@@ -326,6 +326,7 @@ EXTRA_DIST = \
 	pcap-dpdk.h \
 	pcap-enet.c \
 	pcap-int.h \
+	pcap-ioplugin.c \
 	pcap-libdlpi.c \
 	pcap-linux.c \
 	pcap-namedb.h \

--- a/Win32/Prj/wpcap.vcxproj
+++ b/Win32/Prj/wpcap.vcxproj
@@ -209,6 +209,7 @@ win_bison -ppcap_ --yacc --output=..\..\grammar.c --defines ..\..\grammar.y</Com
     <ClCompile Include="..\..\pcap-rpcap.c" />
     <ClCompile Include="..\..\pcap-win32.c" />
     <ClCompile Include="..\..\pcap.c" />
+    <ClCompile Include="..\..\pcap-ioplugin.c" />
     <ClCompile Include="..\..\savefile.c" />
     <ClCompile Include="..\..\scanner.c" />
     <ClCompile Include="..\..\sf-pcapng.c" />

--- a/config.h.in
+++ b/config.h.in
@@ -42,6 +42,12 @@
 /* Define to 1 if you have the declaration of `ether_hostton' */
 #undef HAVE_DECL_ETHER_HOSTTON
 
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#undef HAVE_DLFCN_H
+
+/* Define to 1 if you have the `dlopen' function. */
+#undef HAVE_DLOPEN
+
 /* Define to 1 if `dl_module_id_1' is a member of `dl_hp_ppa_info_t'. */
 #undef HAVE_DL_HP_PPA_INFO_T_DL_MODULE_ID_1
 
@@ -74,6 +80,9 @@
 
 /* Define to 1 if you have the `dag' library (-ldag). */
 #undef HAVE_LIBDAG
+
+/* Define to 1 if you have the `dl' library (-ldl). */
+#undef HAVE_LIBDL
 
 /* if libdlpi exists */
 #undef HAVE_LIBDLPI

--- a/configure
+++ b/configure
@@ -11646,6 +11646,75 @@ fi
 
 fi
 
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for dlopen in -ldl" >&5
+$as_echo_n "checking for dlopen in -ldl... " >&6; }
+if ${ac_cv_lib_dl_dlopen+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  ac_check_lib_save_LIBS=$LIBS
+LIBS="-ldl  $LIBS"
+cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+
+/* Override any GCC internal prototype to avoid an error.
+   Use char because int might match the return type of a GCC
+   builtin and then its argument prototype would still apply.  */
+#ifdef __cplusplus
+extern "C"
+#endif
+char dlopen ();
+int
+main ()
+{
+return dlopen ();
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_link "$LINENO"; then :
+  ac_cv_lib_dl_dlopen=yes
+else
+  ac_cv_lib_dl_dlopen=no
+fi
+rm -f core conftest.err conftest.$ac_objext \
+    conftest$ac_exeext conftest.$ac_ext
+LIBS=$ac_check_lib_save_LIBS
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_cv_lib_dl_dlopen" >&5
+$as_echo "$ac_cv_lib_dl_dlopen" >&6; }
+if test "x$ac_cv_lib_dl_dlopen" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_LIBDL 1
+_ACEOF
+
+  LIBS="-ldl $LIBS"
+
+fi
+
+for ac_header in dlfcn.h
+do :
+  ac_fn_c_check_header_mongrel "$LINENO" "dlfcn.h" "ac_cv_header_dlfcn_h" "$ac_includes_default"
+if test "x$ac_cv_header_dlfcn_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DLFCN_H 1
+_ACEOF
+
+fi
+
+done
+
+for ac_func in dlopen
+do :
+  ac_fn_c_check_func "$LINENO" "dlopen" "ac_cv_func_dlopen"
+if test "x$ac_cv_func_dlopen" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_DLOPEN 1
+_ACEOF
+
+fi
+done
+
+
 # Find a good install program.  We prefer a C program (faster),
 # so one script is as good as another.  But avoid the broken or
 # incompatible versions:

--- a/configure.ac
+++ b/configure.ac
@@ -2731,6 +2731,11 @@ if test "x$enable_rdma" != "xno"; then
 	AC_SUBST(PCAP_SUPPORT_RDMASNIFF)
 fi
 
+dnl check for dynamic gzip support
+AC_CHECK_LIB(dl, dlopen)
+AC_CHECK_HEADERS(dlfcn.h)
+AC_CHECK_FUNCS(dlopen)
+
 AC_PROG_INSTALL
 
 AC_CONFIG_HEADER(config.h)

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -539,6 +539,11 @@ int	pcap_parsesrcstr_ex(const char *, int *, char *, char *,
 extern int pcap_debug;
 #endif
 
+/*
+ * Internal interfaces for I/O plugins
+ */
+const pcap_ioplugin_t* pcap_ioplugin_init(const char *name);
+
 #ifdef __cplusplus
 }
 #endif

--- a/pcap-ioplugin.c
+++ b/pcap-ioplugin.c
@@ -1,0 +1,250 @@
+/*
+ * Copyright (c) 2017
+ *	Internet Systems Consortium, Inc.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code distributions
+ * retain the above copyright notice and this paragraph in its entirety, (2)
+ * distributions including binary code include the above copyright notice and
+ * this paragraph in its entirety in the documentation or other materials
+ * provided with the distribution, and (3) all advertising materials mentioning
+ * features or use of this software display the following acknowledgement:
+ * ``This product includes software developed by the University of California,
+ * Lawrence Berkeley Laboratory and its contributors.'' Neither the name of
+ * the University nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior
+ * written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * pcap-ioplugin.c - supports dynamic loading of compression modules
+ *	Created by Ray Bellis, ISC.
+ *
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "ftmacros.h"
+
+#ifdef _WIN32
+#include <pcap-stdinc.h>
+#else /* _WIN32 */
+#if HAVE_INTTYPES_H
+#include <inttypes.h>
+#elif HAVE_STDINT_H
+#include <stdint.h>
+#endif
+#ifdef HAVE_SYS_BITYPES_H
+#include <sys/bitypes.h>
+#endif
+#include <sys/types.h>
+#endif /* _WIN32 */
+
+#include <errno.h>
+#include <memory.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "pcap-int.h"
+
+#ifdef HAVE_DLFCN_H
+#include <dlfcn.h>
+#endif
+
+#ifdef HAVE_OS_PROTO_H
+#include "os-proto.h"
+#endif
+
+/*
+ * Setting O_BINARY on DOS/Windows is a bit tricky
+ */
+#if defined(_WIN32)
+  #define SET_BINMODE(f)  _setmode(_fileno(f), _O_BINARY)
+#elif defined(MSDOS)
+  #if defined(__HIGHC__)
+  #define SET_BINMODE(f)  setmode(f, O_BINARY)
+  #else
+  #define SET_BINMODE(f)  setmode(fileno(f), O_BINARY)
+  #endif
+#else
+  #define SET_BINMODE(f)  (void)f
+#endif
+
+static FILE*
+stdio_open_read(const char *fname, char *errbuf)
+{
+	FILE *fp = NULL;
+
+	if (strcmp(fname, "-") == 0) {
+		fp = stdin;
+		SET_BINMODE(fp);
+	} else {
+		/*
+		 * "b" is supported as of C90, so *all* UN*Xes should
+		 * support it, even though it does nothing.  It's
+		 * required on Windows, as the file is a binary file
+		 * and must be written in binary mode.
+		 */
+		fp = fopen(fname, "rb");
+		if (fp == NULL) {
+			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "%s: fopen: %s", fname,
+				pcap_strerror(errno));
+			return (NULL);
+		}
+	}
+
+	return fp;
+}
+
+static FILE*
+stdio_open_write(const char *fname, char *errbuf)
+{
+	FILE *fp = NULL;
+
+	if (strcmp(fname, "-") == 0) {
+		fp = stdout;
+		SET_BINMODE(fp);
+	} else {
+		/*
+		 * "b" is supported as of C90, so *all* UN*Xes should
+		 * support it, even though it does nothing.  It's
+		 * required on Windows, as the file is a binary file
+		 * and must be written in binary mode.
+		 */
+		fp = fopen(fname, "wb");
+		if (fp == NULL) {
+			pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE, "%s: fopen: %s", fname,
+				pcap_strerror(errno));
+			return (NULL);
+		}
+	}
+
+	return fp;
+}
+
+static const pcap_ioplugin_t*
+pcap_ioplugin_stdio() {
+	static pcap_ioplugin_t plugin = {
+		.open_read = stdio_open_read,
+		.open_write = stdio_open_write
+	};
+
+	return &plugin;
+}
+
+/*
+ * loads an I/O plugin with the given name
+ * (on UNIX, a .so shared library)
+ *
+ * NB: fails silently and falls back to existing uncompressed
+ *     stdio-based output if the plugin fails to load
+ */
+
+const pcap_ioplugin_t*
+pcap_ioplugin_init(const char *name)
+{
+	void *lib = NULL;
+	if (name == NULL) {
+		goto fail;
+	}
+
+#if HAVE_DLOPEN
+	lib = dlopen(name, RTLD_NOW);
+	if (lib != NULL) {
+		pcap_ioplugin_init_fn ioplugin_init = dlsym(lib, "ioplugin_init");
+		if (ioplugin_init == NULL) {
+			dlclose(lib);
+			goto fail;
+		} else {
+			return ioplugin_init();
+		}
+	}
+#endif /* HAVE_DLOPEN */
+
+fail:
+	return pcap_ioplugin_stdio();
+}
+
+struct file_entry {
+	FILE					*fp;
+	const void				*cookie;
+	struct file_entry		*next;
+};
+
+static struct {
+	struct file_entry		*head;
+} file_list = { NULL };
+
+static int registered_atexit = 0;
+static int running_atexit = 0;
+
+static void
+pcap_ioplugin_closeall(void)
+{
+	struct file_entry *entry = file_list.head;
+
+	running_atexit = 1;
+
+	while (entry) {
+		struct file_entry *tmp = entry;
+		entry = entry->next;
+		fclose(tmp->fp);
+		free(tmp);
+	}
+
+	file_list.head = NULL;
+}
+
+void
+pcap_ioplugin_register_fp_cookie(FILE *fp, const void *cookie)
+{
+	struct file_entry *entry = malloc(sizeof *entry);
+	if (!entry) {
+		return;
+	}
+	entry->fp = fp;
+	entry->cookie = cookie;
+
+	if (!registered_atexit) {
+		registered_atexit = 1;
+		atexit(pcap_ioplugin_closeall);
+	}
+
+	/* O(1) insertion to front of list */
+	entry->next = file_list.head;
+	file_list.head = entry;
+}
+
+void
+pcap_ioplugin_unregister_fp_cookie(const void *cookie)
+{
+	struct file_entry *entry = file_list.head;
+
+	/* atexit handler does its own list traversal */
+	if (running_atexit) {
+		return;
+	}
+
+	/* check head of list */
+	if (entry && entry->cookie == cookie) {
+		file_list.head = entry->next;
+		free(entry);
+		return;
+	}
+
+	/* otherwise check following nodes */
+	while (entry) {
+		struct file_entry *next = entry->next;
+		if (next && next->cookie == cookie) {
+			/* remove following node */
+			entry->next = next->next;
+			free(next);
+			return;
+		}
+		entry = next;
+	}
+}

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -962,6 +962,23 @@ PCAP_API int	pcap_remoteact_list(char *hostlist, char sep, int size,
 PCAP_API int	pcap_remoteact_close(const char *host, char *errbuf);
 PCAP_API void	pcap_remoteact_cleanup(void);
 
+/*
+ * I/O Plugin Support
+ */
+
+typedef FILE* (*pcap_ioplugin_open_read_fn)(const char *fname, char *errbuf);
+typedef FILE* (*pcap_ioplugin_open_write_fn)(const char *fname, char *errbuf);
+
+typedef struct pcap_ioplugin {
+	pcap_ioplugin_open_read_fn		open_read;
+	pcap_ioplugin_open_write_fn		open_write;
+} pcap_ioplugin_t;
+
+typedef const pcap_ioplugin_t* (*pcap_ioplugin_init_fn)();
+
+PCAP_API void pcap_ioplugin_register_fp_cookie(FILE *fp, const void *cookie);
+PCAP_API void pcap_ioplugin_unregister_fp_cookie(const void *cookie);
+
 #ifdef __cplusplus
 }
 #endif

--- a/savefile.c
+++ b/savefile.c
@@ -70,19 +70,6 @@ static pcap_t *pcap_fopen_offline_with_tstamp_precision(FILE *, u_int, char *);
 static pcap_t *pcap_fopen_offline(FILE *, char *);
 #endif
 
-/*
- * Setting O_BINARY on DOS/Windows is a bit tricky
- */
-#if defined(_WIN32)
-  #define SET_BINMODE(f)  _setmode(_fileno(f), _O_BINARY)
-#elif defined(MSDOS)
-  #if defined(__HIGHC__)
-  #define SET_BINMODE(f)  setmode(f, O_BINARY)
-  #else
-  #define SET_BINMODE(f)  setmode(fileno(f), O_BINARY)
-  #endif
-#endif
-
 static int
 sf_getnonblock(pcap_t *p _U_)
 {
@@ -249,6 +236,7 @@ pcap_t *
 pcap_open_offline_with_tstamp_precision(const char *fname, u_int precision,
 					char *errbuf)
 {
+	const pcap_ioplugin_t *plugin = pcap_ioplugin_init(getenv("PCAP_IOPLUGIN_READ"));
 	FILE *fp;
 	pcap_t *p;
 
@@ -257,31 +245,18 @@ pcap_open_offline_with_tstamp_precision(const char *fname, u_int precision,
 		    "A null pointer was supplied as the file name");
 		return (NULL);
 	}
-	if (fname[0] == '-' && fname[1] == '\0')
-	{
-		fp = stdin;
-#if defined(_WIN32) || defined(MSDOS)
-		/*
-		 * We're reading from the standard input, so put it in binary
-		 * mode, as savefiles are binary files.
-		 */
-		SET_BINMODE(fp);
-#endif
+
+	if (plugin->open_read == NULL) {
+		pcap_snprintf(errbuf, PCAP_ERRBUF_SIZE,
+		    "No file reading function found");
+		return NULL;
 	}
-	else {
-		/*
-		 * "b" is supported as of C90, so *all* UN*Xes should
-		 * support it, even though it does nothing.  It's
-		 * required on Windows, as the file is a binary file
-		 * and must be read in binary mode.
-		 */
-		fp = fopen(fname, "rb");
-		if (fp == NULL) {
-			pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
-			    errno, "%s", fname);
-			return (NULL);
-		}
+
+	fp = plugin->open_read(fname, errbuf);
+	if (fp == NULL) {
+		return (NULL);
 	}
+
 	p = pcap_fopen_offline_with_tstamp_precision(fp, precision, errbuf);
 	if (p == NULL) {
 		if (fp != stdin)

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -56,19 +56,6 @@
 #include "sf-pcap.h"
 
 /*
- * Setting O_BINARY on DOS/Windows is a bit tricky
- */
-#if defined(_WIN32)
-  #define SET_BINMODE(f)  _setmode(_fileno(f), _O_BINARY)
-#elif defined(MSDOS)
-  #if defined(__HIGHC__)
-  #define SET_BINMODE(f)  setmode(f, O_BINARY)
-  #else
-  #define SET_BINMODE(f)  setmode(fileno(f), O_BINARY)
-  #endif
-#endif
-
-/*
  * Standard libpcap format.
  */
 #define TCPDUMP_MAGIC		0xa1b2c3d4
@@ -774,15 +761,11 @@ pcap_setup_dump(pcap_t *p, int linktype, FILE *f, const char *fname)
 
 #if defined(_WIN32) || defined(MSDOS)
 	/*
-	 * If we're writing to the standard output, put it in binary
-	 * mode, as savefiles are binary files.
+	 * If we're not writing to the standard output, turn of buffering.
 	 *
-	 * Otherwise, we turn off buffering.
 	 * XXX - why?  And why not on the standard output?
 	 */
-	if (f == stdout)
-		SET_BINMODE(f);
-	else
+	if (f != stdout)
 		setvbuf(f, NULL, _IONBF, 0);
 #endif
 	if (sf_write_header(p, f, linktype, p->snapshot) == -1) {
@@ -801,6 +784,7 @@ pcap_setup_dump(pcap_t *p, int linktype, FILE *f, const char *fname)
 pcap_dumper_t *
 pcap_dump_open(pcap_t *p, const char *fname)
 {
+	const pcap_ioplugin_t *plugin = pcap_ioplugin_init(getenv("PCAP_IOPLUGIN_WRITE"));
 	FILE *f;
 	int linktype;
 
@@ -828,23 +812,18 @@ pcap_dump_open(pcap_t *p, const char *fname)
 		    "A null pointer was supplied as the file name");
 		return NULL;
 	}
-	if (fname[0] == '-' && fname[1] == '\0') {
-		f = stdout;
-		fname = "standard output";
-	} else {
-		/*
-		 * "b" is supported as of C90, so *all* UN*Xes should
-		 * support it, even though it does nothing.  It's
-		 * required on Windows, as the file is a binary file
-		 * and must be written in binary mode.
-		 */
-		f = fopen(fname, "wb");
-		if (f == NULL) {
-			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
-			    errno, "%s", fname);
-			return (NULL);
-		}
+
+	if (plugin->open_write == NULL) {
+		pcap_snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		    "No file writing function found");
+		return NULL;
 	}
+
+	f = plugin->open_write(fname, p->errbuf);
+	if (f == NULL) {
+		return NULL;
+	}
+
 	return (pcap_setup_dump(p, linktype, f, fname));
 }
 


### PR DESCRIPTION
This replaces #578 which I messed up when performing a second rebase.

With this patch deployed, `libpcap` checks the environment variables `PCAP_IOPLUGIN_READ` and `PCAP_IOPLUGIN_WRITE` for dynamically-loadable plugins that replace the file I/O routines, e.g. for automatic decompression or compression of pcap files.

Plugins use `fopencookie` or `funopen` (O/S dependent) to create a virtual `FILE*` handle which is then returned to existing `libpcap` functions.    A sample plugin with gzip support is at https://github.com/raybellis/libpcap-gzip

If the plugin is not found or does not initialise properly the system falls back to generic `stdio`-based functions that are provided in `pcap-ioplugin.c` and which now handle the use of `-` to indicate `stdin` or `stdout` there instead of in `savefile.c` (simplifying the code in the latter).