### PR TITLE
add linktype for ATSC ALP link protocol

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1186,7 +1186,12 @@
  */
 #define LINKTYPE_USB_2_0	288
 
-#define LINKTYPE_MATCHING_MAX	288		/* highest value in the "matching" range */
+/*
+ * ATSC Link-Layer Protocol (A/330) packets.
+ */
+#define LINKTYPE_ATSC_ALP	289
+
+#define LINKTYPE_MATCHING_MAX	289		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1473,6 +1473,11 @@
 #define DLT_USB_2_0		288
 
 /*
+ * ATSC Link-Layer Protocol (A/330) packets.
+ */
+#define DLT_ATSC_ALP		289
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1482,7 +1487,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	288	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	289	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
ATSC 3.0 uses a new packet based link layer - ATSC Link-Layer Protocol (ALP) as defined in the ATSC A/330 specification. The link layer typically carries multicast UDP/IPv4 packets and signalling packets.

ATSC 3.0 devices may use this linktype to capture ALP packets and output in pcap format.

(Silicondust makes network attached tuner devices with open APIs for anyone to use)