### PR TITLE
Make packet_version_string const to match PacketGetVersion return type LPCSTR

### DIFF
--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -2125,7 +2125,7 @@ pcap_lib_version(void)
 		/*
 		 * Generate the version string.
 		 */
-		char *packet_version_string = PacketGetVersion();
+		const char *packet_version_string = PacketGetVersion();
 
 		if (strcmp(WINPCAP_VER_STRING, packet_version_string) == 0) {
 			/*


### PR DESCRIPTION
Minor change. We (Npcap) made a bunch of things `const` a while back, so the compiler issues a warning now for this.