### PR TITLE
Fix compiler warnings on MSYS2/Cygwin

### DIFF
--- a/ftmacros.h
+++ b/ftmacros.h
@@ -83,7 +83,7 @@
    * least with HP's C compiler; hopefully doing so won't make it
    * *not* work with *un*-threaded code.
    */
-#elif defined(__linux__) || defined(linux) || defined(__linux)
+#elif defined(__linux__) || defined(linux) || defined(__linux) || defined(__CYGWIN__)
   /*
    * Turn on _GNU_SOURCE to get everything GNU libc has to offer,
    * including asprintf().


### PR DESCRIPTION
```
/f/Projects/libpcap/fmtutils.c:114:20: warning: initialization of ‘char *’ from ‘int’ makes pointer from integer without a cast [-Wint-conversion]
  114 |  char *errstring = strerror_r(errnum, strerror_buf, PCAP_ERRBUF_SIZE);
      |                    ^~~~~~~~~~
```

CMake executes the test for strerror_r with GNU_SOURCE defined,
but the actual application did not define it.