### PR TITLE
CMAKE_C_LIBRARY_ARCHITECTURE

### DIFF
--- a/cmake/Modules/FindPacket.cmake
+++ b/cmake/Modules/FindPacket.cmake
@@ -59,6 +59,7 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   # without searching in the Lib directory first appears to be to set
   # CMAKE_LIBRARY_ARCHITECTURE to "x64".
   #
+  set(CMAKE_C_LIBRARY_ARCHITECTURE "x64")
   set(CMAKE_LIBRARY_ARCHITECTURE "x64")
 endif()
 

--- a/cmake/Modules/FindPacket.cmake
+++ b/cmake/Modules/FindPacket.cmake
@@ -58,6 +58,10 @@ if(CMAKE_SIZEOF_VOID_P EQUAL 8)
   # without searching in the Lib directory first appears to be to set
   # CMAKE_LIBRARY_ARCHITECTURE to "x64".
   #
+  # In newer versions of CMake, CMAKE_LIBRARY_ARCHITECTURE is set according to
+  # the language, e.g., CMAKE_<LANG>_LIBRARY_ARCHITECTURE. Consequently, it makes
+  # better sense to set CMAKE_C_LIBRARY_ARCHITECTURE as well.
+  #
   set(CMAKE_C_LIBRARY_ARCHITECTURE "x64")
   set(CMAKE_LIBRARY_ARCHITECTURE "x64")
 endif()


### PR DESCRIPTION
Set CMAKE_C_LIBRARY_ARCHITECTURE in addition to CMAKE_LIBRARY_ARCHITECTURE
for more recent versions of CMake. CMAKE_C_LIBRARY_ARCHITECTURE is
apparently now preferred over CMAKE_LIBRARY_ARCHITECTURE.