### PR TITLE
dpdk: add rte_ prefix to ether definitions

### DIFF
--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -152,7 +152,7 @@ static char dpdk_cfg_buf[DPDK_CFG_MAX_LEN];
 static uint16_t nb_rxd = RTE_TEST_RX_DESC_DEFAULT;
 static uint16_t nb_txd = RTE_TEST_TX_DESC_DEFAULT;
 
-#define RTE_ETH_PCAP_SNAPLEN ETHER_MAX_JUMBO_FRAME_LEN
+#define RTE_ETH_PCAP_SNAPLEN RTE_ETHER_MAX_JUMBO_FRAME_LEN
 
 static struct rte_eth_dev_tx_buffer *tx_buffer;
 
@@ -176,7 +176,7 @@ struct pcap_dpdk{
 	uint64_t bps;
 	struct rte_mempool * pktmbuf_pool;
 	struct dpdk_ts_helper ts_helper;
-	struct ether_addr eth_addr;
+	struct rte_ether_addr eth_addr;
 	char mac_addr[DPDK_MAC_ADDR_SIZE];
 	char pci_addr[DPDK_PCI_ADDR_SIZE];
 	unsigned char pcap_tmp_buf[RTE_ETH_PCAP_SNAPLEN];
@@ -365,7 +365,7 @@ static int pcap_dpdk_dispatch(pcap_t *p, int max_cnt, pcap_handler cb, u_char *c
 				bp = rte_pktmbuf_mtod(m, u_char *);
 			}else{
 				// use fast buffer pcap_tmp_buf if pkt_len is small, no need to call malloc and free
-				if ( pkt_len <= ETHER_MAX_JUMBO_FRAME_LEN)
+				if ( pkt_len <= RTE_ETHER_MAX_JUMBO_FRAME_LEN)
 				{
 					gather_len = dpdk_gather_data(pd->pcap_tmp_buf, RTE_ETH_PCAP_SNAPLEN, m);
 					bp = pd->pcap_tmp_buf;
@@ -472,7 +472,7 @@ static int check_link_status(uint16_t portid, struct rte_eth_link *plink)
 	rte_eth_link_get(portid, plink);
 	return plink->link_status == ETH_LINK_UP;
 }
-static void eth_addr_str(struct ether_addr *addrp, char* mac_str, int len)
+static void eth_addr_str(struct rte_ether_addr *addrp, char* mac_str, int len)
 {
 	int offset=0;
 	if (addrp == NULL){
@@ -973,7 +973,7 @@ int pcap_dpdk_findalldevs(pcap_if_list_t *devlistp, char *ebuf)
 	unsigned int nb_ports = 0;
 	char dpdk_name[DPDK_DEV_NAME_MAX];
 	char dpdk_desc[DPDK_DEV_DESC_MAX];
-	struct ether_addr eth_addr;
+	struct rte_ether_addr eth_addr;
 	char mac_addr[DPDK_MAC_ADDR_SIZE];
 	char pci_addr[DPDK_PCI_ADDR_SIZE];
 	do{


### PR DESCRIPTION
DPDK commits 35b2d13fd6fd ("net: add rte prefix to ether defines")
and 6d13ea8e8e49 ("net: add rte prefix to ether structures") renamed
ETHER_MAX_JUMBO_FRAME_LEN to RTE_ETHER_MAX_JUMBO_FRAME_LEN and struct
ether_addr to struct rte_ether_addr.

Fix the compilation of pcap-dpdk.c, which currently fails with:

    error: ‘ETHER_MAX_JUMBO_FRAME_LEN’ undeclared here (not in a function); did you mean ‘RTE_ETHER_MAX_JUMBO_FRAME_LEN’?
    ...
    error: field ‘eth_addr’ has incomplete type
    ...
    error: dereferencing pointer to incomplete type ‘struct ether_addr’

Signed-off-by: Vivien Didelot <vivien.didelot@gmail.com>
Cc: @jingleyang