### PR TITLE
WIP: Set CANFD_FDF when CAN-FD frame received

### DIFF
--- a/pcap/can_socketcan.h
+++ b/pcap/can_socketcan.h
@@ -44,6 +44,8 @@
 #define CAN_MTU     16
 #define CANFD_MTU   72
 
+#define CANFD_BRS   0x01 /* bit rate switch (second bitrate for payload data) */
+#define CANFD_ESI   0x02 /* error state indicator of the transmitting node */
 #define CANFD_FDF   0x04 /* mark CAN FD for dual use of CAN format */
 
 /*

--- a/pcap/can_socketcan.h
+++ b/pcap/can_socketcan.h
@@ -41,6 +41,11 @@
 
 #include <pcap/pcap-inttypes.h>
 
+#define CAN_MTU     16
+#define CANFD_MTU   72
+
+#define CANFD_FDF   0x04 /* mark CAN FD for dual use of CAN format */
+
 /*
  * SocketCAN header, as per Documentation/networking/can.txt in the
  * Linux source.
@@ -48,7 +53,7 @@
 typedef struct {
 	uint32_t can_id;
 	uint8_t payload_length;
-	uint8_t pad;
+	uint8_t fd_flags;
 	uint8_t reserved1;
 	uint8_t reserved2;
 } pcap_can_socketcan_hdr;


### PR DESCRIPTION
# Context

Linux recently introduced the CANFD_FDF flag, it is a flag not used by Linux kernel itself, however it allows application to use `canfd_frame` struct for both CAN and CAN-FD.

Libpcap is one use case of such applications, since it merges CAN and CAN-FD traffic into one format.

## CAN-FD
* CAN & CAN-FD frames could be physically transmitted on the same CAN-FD bus, on the wire the FDF bit is used to distinguish them.
* Linux socket CAN API assume that application check frame size (MTU), to distinguish between them.
* The tcpdump documentation does not mention how the application can differentiate between CAN and CAN-FD when receiving traffic, and does not specify a fixed frame size, original documentation assume that frame ends when payload ends.
* Linux socket CAN introduced the CANFD_FDF bit recently, that allows applications to mark frames manually, the bit is not used by the kernel itself.
* Keeping unused trailing bytes when storing CAN-FD frames on disk present a waste ((72  -16) / 72 = 77% of frame size), removing them makes it difficult to tell if frame was originally was transmitted as CAN or CAN-FD frame.
* When injecting, Linux only accepts frame sizes of 16 and 72.
### Proposal
#### When receiving (This PR)
See https://github.com/the-tcpdump-group/libpcap/pull/1035
* Library must set the CANFD_FDF for CAN-FD frames received from Linux kernel when receiving bytes (Library checks MTU)
* Library will keep the original frame size as received by the Linux kernel, for backward compatibility, application may strip trailing padding bytes when storing frame to disk.
#### When injecting
Currently Libpcap does not support injection, this will be added as reference for future implementation 
Library must upsize the frame to 72 bytes, when injecting a CAN frame if any of the below is true:
  - Any FD flag is set
  - Payload length is > 8
  - Frame size is > 16

Library must upsize the frame to 16 bytes otherwise.