### PR TITLE
[bugfix] build rpcapd static on Windows

### DIFF
--- a/rpcapd/CMakeLists.txt
+++ b/rpcapd/CMakeLists.txt
@@ -112,13 +112,13 @@ if(WIN32 OR ((CMAKE_USE_PTHREADS_INIT OR PTHREADS_FOUND) AND HAVE_CRYPT))
       OSX_ARCHITECTURES "${OSX_PROGRAM_ARCHITECTURES}")
   endif()
 
-  if(WIN32)
+  if(WIN32 AND BUILD_SHARED_LIBS)
     target_link_libraries(rpcapd ${LIBRARY_NAME}
       ${RPCAPD_LINK_LIBRARIES} ${PCAP_LINK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-  else(WIN32)
+  else(WIN32 AND BUILD_SHARED_LIBS)
     target_link_libraries(rpcapd ${LIBRARY_NAME}_static
       ${RPCAPD_LINK_LIBRARIES} ${PCAP_LINK_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
-  endif(WIN32)
+  endif(WIN32 AND BUILD_SHARED_LIBS)
 
   ######################################
   # Install rpcap daemon and man pages


### PR DESCRIPTION
Currently, the build system tries to link `rpcapd` to the shared version of `libpcap` unconditionally, but this library is not created in a static build `-DBUILD_SHARED_LIBS=OFF`

Why don't you just link to the static version all the time, did you have any issues in the past?