### PR TITLE
Unset HAVE_LIBNL if BUILD_WITH_LIBNL is not set

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1650,6 +1650,8 @@ main(void)
             endif(HAVE_STRUCT_SOCKADDR_HCI_HCI_CHANNEL)
         endif(HAVE_BLUETOOTH_BLUETOOTH_H)
     endif()
+else()
+    unset(PCAP_SUPPORT_BT_MONITOR CACHE)
 endif()
 
 # Check for Bluetooth sniffing support

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1329,6 +1329,8 @@ else(WIN32)
                     endif()
                 endif()
             endif()
+        else()
+            unset(HAVE_LIBNL CACHE) # check_function_exists stores results in cache
         endif()
 
         check_include_file(linux/ethtool.h HAVE_LINUX_ETHTOOL_H)


### PR DESCRIPTION
HAVE_LIBNL is the result of check_function_exists();
check_function_exists() stores its results in cache. As such, setting
BUILD_WITH_LIBNL to FALSE after the initial CMake run didn't work. This
patch fixes that.