### PR TITLE
autoconf: Use AS_HELP_STRING macro in configure.ac for '--enable-remote'

### DIFF
--- a/configure
+++ b/configure
@@ -1396,7 +1396,6 @@ Optional Features:
   --disable-protochain    disable \"protochain\" insn
   --enable-ipv6           build IPv6-capable version [default=yes]
   --enable-remote         enable remote packet capture [default=no]
-  --disable-remote        disable remote packet capture
   --enable-optimizer-dbg  build optimizer debugging code
   --enable-yydebug        build parser debugging code
   --disable-universal     don't build universal on macOS

--- a/configure.ac
+++ b/configure.ac
@@ -1520,10 +1520,11 @@ dnl It's off by default, as that increases the attack surface of
 dnl libpcap, exposing it to malicious servers.
 dnl
 AC_MSG_CHECKING([whether to enable remote packet capture])
-AC_ARG_ENABLE(remote,
-[  --enable-remote         enable remote packet capture @<:@default=no@:>@
-  --disable-remote        disable remote packet capture],,
-   enableval=no)
+AC_ARG_ENABLE([remote],
+   [AS_HELP_STRING([--enable-remote],
+     [enable remote packet capture @<:@default=no@:>@])],
+   [],
+   [enableval=no])
 case "$enableval" in
 yes)	AC_MSG_RESULT(yes)
 	AC_WARN([Remote packet capture may expose libpcap-based applications])


### PR DESCRIPTION
There is no need to have:
  --enable-remote         enable remote packet capture [default=no]
  --disable-remote        disable remote packet capture

Use only:
  --enable-remote         enable remote packet capture [default=no]