### PR TITLE
Linux: expect eventfd.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,11 +402,6 @@ main(void)
         # linux/if_bonding.h requires sys/socket.h.
         #
         check_include_files("sys/socket.h;linux/if_bonding.h" HAVE_LINUX_IF_BONDING_H)
-
-        #
-        # Check for the eventfd header.
-        #
-        check_include_files("sys/eventfd.h" HAVE_SYS_EVENTFD_H)
     endif()
 endif(NOT WIN32)
 

--- a/configure.ac
+++ b/configure.ac
@@ -95,12 +95,6 @@ linux*|uclinux*)
 #include <linux/if.h>
 	])
 
-	#
-	# Check for the eventfd header.
-	#
-	AC_CHECK_HEADERS(sys/eventfd.h)
-	;;
-
 haiku*)
 	#
 	# Haiku needs _BSD_SOURCE for the _IO* macros because it doesn't use them.


### PR DESCRIPTION
Since eventfd was introduced in the same release as TPACKET_V2 (2.6.27),
and we require TPACKET_V2 to function, it's a reasonably certain assumption
that we can use eventfd for signaling termination.