### PR TITLE
fixed cross compile for windows

### DIFF
--- a/charconv.c
+++ b/charconv.c
@@ -34,6 +34,7 @@
 
 #ifdef _WIN32
 #include <stdio.h>
+#include <errno.h>
 
 #include <pcap/pcap.h>	/* Needed for PCAP_ERRBUF_SIZE */
 


### PR DESCRIPTION
charconv.c:58: error: ‘EINVAL’ undeclared
error cross-compiling this project for Windows. Used CC i686-w64-mingw32-gcc