### PR TITLE
fix pktgen-dpdk cross compilation with libpcap library

### DIFF
--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -241,8 +241,12 @@ struct bpf_insn {
 /*
  * Macros for insn array initializers.
  */
+#ifndef BPF_STMT
 #define BPF_STMT(code, k) { (u_short)(code), 0, 0, k }
+#endif
+#ifndef BPF_JUMP
 #define BPF_JUMP(code, k, jt, jf) { (u_short)(code), jt, jf, k }
+#endif
 
 PCAP_API u_int	bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
 PCAP_API int	bpf_validate(const struct bpf_insn *f, int len);


### PR DESCRIPTION
While cross compiling an applicaion with libpcap library,
if the function BPF_STMT and BPF_JUMP already defined in
toolchain, it fails to build.

This pach fixes this issue by checking if the function is
defined already before defining it.

Signed-off-by: Rohit Raj <rohit.raj@nxp.com>