### PR TITLE
Add support for uClibc < 0.9.31

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -2894,8 +2894,12 @@ get_if_flags(const char *name, bpf_u_int32 *flags, char *errbuf)
 
 				case ARPHRD_IRDA:
 				case ARPHRD_IEEE80211:
+#ifdef ARPHRD_IEEE80211_PRISM
 				case ARPHRD_IEEE80211_PRISM:
+#endif
+#ifdef ARPHRD_IEEE80211_RADIOTAP
 				case ARPHRD_IEEE80211_RADIOTAP:
+#endif
 #ifdef ARPHRD_IEEE802154
 				case ARPHRD_IEEE802154:
 #endif


### PR DESCRIPTION
FWIW the systems where I found this to be a problem define ARPHRD_IEEE80211_PRISM and ARPHRD_IEEE80211_RADIOTAP, but only in `linux/if_arp.h`, not in `net/if_arp.h`.

This file being `pcap-linux.c` not sure whether to argue for changing the #include.
