### PR TITLE
Help CMake find Npcap's version.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,7 +319,7 @@ if(WIN32)
     endif(PACKET_FOUND)
 
     message(STATUS "checking for Npcap's version.h")
-    check_symbol_exists(WINPCAP_PRODUCT_NAME "../../version.h" HAVE_VERSION_H)
+    check_symbol_exists(WINPCAP_PRODUCT_NAME "${CMAKE_SOURCE_DIR}/../../version.h" HAVE_VERSION_H)
     if(HAVE_VERSION_H)
         message(STATUS "HAVE version.h")
     else(HAVE_VERSION_H)


### PR DESCRIPTION
The source files use a relative path, but the working directory when
building is different than when running CMake. Using CMAKE_SOURCE_DIR
fixes this discrepancy.