### PR TITLE
fix unaligned access to structs in rpcapd

### DIFF
--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -1703,7 +1703,10 @@ daemon_msg_findallif_req(uint8 ver, struct daemon_slpars *pars, uint32 plen)
 	{
 		uint16 lname, ldescr;
 
-		findalldevs_if = (struct rpcap_findalldevs_if *) &sendbuf[sendbufidx];
+		struct rpcap_findalldevs_if dev_if_tmp;
+		char*  dev_if_p = &sendbuf[sendbufidx];
+		
+		findalldevs_if = (struct rpcap_findalldevs_if *) &dev_if_tmp;
 
 		if (sock_bufferize(NULL, sizeof(struct rpcap_findalldevs_if), NULL,
 		    &sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, errmsgbuf, PCAP_ERRBUF_SIZE) == -1)
@@ -1747,6 +1750,8 @@ daemon_msg_findallif_req(uint8 ver, struct daemon_slpars *pars, uint32 plen)
 			}
 		}
 		findalldevs_if->naddr = htons(findalldevs_if->naddr);
+
+		memcpy( dev_if_p, &dev_if_tmp, sizeof( struct rpcap_findalldevs_if ) );
 
 		if (sock_bufferize(d->name, lname, sendbuf, &sendbufidx,
 		    RPCAP_NETBUF_SIZE, SOCKBUF_BUFFERIZE, errmsgbuf,
@@ -2826,11 +2831,14 @@ daemon_seraddr(struct sockaddr_storage *sockaddrin, struct rpcap_sockaddr *socka
 		struct rpcap_sockaddr_in *sockaddrout_ipv4;
 
 		sockaddrin_ipv4 = (struct sockaddr_in *) sockaddrin;
-		sockaddrout_ipv4 = (struct rpcap_sockaddr_in *) sockaddrout;
+		struct rpcap_sockaddr_in tmp;
+		sockaddrout_ipv4 = &tmp;
+		
 		sockaddrout_ipv4->family = htons(RPCAP_AF_INET);
 		sockaddrout_ipv4->port = htons(sockaddrin_ipv4->sin_port);
 		memcpy(&sockaddrout_ipv4->addr, &sockaddrin_ipv4->sin_addr, sizeof(sockaddrout_ipv4->addr));
 		memset(sockaddrout_ipv4->zero, 0, sizeof(sockaddrout_ipv4->zero));
+		memcpy( sockaddrout, &tmp, sizeof( struct rpcap_sockaddr_in ) );
 		break;
 		}
 
@@ -2841,12 +2849,15 @@ daemon_seraddr(struct sockaddr_storage *sockaddrin, struct rpcap_sockaddr *socka
 		struct rpcap_sockaddr_in6 *sockaddrout_ipv6;
 
 		sockaddrin_ipv6 = (struct sockaddr_in6 *) sockaddrin;
-		sockaddrout_ipv6 = (struct rpcap_sockaddr_in6 *) sockaddrout;
+		struct rpcap_sockaddr_in6 tmp;
+		sockaddrout_ipv6 = &tmp;
+		
 		sockaddrout_ipv6->family = htons(RPCAP_AF_INET6);
 		sockaddrout_ipv6->port = htons(sockaddrin_ipv6->sin6_port);
 		sockaddrout_ipv6->flowinfo = htonl(sockaddrin_ipv6->sin6_flowinfo);
 		memcpy(&sockaddrout_ipv6->addr, &sockaddrin_ipv6->sin6_addr, sizeof(sockaddrout_ipv6->addr));
 		sockaddrout_ipv6->scope_id = htonl(sockaddrin_ipv6->sin6_scope_id);
+		memcpy( sockaddrout, &tmp, sizeof( struct rpcap_sockaddr_in6 ) );
 		break;
 		}
 #endif


### PR DESCRIPTION

fix unaligned access to structs in daemon_msg_findallif_req() and daemon_seraddr()

if an interface has, for example a 3 char name ( unm ), the pointer for sockaddrout_ipv4
gets an uneven address like 0x1003

an processors with alignment restrictions like arm and mips
the write to sockaddrout_ipv4->family does not write to 0x1003 but to 0x1002

same problem for findalldevs_if

so an local variable is defined which will have the correct alignment and then
the variable is copied to the destination address with memcpy