### PR TITLE
netmap: Add ability to time out

### DIFF
--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -109,6 +109,8 @@ pcap_netmap_dispatch(pcap_t *p, int cnt, pcap_handler cb, u_char *user)
 			break;
 		errno = 0;
 		ret = poll(&pfd, 1, p->opt.timeout);
+		if (ret == 0)
+			break;
 	}
 	return ret;
 }


### PR DESCRIPTION
pcap_next() should return 0 if timeout buffer expired.
Without this feature, we will hang in pcap_next() until
first packet arrived and more over we do not know when
all packets grabbed from ring, so we should do select()
after each pcap_next(). If we don't do this all multiplexing
part becomes meaningless, because we hang on one pcap and do
not have chance to process other fds.