### PR TITLE
Linux: get ifdrop stats from sysfs.

### DIFF
--- a/testprogs/capturetest.c
+++ b/testprogs/capturetest.c
@@ -188,6 +188,10 @@ main(int argc, char **argv)
 		if (status != 0) {
 			printf("%d packets seen, %d packets counted after pcap_dispatch returns\n",
 			    status, packet_count);
+			struct pcap_stat ps;
+			pcap_stats(pd, &ps);
+			printf("%d ps_recv, %d ps_drop, %d ps_ifdrop\n",
+			    ps.ps_recv, ps.ps_drop, ps.ps_ifdrop);
 		}
 	}
 	if (status == -2) {


### PR DESCRIPTION
This change-set trades off possible over-accounting of packet loss by possible under-accounting it.
The previous way, reading the `rx_dropped` field from `/proc/net/dev` would always count not just what the interface loses (which is what we want), but what the link and upper layers decide to drop.
Instead, the sysfs stats are more accurate, and represent only one event each.
We care about those reported as missed and ones coming from FIFO errors, so we only gather that.
However, not all Linux drivers correctly fill these stats, and use `rx_dropped` as a one-size-fits-all stat.
For these cards, we lose the ability to account for interface-level losses.
Linux defaults that value to 0 in that case, so it follows what the manual specifies.

Due to lack of tools to simulate the loss, I tested this by stepping with a debugger to check the right values were read.

This addresses #828.