### PR TITLE
Fixes double free in opt_cleanup

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -2051,18 +2051,12 @@ intern_blocks(opt_state_t *opt_state, struct icode *ic)
 static void
 opt_cleanup(opt_state_t *opt_state)
 {
-	if (opt_state->vnode_base)
-		free((void *)opt_state->vnode_base);
-	if (opt_state->vmap)
-		free((void *)opt_state->vmap);
-	if (opt_state->edges)
-		free((void *)opt_state->edges);
-	if (opt_state->space)
-		free((void *)opt_state->space);
-	if (opt_state->levels)
-		free((void *)opt_state->levels);
-	if (opt_state->blocks)
-		free((void *)opt_state->blocks);
+	free((void *)opt_state->vnode_base);
+	free((void *)opt_state->vmap);
+	free((void *)opt_state->edges);
+	free((void *)opt_state->space);
+	free((void *)opt_state->levels);
+	free((void *)opt_state->blocks);
 }
 
 /*

--- a/optimize.c
+++ b/optimize.c
@@ -2051,12 +2051,18 @@ intern_blocks(opt_state_t *opt_state, struct icode *ic)
 static void
 opt_cleanup(opt_state_t *opt_state)
 {
-	free((void *)opt_state->vnode_base);
-	free((void *)opt_state->vmap);
-	free((void *)opt_state->edges);
-	free((void *)opt_state->space);
-	free((void *)opt_state->levels);
-	free((void *)opt_state->blocks);
+	if (opt_state->vnode_base)
+		free((void *)opt_state->vnode_base);
+	if (opt_state->vmap)
+		free((void *)opt_state->vmap);
+	if (opt_state->edges)
+		free((void *)opt_state->edges);
+	if (opt_state->space)
+		free((void *)opt_state->space);
+	if (opt_state->levels)
+		free((void *)opt_state->levels);
+	if (opt_state->blocks)
+		free((void *)opt_state->blocks);
 }
 
 /*
@@ -2183,6 +2189,7 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	opt_state->edges = (struct edge **)calloc(opt_state->n_edges, sizeof(*opt_state->edges));
 	if (opt_state->edges == NULL) {
 		free(opt_state->blocks);
+		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 
@@ -2193,6 +2200,8 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	if (opt_state->levels == NULL) {
 		free(opt_state->edges);
 		free(opt_state->blocks);
+		opt_state->edges = NULL;
+		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 
@@ -2206,6 +2215,9 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 		free(opt_state->levels);
 		free(opt_state->edges);
 		free(opt_state->blocks);
+		opt_state->levels = NULL;
+		opt_state->edges = NULL;
+		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 	p = opt_state->space;
@@ -2249,6 +2261,10 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 		free(opt_state->levels);
 		free(opt_state->edges);
 		free(opt_state->blocks);
+		opt_state->space = NULL;
+		opt_state->levels = NULL;
+		opt_state->edges = NULL;
+		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 	opt_state->vnode_base = (struct valnode *)calloc(opt_state->maxval, sizeof(*opt_state->vnode_base));
@@ -2258,6 +2274,11 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 		free(opt_state->levels);
 		free(opt_state->edges);
 		free(opt_state->blocks);
+		opt_state->vmap = NULL;
+		opt_state->space = NULL;
+		opt_state->levels = NULL;
+		opt_state->edges = NULL;
+		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 }

--- a/optimize.c
+++ b/optimize.c
@@ -2188,8 +2188,6 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	opt_state->n_edges = 2 * opt_state->n_blocks;
 	opt_state->edges = (struct edge **)calloc(opt_state->n_edges, sizeof(*opt_state->edges));
 	if (opt_state->edges == NULL) {
-		free(opt_state->blocks);
-		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 
@@ -2198,10 +2196,6 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	 */
 	opt_state->levels = (struct block **)calloc(opt_state->n_blocks, sizeof(*opt_state->levels));
 	if (opt_state->levels == NULL) {
-		free(opt_state->edges);
-		free(opt_state->blocks);
-		opt_state->edges = NULL;
-		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 
@@ -2212,12 +2206,6 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	opt_state->space = (bpf_u_int32 *)malloc(2 * opt_state->n_blocks * opt_state->nodewords * sizeof(*opt_state->space)
 				 + opt_state->n_edges * opt_state->edgewords * sizeof(*opt_state->space));
 	if (opt_state->space == NULL) {
-		free(opt_state->levels);
-		free(opt_state->edges);
-		free(opt_state->blocks);
-		opt_state->levels = NULL;
-		opt_state->edges = NULL;
-		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 	p = opt_state->space;
@@ -2257,28 +2245,10 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	opt_state->maxval = 3 * max_stmts;
 	opt_state->vmap = (struct vmapinfo *)calloc(opt_state->maxval, sizeof(*opt_state->vmap));
 	if (opt_state->vmap == NULL) {
-		free(opt_state->space);
-		free(opt_state->levels);
-		free(opt_state->edges);
-		free(opt_state->blocks);
-		opt_state->space = NULL;
-		opt_state->levels = NULL;
-		opt_state->edges = NULL;
-		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 	opt_state->vnode_base = (struct valnode *)calloc(opt_state->maxval, sizeof(*opt_state->vnode_base));
 	if (opt_state->vnode_base == NULL) {
-		free(opt_state->vmap);
-		free(opt_state->space);
-		free(opt_state->levels);
-		free(opt_state->edges);
-		free(opt_state->blocks);
-		opt_state->vmap = NULL;
-		opt_state->space = NULL;
-		opt_state->levels = NULL;
-		opt_state->edges = NULL;
-		opt_state->blocks = NULL;
 		opt_error(opt_state, "malloc");
 	}
 }


### PR DESCRIPTION
Found by oss-fuzz
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=15178

When `opt_init` fails after allocating some of `opt_state` fields, they get double freed : once in `opt_init` and once again in `opt_cleanup` after `opt_error` called `longjmp`

Proposed fix is :
- do not free null pointers (`opt_state` is memset to zero in `bpf_optimize`)
- set pointers to null after we free them in `opt_init`