### PR TITLE
A new filter "ifindex" for LINUX_SLL2 and live Linux captures

### DIFF
--- a/gencode.h
+++ b/gencode.h
@@ -328,6 +328,7 @@ struct block *gen_greater(compiler_state_t *, int);
 struct block *gen_byteop(compiler_state_t *, int, int, bpf_u_int32);
 struct block *gen_broadcast(compiler_state_t *, int);
 struct block *gen_multicast(compiler_state_t *, int);
+struct block *gen_ifindex(compiler_state_t *, int);
 struct block *gen_inbound(compiler_state_t *, int);
 
 struct block *gen_llc(compiler_state_t *);

--- a/grammar.y
+++ b/grammar.y
@@ -355,6 +355,7 @@ DIAG_OFF_BISON_BYACC
 %token  ATALK AARP DECNET LAT SCA MOPRC MOPDL
 %token  TK_BROADCAST TK_MULTICAST
 %token  NUM INBOUND OUTBOUND
+%token  IFINDEX
 %token  PF_IFNAME PF_RSET PF_RNR PF_SRNR PF_REASON PF_ACTION
 %token	TYPE SUBTYPE DIR ADDR1 ADDR2 ADDR3 ADDR4 RA TA
 %token  LINK
@@ -581,6 +582,7 @@ other:	  pqual TK_BROADCAST	{ CHECK_PTR_VAL(($$ = gen_broadcast(cstate, $1))); }
 	| CBYTE NUM byteop NUM	{ CHECK_PTR_VAL(($$ = gen_byteop(cstate, $3, $2, $4))); }
 	| INBOUND		{ CHECK_PTR_VAL(($$ = gen_inbound(cstate, 0))); }
 	| OUTBOUND		{ CHECK_PTR_VAL(($$ = gen_inbound(cstate, 1))); }
+	| IFINDEX NUM		{ CHECK_PTR_VAL(($$ = gen_ifindex(cstate, $2))); }
 	| VLAN pnum		{ CHECK_PTR_VAL(($$ = gen_vlan(cstate, $2, 1))); }
 	| VLAN			{ CHECK_PTR_VAL(($$ = gen_vlan(cstate, 0, 0))); }
 	| MPLS pnum		{ CHECK_PTR_VAL(($$ = gen_mpls(cstate, $2, 1))); }

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -5923,6 +5923,12 @@ fix_offset(pcap_t *handle, struct bpf_insn *p)
 			 * special magic kernel offset for that field.
 			 */
 			p->k = SKF_AD_OFF + SKF_AD_PROTOCOL;
+		} else if (p->k == 4) {
+			/*
+			 * It's the ifindex field; map it to the
+			 * special magic kernel offset for that field.
+			 */
+			p->k = SKF_AD_OFF + SKF_AD_IFINDEX;
 		} else if (p->k == 10) {
 			/*
 			 * It's the packet type field; map it to the

--- a/scanner.l
+++ b/scanner.l
@@ -337,6 +337,8 @@ len|length	return LEN;
 inbound		return INBOUND;
 outbound	return OUTBOUND;
 
+ifindex		return IFINDEX;
+
 vlan		return VLAN;
 mpls		return MPLS;
 pppoed		return PPPOED;


### PR DESCRIPTION
Create a filter for the ifIndex field in the LINUX_SLL2 pcap format, and convert it to the right SKF_AD_ value for live captures.
