### PR TITLE
Fix missing underscore in pcap man page.

### DIFF
--- a/pcap.3pcap.in
+++ b/pcap.3pcap.in
@@ -420,7 +420,7 @@ set packet buffer timeout for a not-yet-activated
 .B pcap_t
 for live capture
 .TP
-.BR pcap_set_immediate mode (3PCAP)
+.BR pcap_set_immediate_mode (3PCAP)
 set immediate mode for a not-yet-activated
 .B pcap_t
 for live capture


### PR DESCRIPTION
pcap_set_immediate mode -> pcap_set_immediate_mode