### PR TITLE
RFC: Remove undocumented and rather old "ether proto" protocols

### DIFF
--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -593,25 +593,17 @@ PCAP_API_DEF struct eproto eproto_db[] = {
 	{ "arp", ETHERTYPE_ARP },
 	{ "atalk", ETHERTYPE_ATALK },
 	{ "atalkarp", ETHERTYPE_AARP },
-	{ "decdns", ETHERTYPE_DECDNS },
-	{ "decdts", ETHERTYPE_DECDTS },
 	{ "decnet", ETHERTYPE_DN },
 	{ "ip", ETHERTYPE_IP },
 #ifdef INET6
 	{ "ip6", ETHERTYPE_IPV6 },
 #endif
-	{ "lanbridge", ETHERTYPE_LANBRIDGE },
 	{ "lat", ETHERTYPE_LAT },
 	{ "loopback", ETHERTYPE_LOOPBACK },
 	{ "mopdl", ETHERTYPE_MOPDL },
 	{ "moprc", ETHERTYPE_MOPRC },
-	{ "pup", ETHERTYPE_PUP },
 	{ "rarp", ETHERTYPE_REVARP },
 	{ "sca", ETHERTYPE_SCA },
-	{ "sprite", ETHERTYPE_SPRITE },
-	{ "vexp", ETHERTYPE_VEXP },
-	{ "vprod", ETHERTYPE_VPROD },
-	{ "xns", ETHERTYPE_NS },
 	{ (char *)0, 0 }
 };
 


### PR DESCRIPTION
They were never documented (at least since version 0.4 - 1999).

The only documented protocols are:
```
    ether proto protocol
          True if the packet is of ether type protocol.  Protocol can be a
          number  or  one  of the names aarp, arp, atalk, decnet, ip, ip6,
          ipx, iso, lat, mopdl, moprc, netbeui, rarp, sca  or  stp.
```
(pcap-filter man page)

They are rather old and unlikely to be found in a capture file.

Summary:
```
protocol	value	IANA ieee-802-numbers.xhtml
--------        -----   ---------------------------
decdns		803c	DEC Unassigned
decdts		803e	DEC Unassigned
lanbridge	8038	DEC LANBridge
pup		0200	XEROX PUP
sprite		0500	<UNKWOWN in IANA Registry>
vexp		805b	Stanford V Kernel exp.
vprod		805c	Stanford V Kernel prod.
xns		0600	XEROX NS IDP
```