### PR TITLE
Plug memory-leak

### DIFF
--- a/testprogs/opentest.c
+++ b/testprogs/opentest.c
@@ -81,7 +81,7 @@ main(int argc, char **argv)
 		switch (op) {
 
 		case 'i':
-			device = optarg;
+			device = strdup(optarg);
 			break;
 
 		case 'I':
@@ -192,6 +192,7 @@ main(int argc, char **argv)
 		else
 			printf("%s opened successfully\n", device);
 	}
+	free(device);
 	pcap_close(pd);
 	exit(status < 0 ? 1 : 0);
 }


### PR DESCRIPTION
If the `-i` option is not used, the `strdup()` memory was not freed.
To keep the code simpler, use `strdup()` on the `-i` argument.