### PR TITLE
Avoid calling free() on known-null pointer

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -2899,7 +2899,6 @@ icode_to_fcode(struct icode *ic, struct block *root, u_int *lenp,
 	    if (fp == NULL) {
 		(void)snprintf(errbuf, PCAP_ERRBUF_SIZE,
 		    "malloc");
-		free(fp);
 		return NULL;
 	    }
 	    memset((char *)fp, 0, sizeof(*fp) * n);


### PR DESCRIPTION
Standards all say free(NULL) is a safe no-op, but since we *know* fp
is NULL here because of the condition above, there's no need to risk it.