### PR TITLE
Add separate ENABLE_RPCAPD option to build rpcapd

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ env:
     - REMOTE=disable CMAKE=no
     - ENABLE_REMOTE="" CMAKE=yes
     - REMOTE=enable CMAKE=no
-    - ENABLE_REMOTE="-DENABLE_REMOTE=ON" CMAKE=yes
+    - ENABLE_REMOTE="-DENABLE_REMOTE=ON -DENABLE_RPCAPD=ON" CMAKE=yes
 
 matrix:
   fast_finish: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,9 +205,11 @@ set(PCAP_TYPE "" CACHE STRING "Packet capture type")
 # not having it on UN*X.
 #
 if(WIN32)
-    option(ENABLE_REMOTE "Enable remote capture" ON)
+    option(ENABLE_RPCAPD "Enable building of rpcapd" ON)
+    option(ENABLE_REMOTE "Enable libpcap API for connecting to rpcapd" ON)
 else()
-    option(ENABLE_REMOTE "Enable remote capture" OFF)
+    option(ENABLE_RPCAPD "Enable building of rpcapd" OFF)
+    option(ENABLE_REMOTE "Enable libpcap API for connecting to rpcapd" OFF)
 endif(WIN32)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -2202,9 +2204,9 @@ endif(WIN32)
 # Add subdirectories after we've set various variables, so they pick up
 # pick up those variables.
 #
-if(ENABLE_REMOTE)
+if(ENABLE_RPCAPD)
     add_subdirectory(rpcapd)
-endif(ENABLE_REMOTE)
+endif(ENABLE_RPCAPD)
 add_subdirectory(testprogs)
 
 ######################################


### PR DESCRIPTION
This PR is related to https://github.com/the-tcpdump-group/libpcap/issues/955 and shows how `rpcapd` can be build without having to enable the new and experimental "remote" `libpcap` API (`ENABLE_REMOTE`).