### PR TITLE
RFC: Remove undocumented and rather old "ether proto" protocols

### DIFF
--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -361,9 +361,9 @@ True if the packet is an IPv6 multicast packet.
 .IP  "\fBether proto \fIprotocol\fR"
 True if the packet is of ether type \fIprotocol\fR.
 \fIProtocol\fP can be a number or one of the names
-\fBip\fP, \fBip6\fP, \fBarp\fP, \fBrarp\fP, \fBatalk\fP, \fBaarp\fP,
-\fBdecnet\fP, \fBsca\fP, \fBlat\fP, \fBmopdl\fP, \fBmoprc\fP,
-\fBiso\fP, \fBstp\fP, \fBipx\fP, or \fBnetbeui\fP.
+\fBaarp\fP, \fBarp\fP, \fBatalk\fP, \fBdecnet\fP, \fBip\fP, \fBip6\fP,
+\fBipx\fP, \fBiso\fP, \fBlat\fP, \fBmopdl\fP, \fBmoprc\fP, \fBnetbeui\fP,
+\fBrarp\fP, \fBsca\fP or \fBstp\fP.
 Note these identifiers are also keywords
 and must be escaped via backslash (\\).
 .IP


### PR DESCRIPTION
They were never documented (at least since 1999).

The only documented protocols are:
```
    ether proto protocol
          True if the packet is of ether type protocol.  Protocol can be a
          number or one of the names ip, ip6, arp, rarp, atalk, aarp, dec-
          net,  sca,  lat,  mopdl, moprc, iso, stp, ipx, or netbeui.
```
(pcap-filter man page)

They are rather old and unlikely to be found in a capture file.

Summary:
```
protocol	value	IANA ieee-802-numbers.xhtml
--------        -----   ---------------------------
decdns		803c	DEC Unassigned
decdts		803e	DEC Unassigned
lanbridge	8038	DEC LANBridge
loopback	9000	Loopback
pup		0200	XEROX PUP
sprite		0500	<UNKWOWN in IANA Registry>
vexp		805b	Stanford V Kernel exp.
vprod		805c	Stanford V Kernel prod.
xns		0600	XEROX NS IDP
```