### PR TITLE
Linux: remove support for SOCK_PACKET.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -697,11 +697,6 @@ else
 		# No prizes for guessing this one.
 		#
 		V_PCAP=linux
-
-		#
-		# XXX - this won't work with older kernels that have
-		# SOCK_PACKET sockets but not PF_PACKET sockets.
-		#
 		VALGRINDTEST_SRC=valgrindtest.c
 	elif test "$ac_cv_header_net_pfilt_h" = yes; then
 	        #


### PR DESCRIPTION
Removes code supporting SOCK_PACKET, as well as any mentions I could find, and makes the code expect AF_PACKET to be present.
Later on I will be updating with whatever we agree to remove, and will add a simple version check that warns the user if their system is unsupported, as well as the last version supporting it.