### PR TITLE
Added linktype for ZBOSS NCP setial protocol.

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1207,7 +1207,13 @@
  */
 #define LINKTYPE_NETANALYZER_NG	291
 
-#define LINKTYPE_MATCHING_MAX	291		/* highest value in the "matching" range */
+/*
+ * Serial NCP (Network Co-Processor) protocol for Zigbee stack ZBOSS
+ * by DSR, https://dsr-iot.com/downloads
+ */
+#define LINKTYPE_ZBOSS_NCP	292
+
+#define LINKTYPE_MATCHING_MAX	292		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1209,7 +1209,11 @@
 
 /*
  * Serial NCP (Network Co-Processor) protocol for Zigbee stack ZBOSS
- * by DSR, https://dsr-iot.com/downloads
+ * by DSR.
+ * ZBOSS NCP protocol description: https://cloud.dsr-corporation.com/index.php/s/3isHzaNTTgtJebn
+ * Header in pcap file: https://cloud.dsr-corporation.com/index.php/s/fiqSDorAAAZrsYB
+ *
+ * Requested by Eugene Exarevsky <eugene.exarevsky@dsr-corporation.com>
  */
 #define LINKTYPE_ZBOSS_NCP	292
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1497,6 +1497,12 @@
 #define DLT_NETANALYZER_NG	291
 
 /*
+ * Serial NCP (Network Co-Processor) protocol for Zigbee stack ZBOSS
+ * by DSR, https://dsr-iot.com/downloads
+ */
+#define DLT_ZBOSS_NCP		292
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1506,7 +1512,7 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	291	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	292	/* highest value in the "matching" range */
 
 /*
  * DLT and savefile link type values are split into a class and

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1498,7 +1498,11 @@
 
 /*
  * Serial NCP (Network Co-Processor) protocol for Zigbee stack ZBOSS
- * by DSR, https://dsr-iot.com/downloads
+ * by DSR.
+ * ZBOSS NCP protocol description: https://cloud.dsr-corporation.com/index.php/s/3isHzaNTTgtJebn
+ * Header in pcap file: https://cloud.dsr-corporation.com/index.php/s/fiqSDorAAAZrsYB
+ *
+ * Requested by Eugene Exarevsky <eugene.exarevsky@dsr-corporation.com>
  */
 #define DLT_ZBOSS_NCP		292
 


### PR DESCRIPTION
Zigbee stack ZBOSS by DSR has serial protocol for Network Co-Processor configuration (NCP).
DSR implemented a parser for Wireshark for that protocol.
The idea is to display both serial NCP commands and 802.15.4 traffic in the same log.
NCP serial protocol is not related to 802.15.4 itself, so it will be wrong to base NCP parser on 803.15.4 protocol parser in Wireshark - that is why we need a separate DLK/LINKTYPE.