### PR TITLE
nflog: only increment packets_nobufs when recv() returns an error

### DIFF
--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -123,7 +123,7 @@ netfilter_read_linux(pcap_t *handle, int max_packets, pcap_handler callback, u_c
 				handle->break_loop = 0;
 				return PCAP_ERROR_BREAK;
 			}
-			if (errno == ENOBUFS)
+			if (len == -1 && errno == ENOBUFS)
 				handlep->packets_nobufs++;
 		} while ((len == -1) && (errno == EINTR || errno == ENOBUFS));
 


### PR DESCRIPTION
Errno should only be valid when `recv()` returns a `-1`, indicating an
error.

I believe the intended behavior here is for packets_nobufs to
be a counter that reports back how many times `recv()` returns
an `ENOBUFS` during a packet capture. Because of the existing logic
however, `packets_nobufs` begins incrementing for every `recv()` call
once the first `ENOBUFS` error is seen, since `errno` is not reset when
there are no errors returned from `recv()`.

Before (counter deviates from strace):

    # tcpdump output
    38069 packets captured
    38069 packets received by filter
    38061 packets dropped by kernel

    # strace output
    % time     seconds  usecs/call     calls    errors syscall
    ------ ----------- ----------- --------- --------- ----------------
    26.47    0.282728           7     38067         3 recvfrom

After (counter matches strace):

    # tcpdump output
    38095 packets captured
    38095 packets received by filter
    7 packets dropped by kernel

    # strace output
    % time     seconds  usecs/call     calls    errors syscall
    ------ ----------- ----------- --------- --------- ----------------
    27.11    0.258596           6     38096         7 recvfrom