### PR TITLE
Provide APIs to map between DLT_ values and LINKTYPE_ values

### DIFF
--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -477,6 +477,8 @@ PCAP_API int	pcap_is_swapped(pcap_t *);
 PCAP_API int	pcap_major_version(pcap_t *);
 PCAP_API int	pcap_minor_version(pcap_t *);
 PCAP_API int	pcap_bufsize(pcap_t *);
+PCAP_API int    dlt_to_linktype(int dlt);
+PCAP_API int    linktype_to_dlt(int dlt);
 
 /* XXX */
 PCAP_API FILE	*pcap_file(pcap_t *);


### PR DESCRIPTION
So it's useable in the .so, not just the .a version of the lib.
This is relevant as the moloch project is using this function in https://github.com/aol/moloch/blob/master/capture/reader-libpcap.c#L94
The full issue is described at https://github.com/aol/moloch/issues/1303