### PR TITLE
fuzz: asserts cap_len is always lesser than length

### DIFF
--- a/testprogs/fuzz/fuzz_pcap.c
+++ b/testprogs/fuzz/fuzz_pcap.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <assert.h>
 
 #include <pcap/pcap.h>
 
@@ -67,6 +68,7 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     r = pcap_next_ex(pkts, &header, &pkt);
     while (r > 0) {
         //TODO pcap_offline_filter
+        assert(header.caplen <= header.len);
         fprintf(outfile, "packet length=%d/%d\n",header->caplen, header->len);
         r = pcap_next_ex(pkts, &header, &pkt);
     }


### PR DESCRIPTION
It is my understanding that `cap_len` should always be lesser than `len`
cf https://stackoverflow.com/questions/1491660/pcap-struct-pcap-pkthdr-len-vs-caplen
If so, the PR enhances one fuzz target to add this check.

I have a pcap with len=0 and caplen=0x63503d00