### PR TITLE
support user/pass in rpcap:// and rpcaps:// source URIs

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -651,9 +651,9 @@ int	pcap_strcasecmp(const char *, const char *);
  * rpcaps://).
  */
 int	pcap_createsrcstr_ex(char *, int, const char *, const char *,
-    const char *, unsigned char, char *);
+    const char *, const char *, unsigned char, char *);
 int	pcap_parsesrcstr_ex(const char *, int *, char *, char *,
-    char *, unsigned char *, char *);
+    char *, char *, unsigned char *, char *);
 
 #ifdef YYDEBUG
 extern int pcap_debug;

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -2158,7 +2158,7 @@ static int rpcap_doauth_userinfo(SOCKET sockctrl, SSL *ssl, uint8 *ver, const ch
 		passp = strchr(userinfo, ':');
 		if (passp)
 		{
-			long unsigned int len = passp - userinfo + 1;
+			long unsigned int len = (long unsigned int)(passp - userinfo + 1);
 			if (len > (sizeof(username) - 1)) len = sizeof(username) - 1;
 			pcap_strlcpy(username, userinfo, len);
 			pcap_strlcpy(password, passp + 1, sizeof(password) - 1);

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -2196,15 +2196,16 @@ rpcap_setup_session(const char *source, struct pcap_rmtauth *auth,
 {
 	int type;
 	int auth_result;
+	char userinfo[512];			/* 256 characters each for username and password */
 	struct activehosts *activeconn;		/* active connection, if there is one */
 	int error;				/* 1 if rpcap_remoteact_getsock got an error */
+	userinfo[0] = '\0';
 
 	/*
 	 * Determine the type of the source (NULL, file, local, remote).
 	 * You must have a valid source string even if we're in active mode,
 	 * because otherwise the call to the following function will fail.
 	 */
-	char userinfo[PCAP_BUF_SIZE];
 	if (pcap_parsesrcstr_ex(source, &type, userinfo, host, port, iface, uses_sslp,
 	    errbuf) == -1)
 		return -1;
@@ -2310,7 +2311,7 @@ rpcap_setup_session(const char *source, struct pcap_rmtauth *auth,
 #endif
 		}
 
-		if (auth == NULL && userinfo != NULL)
+		if (auth == NULL && *userinfo != '\0')
 		{
 			auth_result = rpcap_doauth_userinfo(*sockctrlp, *sslp, protocol_versionp,
 			    userinfo, errbuf);

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -2161,6 +2161,7 @@ static int rpcap_doauth_userinfo(SOCKET sockctrl, SSL *ssl, uint8 *ver, const ch
 			long unsigned int len = (long unsigned int)(passp - userinfo + 1);
 			if (len > (sizeof(username) - 1)) len = sizeof(username) - 1;
 			pcap_strlcpy(username, userinfo, len);
+			/* TODO: handle percent escapes? */
 			pcap_strlcpy(password, passp + 1, sizeof(password) - 1);
 		}
 

--- a/pcap.c
+++ b/pcap.c
@@ -2063,8 +2063,8 @@ pcap_parse_source(const char *source, char **schemep, char **userinfop,
 }
 
 int
-pcap_createsrcstr_ex(char *source, int type, const char *host, const char *port,
-    const char *name, unsigned char uses_ssl, char *errbuf)
+pcap_createsrcstr_ex(char *source, int type, const char *userinfo, const char *host,
+    const char *port, const char *name, unsigned char uses_ssl, char *errbuf)
 {
 	switch (type) {
 
@@ -2133,16 +2133,18 @@ int
 pcap_createsrcstr(char *source, int type, const char *host, const char *port,
     const char *name, char *errbuf)
 {
-	return (pcap_createsrcstr_ex(source, type, host, port, name, 0, errbuf));
+	return (pcap_createsrcstr_ex(source, type, NULL, host, port, name, 0, errbuf));
 }
 
 int
-pcap_parsesrcstr_ex(const char *source, int *type, char *host, char *port,
-    char *name, unsigned char *uses_ssl, char *errbuf)
+pcap_parsesrcstr_ex(const char *source, int *type, char *userinfo, char *host,
+    char *port, char *name, unsigned char *uses_ssl, char *errbuf)
 {
 	char *scheme, *tmpuserinfo, *tmphost, *tmpport, *tmppath;
 
 	/* Initialization stuff */
+	if (userinfo)
+		*userinfo = '\0';
 	if (host)
 		*host = '\0';
 	if (port)
@@ -2191,13 +2193,10 @@ pcap_parsesrcstr_ex(const char *source, int *type, char *host, char *port,
 		 * pcap_parse_source() has already handled the case of
 		 * rpcap[s]://device
 		 */
-		if (host && tmphost) {
-			if (tmpuserinfo)
-				snprintf(host, PCAP_BUF_SIZE, "%s@%s",
-				    tmpuserinfo, tmphost);
-			else
-				pcap_strlcpy(host, tmphost, PCAP_BUF_SIZE);
-		}
+		if (userinfo && tmpuserinfo)
+			pcap_strlcpy(userinfo, tmpuserinfo, PCAP_BUF_SIZE);
+		if (host && tmphost)
+			pcap_strlcpy(host, tmphost, PCAP_BUF_SIZE);
 		if (port && tmpport)
 			pcap_strlcpy(port, tmpport, PCAP_BUF_SIZE);
 		if (name && tmppath)
@@ -2248,7 +2247,7 @@ int
 pcap_parsesrcstr(const char *source, int *type, char *host, char *port,
     char *name, char *errbuf)
 {
-	return (pcap_parsesrcstr_ex(source, type, host, port, name, NULL, errbuf));
+	return (pcap_parsesrcstr_ex(source, type, NULL, host, port, name, NULL, errbuf));
 }
 #endif
 

--- a/pcap.c
+++ b/pcap.c
@@ -2084,6 +2084,11 @@ pcap_createsrcstr_ex(char *source, int type, const char *userinfo, const char *h
 		    (uses_ssl ? "rpcaps://" : PCAP_SRC_IF_STRING),
 		    PCAP_BUF_SIZE);
 		if (host != NULL && *host != '\0') {
+			if (userinfo != NULL && *userinfo != '\0') {
+				pcap_strlcat(source, userinfo, PCAP_BUF_SIZE);
+				pcap_strlcat(source, "@", PCAP_BUF_SIZE);
+			}
+
 			if (strchr(host, ':') != NULL) {
 				/*
 				 * The host name contains a colon, so it's

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -876,18 +876,21 @@ PCAP_API const char *pcap_lib_version(void);
 #define PCAP_SRC_IFREMOTE	4	/* interface on a remote host, using RPCAP */
 
 /*
- * The formats allowed by pcap_open() are the following:
+ * The formats allowed by pcap_open() are the following (optional parts in []):
  * - file://path_and_filename [opens a local file]
  * - rpcap://devicename [opens the selected device available on the local host, without using the RPCAP protocol]
- * - rpcap://host/devicename [opens the selected device available on a remote host]
- * - rpcap://host:port/devicename [opens the selected device available on a remote host, using a non-standard port for RPCAP]
+ * - rpcap://[username:password@]host[:port]/devicename [opens the selected device available on a remote host]
+ *   - username and password, if present, will be used to authenticate to the remote host
+ *   - port, if present, will specify a port for RPCAP rather than using the default
  * - adaptername [to open a local adapter; kept for compatibility, but it is strongly discouraged]
  * - (NULL) [to open the first local adapter; kept for compatibility, but it is strongly discouraged]
  *
- * The formats allowed by the pcap_findalldevs_ex() are the following:
+ * The formats allowed by the pcap_findalldevs_ex() are the following (optional parts in []):
  * - file://folder/ [lists all the files in the given folder]
  * - rpcap:// [lists all local adapters]
- * - rpcap://host:port/ [lists the devices available on a remote host]
+ * - rpcap://[username:password@]host[:port]/ [lists the devices available on a remote host]
+ *   - username and password, if present, will be used to authenticate to the remote host
+ *   - port, if present, will specify a port for RPCAP rather than using the default
  *
  * In all the above, "rpcaps://" can be substituted for "rpcap://" to enable
  * SSL (if it has been compiled in).
@@ -904,6 +907,7 @@ PCAP_API const char *pcap_lib_version(void);
  * Here you find some allowed examples:
  * - rpcap://host.foo.bar/devicename [everything literal, no port number]
  * - rpcap://host.foo.bar:1234/devicename [everything literal, with port number]
+ * - rpcap://root:hunter2@host.foo.bar/devicename [everything literal, with username/password]
  * - rpcap://10.11.12.13/devicename [IPv4 numeric, no port number]
  * - rpcap://10.11.12.13:1234/devicename [IPv4 numeric, with port number]
  * - rpcap://[10.11.12.13]:1234/devicename [IPv4 numeric with IPv6 format, with port number]


### PR DESCRIPTION
Hi!

These changes allow for a username and password to be supplied in the source uri for authentication to a remote pcap source, which should work transparently with existing applications - e.g. `tcpdump` required no changes.

I've tried to follow the existing code style as much as possible, but please let me know if there's anything that needs to be changed.

- [x] Handle %encoded values in userinfo portion of URI (necessary for e.g. passwords containing `@` or ` `)