### PR TITLE
Added DLT_NETANALYZER_NG and LINKTYPE_NETANALYZER_NG 

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1196,7 +1196,18 @@
  */
 #define LINKTYPE_ETW		290
 
-#define LINKTYPE_MATCHING_MAX	290		/* highest value in the "matching" range */
+/*
+ * Hilscher Gesellschaft fuer Systemautomation mbH 
+ * netANALYZER NG hardware and software.
+ * 
+ * The specification for this footer can be found at:
+ * https://kb.hilscher.com/x/brDJBw
+ *
+ * Requested by Jan Adam <jadam@hilscher.com>
+ */
+#define LINKTYPE_NETANALYZER_NG	292
+
+#define LINKTYPE_MATCHING_MAX	292		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1205,9 +1205,9 @@
  *
  * Requested by Jan Adam <jadam@hilscher.com>
  */
-#define LINKTYPE_NETANALYZER_NG	292
+#define LINKTYPE_NETANALYZER_NG	291
 
-#define LINKTYPE_MATCHING_MAX	292		/* highest value in the "matching" range */
+#define LINKTYPE_MATCHING_MAX	291		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1494,7 +1494,7 @@
  *
  * Requested by Jan Adam <jadam@hilscher.com>
  */
-#define DLT_NETANALYZER_NG	292
+#define DLT_NETANALYZER_NG	291
 
 /*
  * In case the code that includes this file (directly or indirectly)
@@ -1506,7 +1506,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	292	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	291	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1486,6 +1486,17 @@
 #define DLT_ETW			290
 
 /*
+ * Hilscher Gesellschaft fuer Systemautomation mbH 
+ * netANALYZER NG hardware and software.
+ * 
+ * The specification for this footer can be found at:
+ * https://kb.hilscher.com/x/brDJBw
+ *
+ * Requested by Jan Adam <jadam@hilscher.com>
+ */
+#define DLT_NETANALYZER_NG	292
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1495,7 +1506,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	290	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	292	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and


### PR DESCRIPTION
Request for a new Link layer type for Hilscher netANALYZER NG 

Discussion can be found here: 
https://seclists.org/tcpdump/2021/q1/66
