### PR TITLE
pcap-npf.c: handle NdisMediumIP

### DIFF
--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -1127,6 +1127,10 @@ pcap_activate_npf(pcap_t *p)
 		p->linktype = DLT_RAW;
 		break;
 
+	case NdisMediumIP:
+		p->linktype = DLT_RAW;
+		break;
+
 	default:
 		/*
 		 * An unknown medium type is assumed to supply Ethernet


### PR DESCRIPTION
When encountering the NDIS medium type `NdisMediumIP`, treat the interface as an IP interface.

Related to nmap/npcap#173.
