### PR TITLE
Windows: Remove the socklen_t typedef.

### DIFF
--- a/pcap/socket.h
+++ b/pcap/socket.h
@@ -49,15 +49,6 @@
   #include <ws2tcpip.h>
 
   /*
-   * Winsock doesn't have this UN*X type; it's used in the UN*X
-   * sockets API.
-   *
-   * XXX - do we need to worry about UN*Xes so old that *they*
-   * don't have it, either?
-   */
-  typedef int socklen_t;
-
-  /*
    * Winsock doesn't have this POSIX type; it's used for the
    * tv_usec value of struct timeval.
    */


### PR DESCRIPTION
Ws2tcpip.h typedefs socklen_t, so we don't need to do so in socket.h.