### PR TITLE
[optimizer] mark value as unknown when statement is deleted so it is …

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -1474,6 +1474,7 @@ opt_deadstores(opt_state_t *opt_state, register struct block *b)
 			 */
 			opt_state->non_branch_movement_performed = 1;
 			opt_state->done = 0;
+			vstore(0, &b->val[atom], VAL_UNKNOWN, 0);
 		}
 }
 


### PR DESCRIPTION
…unavailable to successor blocks.

The libpcap optimizer removes statements as dead that store certain values but does not account for the fact that a successor block may attempt to read the value written by the dead statemenent.  The proposed patch marks the "val" data structure as having unknown value when statements are removed as dead to indicate to successor blocks that the value is not available. Bug / test case is further documented here: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=144325.