### PR TITLE
Bluetooth: fix non-blocking mode

### DIFF
--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -341,6 +341,10 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 	} while ((ret == -1) && (errno == EINTR));
 
 	if (ret < 0) {
+		if (errno == EAGAIN || errno == EWOULDBLOCK) {
+			/* Nonblocking mode, no data */
+			return 0;
+		}
 		pcap_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "Can't receive packet");
 		return -1;

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -127,6 +127,10 @@ bt_monitor_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_ch
     } while ((ret == -1) && (errno == EINTR));
 
     if (ret < 0) {
+        if (errno == EAGAIN || errno == EWOULDBLOCK) {
+            /* Nonblocking mode, no data */
+            return 0;
+        }
         pcap_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
             errno, "Can't receive packet");
         return -1;


### PR DESCRIPTION
Fix non-blocking mode with bt-linux and bt-monitor-linux. Previously
when fd was set to non-blocking mode and pcap_dispatch() was called
from application, it returned -1 with errno EAGAIN breaking the api
contract.

Fix is to handle errnos EAGAIN and EWOULDBLOCK so that 0 is returned.