### PR TITLE
Add speed specific USB 2.0/1.1/1.0 linktypes

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1194,6 +1194,8 @@
 
 /*
  * USB 2.0, 1.1, and 1.0 packets as transmitted over the cable.
+ * Deprecated in favor of speed specific LINKTYPEs: LINKTYPE_USB_2_0_LOW_SPEED,
+ * LINKTYPE_USB_2_0_FULL_SPEED and LINKTYPE_USB_2_0_HIGH_SPEED.
  */
 #define LINKTYPE_USB_2_0	288
 
@@ -1228,7 +1230,14 @@
  */
 #define LINKTYPE_ZBOSS_NCP	292
 
-#define LINKTYPE_MATCHING_MAX	292		/* highest value in the "matching" range */
+/*
+ * USB 2.0, 1.1, and 1.0 packets as transmitted over the cable.
+ */
+#define LINKTYPE_USB_2_0_LOW_SPEED	293
+#define LINKTYPE_USB_2_0_FULL_SPEED	294
+#define LINKTYPE_USB_2_0_HIGH_SPEED	295
+
+#define LINKTYPE_MATCHING_MAX	295		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3336,6 +3336,9 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(ETW, "Event Tracing for Windows messages"),
 	DLT_CHOICE(NETANALYZER_NG, "Hilscher netANALYZER NG pseudo-footer"),
 	DLT_CHOICE(ZBOSS_NCP, "ZBOSS NCP protocol with pseudo-header"),
+	DLT_CHOICE(USB_2_0_LOW_SPEED, "Low-Speed USB 2.0/1.1/1.0 as transmitted over the cable"),
+	DLT_CHOICE(USB_2_0_FULL_SPEED, "Full-Speed USB 2.0/1.1/1.0 as transmitted over the cable"),
+	DLT_CHOICE(USB_2_0_HIGH_SPEED, "High-Speed USB 2.0 as transmitted over the cable"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1544,6 +1544,8 @@
 
 /*
  * USB 2.0, 1.1, and 1.0 packets as transmitted over the cable.
+ * Deprecated in favor of speed specific DLTs: DLT_USB_2_0_LOW_SPEED,
+ * DLT_USB_2_0_FULL_SPEED and DLT_USB_2_0_HIGH_SPEED.
  */
 #define DLT_USB_2_0		288
 
@@ -1579,6 +1581,13 @@
 #define DLT_ZBOSS_NCP		292
 
 /*
+ * USB 2.0, 1.1, and 1.0 packets as transmitted over the cable.
+ */
+#define DLT_USB_2_0_LOW_SPEED	293
+#define DLT_USB_2_0_FULL_SPEED	294
+#define DLT_USB_2_0_HIGH_SPEED	295
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1588,6 +1597,6 @@
 #ifdef DLT_MATCHING_MAX
 #undef DLT_MATCHING_MAX
 #endif
-#define DLT_MATCHING_MAX	292	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	295	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
USB 2.0/1.1/1.0 devices (or 3.x and newer when connected to hosts that
are not Super-Speed capable) operate at one of three speeds:
  * Low-Speed (1.5 Mbps)
  * Full-Speed (12 Mbps)
  * High-Speed (480 Mbps)

While the packets are generally common to all three speeds, there are
some differences that span across different layers. The capture speed
should be available to analyzer and it makes sense to expose it via
speed specific linktypes. Existing USB 2.0/1.1/1.0 captures can be
manually, retroactively updated to speed specific linktype.

Low-Speed device will always operate at Low-Speed, regardless of what
host it is connected to. USB cable connected to Low-Speed device only
ever carries packets sent at Low-Speed.

High-Speed device will operate at High-Speed when connected to High-Speed
capable host. If High-Speed Detection Handshake succeeds, the cable will
only carry High-Speed packets.

Full-Speed device will always operate at Full-Speed, regardless of what
host it is connected to. High-Speed device connected to Full-Speed host
or hub, will operate at Full-Speed. The cable connected to device
operating at Full-Speed can only carry Full-Speed or Low-Speed packets
preceded by Low-Speed preamble (PRE packet) sent at Full-Speed. Non-hub
device operating at Full-Speed always ignores Low-Speed packets. The hub
forwards the Low-Speed packets to downstream ports but does not act upon
the actual Low-Speed packet contents. The packets intended for device
operating at Full-Speed are always sent at Full-Speed.