### PR TITLE
Added support for icmp6 types 1-4 as tokens in scanner.l

### DIFF
--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -877,7 +877,9 @@ The following ICMP type field values are available: \fBicmp-echoreply\fP,
 \fBicmp-tstampreply\fP, \fBicmp-ireq\fP, \fBicmp-ireqreply\fP,
 \fBicmp-maskreq\fP, \fBicmp-maskreply\fP.
 
-The following ICMPv6 type fields are available: \fBicmp6-echo\fP,
+The following ICMPv6 type fields are available: \fBicmp6-destinationrunreach\fP,
+\fBicmp6-packettoobig\fP, \fBicmp6-timeexceeded\fP, 
+\fBicmp6-parameterproblem\fP, \fBicmp6-echo\fP,
 \fBicmp6-echoreply\fP, \fBicmp6-multicastlistenerquery\fP,
 \fBicmp6-multicastlistenerreportv1\fP, \fBicmp6-multicastlistenerdone\fP,
 \fBicmp6-routersolicit\fP, \fBicmp6-routeradvert\fP,
@@ -1024,6 +1026,8 @@ ping packets):
 .nf
 .B
 icmp[icmptype] != icmp-echo and icmp[icmptype] != icmp-echoreply
+.B
+icmp6[icmp6type] != icmp6-echo and icmp6[icmp6type] != icmp6-echoreply
 .fi
 .RE
 .SH "SEE ALSO"
@@ -1045,7 +1049,9 @@ correctly handle 802.11 data packets with both To DS and From DS set.
 .BR "ip6 proto"
 should chase header chain, but at this moment it does not.
 .BR "ip6 protochain"
-is supplied for this behavior.
+is supplied for this behavior.  For example, to match ipv6 fragments:
+.B
+ip6 protochain 44
 .LP
 Arithmetic expression against transport layer headers, like \fBtcp[0]\fP,
 does not work against IPv6 packets.

--- a/scanner.l
+++ b/scanner.l
@@ -436,6 +436,10 @@ icmp-maskreply		{ yylval->h = 18; return NUM; }
 icmp6type       { yylval->h = 0; return NUM; }
 icmp6code       { yylval->h = 1; return NUM; }
 
+icmp6-destinationunreach	{ yylval->h = 1; return NUM; }
+icmp6-packettoobig		{ yylval->h = 2; return NUM; }
+icmp6-timeexceeded		{ yylval->h = 3; return NUM; }
+icmp6-parameterproblem		{ yylval->h = 4; return NUM; }
 icmp6-echo      { yylval->h = 128; return NUM; }
 icmp6-echoreply { yylval->h = 129; return NUM; }
 icmp6-multicastlistenerquery    { yylval->h = 130; return NUM; }


### PR DESCRIPTION
Updated pcap-filter.manmisc.in to clarify new token usage
Added an example to pcap-filter.manmisc.in for ip6 protochain for fragments
