### PR TITLE
Possible resource leak in pcap-linux.c

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -1612,8 +1612,8 @@ get_if_flags(const char *name, bpf_u_int32 *flags, char *errbuf)
 				}
 			}
 			fclose(fh);
-			free(pathstr);
 		}
+		free(pathstr);
 	}
 
 #ifdef ETHTOOL_GLINK


### PR DESCRIPTION
Hi,
when freeing the pathstr string in pcap-linux, if for some reason the opened file is not properly opened, pathstr might leak. Moving free(pathstr) outside the if{} should free the variable in either case(fr == NULL or fh != NULL).