### PR TITLE
Add support for Realtek (Ethertype) DSA data

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -5048,6 +5048,9 @@ static struct dsa_proto {
 	{ "brcm-prepend", DLT_DSA_TAG_BRCM_PREPEND },
 	{ "dsa", DLT_DSA_TAG_DSA },
 	{ "edsa", DLT_DSA_TAG_EDSA },
+	{ "rtl4a", DLT_EN10MB },
+	{ "rtl8_4", DLT_EN10MB },
+	{ "rtl8_4t", DLT_EN10MB },
 };
 
 static int


### PR DESCRIPTION
Realtek switchtag rtl4a (4 bytes long, protocol 0xA) and rtl8_4 (8 bytes
long, protocol 0x04) are Ethertype DSA tags, inserted in the Ethernet
header similar to an 802.1Q tag. Both shares the same Ethertype 0x8899
as other Realtek proprietary protocols.