### PR TITLE
Add new DLT_ and LINKTYPE_ for Silabs Debug Channel.

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1240,8 +1240,12 @@
  */
 #define LINKTYPE_AUERSWALD_LOG	296
 
-#define LINKTYPE_MATCHING_MAX	296		/* highest value in the "matching" range */
+/*
+ * Silicon Labs Debug Channel. 
+ */
+#define LINKTYPE_SILABS_DEBUG_CHANNEL 297
 
+#define LINKTYPE_MATCHING_MAX	297		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3330,6 +3330,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(USB_2_0_LOW_SPEED, "Low-Speed USB 2.0/1.1/1.0 as transmitted over the cable"),
 	DLT_CHOICE(USB_2_0_FULL_SPEED, "Full-Speed USB 2.0/1.1/1.0 as transmitted over the cable"),
 	DLT_CHOICE(USB_2_0_HIGH_SPEED, "High-Speed USB 2.0 as transmitted over the cable"),
+	DLT_CHOICE(SILABS_DEBUG_CHANNEL, "Silicon Labs Debug Channel"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1597,6 +1597,19 @@
 #define DLT_AUERSWALD_LOG	296
 
 /*
+ * Silicon Labs Debug Channel protocol, for communication between Silabs debug adapters and PC.
+ * This carries packet data for any mesh networking protocols (Zigbee, Bluetooth, Matter, Wi-Fi, etc)
+ * depending on what application you run on the hardware. It can also carry other payloads, not
+ * mesh-network related.
+ * 
+ * Specification can be found at:
+ *   https://github.com/SiliconLabs/java_packet_trace_library/blob/master/doc/debug-channel.md
+ *
+ * Requested by Timotej Ecimovic <timotej.ecimovic@silabs.com>
+ */
+#define DLT_SILABS_DEBUG_CHANNEL 297
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1606,7 +1619,6 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-
-#define DLT_MATCHING_MAX	296	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	297	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
Add a new LINKTYPE_, DLT_ and a DLT_CHOICE for the Silabs Debug Channel protocol.

See: 
   https://github.com/SiliconLabs/java_packet_trace_library/blob/master/doc/debug-channel.md
