### PR TITLE
rpcap: add timeout configuration on socket connect

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -362,6 +362,8 @@ struct pcap {
 	get_airpcap_handle_op_t get_airpcap_handle_op;
 #endif
 	cleanup_op_t cleanup_op;
+
+	unsigned int sock_open_timeout;
 };
 
 /*

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1193,7 +1193,8 @@ static int pcap_startcapture_remote(pcap_t *fp)
 			goto error_nodiscard;
 
 		if ((sockdata = sock_open(addrinfo, SOCKOPEN_SERVER,
-			1 /* max 1 connection in queue */, fp->errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+			1 /* max 1 connection in queue */, fp->errbuf, PCAP_ERRBUF_SIZE,
+			fp->sock_open_timeout)) == INVALID_SOCKET)
 			goto error_nodiscard;
 
 		/* addrinfo is no longer used */
@@ -1316,7 +1317,8 @@ static int pcap_startcapture_remote(pcap_t *fp)
 			if (sock_initaddress(host, portstring, &hints, &addrinfo, fp->errbuf, PCAP_ERRBUF_SIZE) == -1)
 				goto error;
 
-			if ((sockdata = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, fp->errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+			if ((sockdata = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, fp->errbuf, PCAP_ERRBUF_SIZE,
+								fp->sock_open_timeout)) == INVALID_SOCKET)
 				goto error;
 
 			/* addrinfo is no longer used */
@@ -2268,7 +2270,7 @@ rpcap_setup_session(const char *source, struct pcap_rmtauth *auth,
 		}
 
 		if ((*sockctrlp = sock_open(addrinfo, SOCKOPEN_CLIENT, 0,
-		    errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+		    errbuf, PCAP_ERRBUF_SIZE, 0)) == INVALID_SOCKET)
 		{
 			freeaddrinfo(addrinfo);
 			return -1;
@@ -2875,7 +2877,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 	}
 
 
-	if ((sockmain = sock_open(addrinfo, SOCKOPEN_SERVER, 1, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+	if ((sockmain = sock_open(addrinfo, SOCKOPEN_SERVER, 1, errbuf, PCAP_ERRBUF_SIZE, 0)) == INVALID_SOCKET)
 	{
 		freeaddrinfo(addrinfo);
 		return (SOCKET)-2;

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -2078,7 +2078,7 @@ daemon_msg_startcap_req(uint8 ver, struct daemon_slpars *pars, uint32 plen,
 		if (sock_initaddress(peerhost, portdata, &hints, &addrinfo, errmsgbuf, PCAP_ERRBUF_SIZE) == -1)
 			goto error;
 
-		if ((session->sockdata = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, errmsgbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+		if ((session->sockdata = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, errmsgbuf, PCAP_ERRBUF_SIZE, 0)) == INVALID_SOCKET)
 			goto error;
 	}
 	else		// Data connection is opened by the client toward the server
@@ -2089,7 +2089,7 @@ daemon_msg_startcap_req(uint8 ver, struct daemon_slpars *pars, uint32 plen,
 		if (sock_initaddress(NULL, "0", &hints, &addrinfo, errmsgbuf, PCAP_ERRBUF_SIZE) == -1)
 			goto error;
 
-		if ((session->sockdata = sock_open(addrinfo, SOCKOPEN_SERVER, 1 /* max 1 connection in queue */, errmsgbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+		if ((session->sockdata = sock_open(addrinfo, SOCKOPEN_SERVER, 1 /* max 1 connection in queue */, errmsgbuf, PCAP_ERRBUF_SIZE, 0)) == INVALID_SOCKET)
 			goto error;
 
 		// get the complete sockaddr structure used in the data connection

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -623,7 +623,7 @@ void main_startup(void)
 			SOCKET sock;
 			struct listen_sock *sock_info;
 
-			if ((sock = sock_open(tempaddrinfo, SOCKOPEN_SERVER, SOCKET_MAXCONN, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+			if ((sock = sock_open(tempaddrinfo, SOCKOPEN_SERVER, SOCKET_MAXCONN, errbuf, PCAP_ERRBUF_SIZE, 0)) == INVALID_SOCKET)
 			{
 				switch (tempaddrinfo->ai_family)
 				{
@@ -1358,7 +1358,7 @@ main_active(void *ptr)
 	{
 		int activeclose;
 
-		if ((sockctrl = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
+		if ((sockctrl = sock_open(addrinfo, SOCKOPEN_CLIENT, 0, errbuf, PCAP_ERRBUF_SIZE, 0)) == INVALID_SOCKET)
 		{
 			rpcapd_log(LOGPRIO_DEBUG, "%s", errbuf);
 

--- a/sockutils.h
+++ b/sockutils.h
@@ -136,7 +136,7 @@ int sock_recv(SOCKET sock, SSL *, void *buffer, size_t size, int receiveall,
     char *errbuf, int errbuflen);
 int sock_recv_dgram(SOCKET sock, SSL *, void *buffer, size_t size,
     char *errbuf, int errbuflen);
-SOCKET sock_open(struct addrinfo *addrinfo, int server, int nconn, char *errbuf, int errbuflen);
+SOCKET sock_open(struct addrinfo *addrinfo, int server, int nconn, char *errbuf, int errbuflen, unsigned int timeout_sec);
 int sock_close(SOCKET sock, char *errbuf, int errbuflen);
 
 int sock_send(SOCKET sock, SSL *, const char *buffer, size_t size,


### PR DESCRIPTION
Hi,

This is a small proposal to allow to configure the connection timeout for rpcap sockets.
This is just to avoid waiting minutes for nothing should the connect() call fail.

Best regards,
