### PR TITLE
Add split pcap dumping functionality to PCAP API

### DIFF
--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -596,6 +596,8 @@ PCAP_API int64_t	pcap_dump_ftell64(pcap_dumper_t *);
 PCAP_API int	pcap_dump_flush(pcap_dumper_t *);
 PCAP_API void	pcap_dump_close(pcap_dumper_t *);
 PCAP_API void	pcap_dump(u_char *, const struct pcap_pkthdr *, const u_char *);
+PCAP_API int	pcap_dump_split(u_char *, const struct pcap_pkthdr *, const u_char *, bpf_u_int32,
+	const u_char *, bpf_u_int32);
 
 PCAP_API int	pcap_findalldevs(pcap_if_t **, char *);
 PCAP_API void	pcap_freealldevs(pcap_if_t *);

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -765,7 +765,7 @@ pcap_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
  * Output a packet in two parts to the initialized dump file.
  */
 int
-pcap_dump_split(u_char *user, struct pcap_pkthdr *h, const u_char *sp1, bpf_u_int32 sp1_len,
+pcap_dump_split(u_char *user, const struct pcap_pkthdr *h, const u_char *sp1, bpf_u_int32 sp1_len,
 	const u_char *sp2, bpf_u_int32 sp2_len)
 {
 	register FILE *f;

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -768,7 +768,7 @@ int
 pcap_dump_split(u_char *user, struct pcap_pkthdr *h, const u_char *sp1, bpf_u_int32 sp1_len,
 	const u_char *sp2, bpf_u_int32 sp2_len)
 {
-	register File *f;
+	register FILE *f;
 	struct pcap_sf_pkthdr sf_hdr;
 
 	f = (FILE *)user;


### PR DESCRIPTION
Hello!

I've created a pull request here to add in a functionality to allow for dumping to a pcap dumper in two separate parts. I came across a use case where packet header and payload were held separately and I used this approach to allow for dumping them in unison. I've followed the same approach used in pcap_dump, but with additional writes to handle the two separate parts to dump. It's fairly straightforward code, but I had two questions about what I've done so far:
1. It wasn't clear what kind test setup you have for the pcap_dump code so I haven't added in any test cases. Is this something you would like to see? If so how should I set that up?
2. Wondering about the function name and if there's something else you'd prefer.
