### PR TITLE
Use correct strings for DLL VersionInfo

### DIFF
--- a/pcap-dll.rc
+++ b/pcap-dll.rc
@@ -20,12 +20,12 @@
         VALUE "Comments",         "https://github.com/the-tcpdump-group/libpcap/"
         VALUE "CompanyName",      "The TCPdump Group"
         VALUE "FileDescription",  "System-Independent Interface for User-Level Packet Capture"
-        VALUE "FileVersion",      "PACKAGE_VERSION_DLL"
+        VALUE "FileVersion",      PACKAGE_VERSION
         VALUE "InternalName",     PACKAGE_NAME
         VALUE "LegalCopyright",   "Copyright (c) The TCPdump Group"
         VALUE "LegalTrademarks",  ""
-        VALUE "OriginalFilename", "wpcap.dll"
-        VALUE "ProductName",      PACKAGE_NAME
+        VALUE "OriginalFilename", PACKAGE_NAME ".dll"
+        VALUE "ProductName",      "libpcap"
         VALUE "ProductVersion",   PACKAGE_VERSION
       END
     END


### PR DESCRIPTION
Previous DLL build reported FileVersion as literally
"PACKAGE_VERSION_DLL" instead of expanding the macro because of the
quotes. Also reported original filename as "wpcap.dll" regardless of
library name configured via CMake.

This change also preserves the "libpcap" product name, since regardless
of the library name configured, the code is still the libpcap product.