### PR TITLE
Ignore ENETDOWN

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -5149,6 +5149,7 @@ static int pcap_wait_for_frames_mmap(pcap_t *handle)
 					snprintf(handle->errbuf,
 						PCAP_ERRBUF_SIZE,
 						"The interface went down");
+					continue;
 				} else {
 					pcap_fmt_errmsg_for_errno(handle->errbuf,
 					    PCAP_ERRBUF_SIZE, errno,


### PR DESCRIPTION
It was the initial intent of @yuguy back in 2008 with this [commit](https://github.com/the-tcpdump-group/libpcap/commit/34624f128f2e6f937c04317fdd2c0ae6d8883ad5) to ignore `ENETDOWN` and allow libpcap to continue even if the interface goes down.

This functionality was later broken; probably by this [commit](https://github.com/the-tcpdump-group/libpcap/commit/e9de4b862ed18e08b9d1d8f04c804bed30a51431).

I'd like to propose that we attempt a fix with this small change.

The one thing I'm not sure of without really digging in is what the call structure looks like to get to each of `pcap_read_packet()` vs `pcap_wait_for_frames_mmap()`.

I would also like to know if I should restore the change that once existed from @yuguy 's commit in the `pcap_read_packet()` function by switching the do-while conditional back to include a test on `ENETDOWN` and effectively ignoring it there as well.