### PR TITLE
.cirrus.yml: quote strings in only_if expression

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,7 +4,7 @@ env:
 
 freebsd_task:
   name: FBSD+BM
-  only_if: $CIRRUS_BRANCH != coverity_scan
+  only_if: $CIRRUS_BRANCH != 'coverity_scan'
   freebsd_instance:
     matrix:
       - image_family: freebsd-11-4
@@ -28,7 +28,7 @@ freebsd_task:
 
 linux_task:
   name: LNX+BM
-  only_if: $CIRRUS_BRANCH != coverity_scan
+  only_if: $CIRRUS_BRANCH != 'coverity_scan'
   container:
     image: ubuntu:20.04
     cpu: 2
@@ -46,7 +46,7 @@ linux_task:
 
 macos_task:
   name: MAC+BM
-  only_if: $CIRRUS_BRANCH != coverity_scan
+  only_if: $CIRRUS_BRANCH != 'coverity_scan'
   macos_instance:
     image: big-sur-xcode
   env:
@@ -58,7 +58,7 @@ macos_task:
 
 coverity_task:
   name: Coverity Scan
-  only_if: $CIRRUS_BRANCH == coverity_scan
+  only_if: $CIRRUS_BRANCH == 'coverity_scan'
   container:
     image: ubuntu:20.04
     cpu: 2


### PR DESCRIPTION
Hi!

We're going to make some changes to how Cirrus CI parses configurations in the next couple of weeks (there's no press-release ATM) and found some potential issues with your `.cirrus.yml` while doing backwards compatibility checks.

Conditional task execution using`only_if` script should quote strings, similarly to the [examples in the documentation](https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution), otherwise the expression engine might treat these characters as operators.

This change makes sure the transition goes smoothly.