### PR TITLE
Nine is a digit.

### DIFF
--- a/etherent.c
+++ b/etherent.c
@@ -44,7 +44,7 @@ static inline int skip_line(FILE *);
 static inline u_char
 xdtoi(u_char c)
 {
-	if (c >= '0' && c < '9')
+	if (c >= '0' && c <= '9')
 		return (u_char)(c - '0');
 	else if (c >= 'a' && c <= 'f')
 		return (u_char)(c - 'a' + 10);

--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -652,7 +652,7 @@ pcap_nametollc(const char *s)
 static inline u_char
 xdtoi(u_char c)
 {
-	if (c >= '0' && c < '9')
+	if (c >= '0' && c <= '9')
 		return (u_char)(c - '0');
 	else if (c >= 'a' && c <= 'f')
 		return (u_char)(c - 'a' + 10);


### PR DESCRIPTION
Fixes fencepost error in git commit 5a41835

Closes #846 - testing:
```
% tcpdump -d ether dst host 00:01:03:05:07:09
(000) ld       [2]
(001) jeq      #0x3050709       jt 2    jf 5
(002) ldh      [0]
(003) jeq      #0x1             jt 4    jf 5
(004) ret      #262144
(005) ret      #0
```