### PR TITLE
Fixed the fread call in the savefile.c file

### DIFF
--- a/savefile.c
+++ b/savefile.c
@@ -360,7 +360,7 @@ pcap_fopen_offline_with_tstamp_precision(FILE *fp, u_int precision,
 	 * numbers that are unique in their first 4 bytes.
 	 */
 	amt_read = fread(&magic, sizeof(magic), 1, fp);
-	if (amt_read != sizeof(magic)) {
+	if (amt_read != 1) {
 		if (ferror(fp)) {
 			pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
 			    errno, "error reading dump file");

--- a/savefile.c
+++ b/savefile.c
@@ -359,7 +359,7 @@ pcap_fopen_offline_with_tstamp_precision(FILE *fp, u_int precision,
 	 * Windows Sniffer, and Microsoft Network Monitor) all have magic
 	 * numbers that are unique in their first 4 bytes.
 	 */
-	amt_read = fread((char *)&magic, 1, sizeof(magic), fp);
+	amt_read = fread(&magic, sizeof(magic), 1, fp);
 	if (amt_read != sizeof(magic)) {
 		if (ferror(fp)) {
 			pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,


### PR DESCRIPTION
Currently it was an undefined behavior (UB).
It passes wrong parameters to the fread function call (1 byte, 4 elements).
It should be 4 bytes and 1 element because the `magic` variable is a single 32-bits integer (4 bytes).

```
bytes_read = fread(pointer, number_of_bytes, number_of_elements, file);
```

On some machines the `fread()` call returned 0 with no error from the `ferror()` call for
correct and valid PCAP file.

Reference: https://en.cppreference.com/w/c/io/fread