### PR TITLE
Fix FreeBSD build issues

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -59,10 +59,16 @@
 #include <sys/socket.h>
 #include <net/if.h>
 #include <net/pfvar.h>
-#include <net/if_pflog.h>
 #endif /* HAVE_NET_PFVAR_H */
 
 #include "pcap-int.h"
+
+#ifdef HAVE_NET_PFVAR_H
+/* FreeBSD includes <net/bpf.h> from <net/if_pflog.h>, and indirectly includes
+ * <net/dlt.h>. The FreeBSD version lacks DLT_IEEE802_15_4_TAP, so we really
+ * want to use our own version. */
+#include <net/if_pflog.h>
+#endif /* HAVE_NET_PFVAR_H */
 
 #include "extract.h"
 

--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -78,6 +78,10 @@
  */
 #if !defined(_NET_BPF_H_) && !defined(_NET_BPF_H_INCLUDED) && !defined(_BPF_H_) && !defined(_H_BPF) && !defined(lib_pcap_bpf_h)
 #define lib_pcap_bpf_h
+#define _NET_BPF_H_
+#define _NET_BPF_H_INCLUDED
+#define _BPF_H_
+#define _H_BPF
 
 /* u_char, u_short and u_int */
 #if defined(_WIN32)


### PR DESCRIPTION
Recent FreeBSD versions started including <net/bpf.h> from <net/if_pflog.h>, which triggered two distinct build issues.