### PR TITLE
Haiku: implement pcap_lib_version

### DIFF
--- a/pcap-haiku.cpp
+++ b/pcap-haiku.cpp
@@ -280,3 +280,12 @@ pcap_platform_finddevs(pcap_if_list_t* _allDevices, char* errorBuffer)
 	return pcap_findalldevs_interfaces(_allDevices, errorBuffer, can_be_bound,
 		get_if_flags);
 }
+
+/*
+ * Libpcap version string.
+ */
+extern "C" const char *
+pcap_lib_version(void)
+{
+	return (PCAP_VERSION_STRING);
+}


### PR DESCRIPTION
Since the introduction of commit #f290068 each pcap-xx file provides its own pcap_lib_version() implementation.

This pull request adds pcap_lib_version() to pcap-haiku as it was missing before, leading to library loading issues on Haiku.