### PR TITLE
cmake: suppress CMP0042 OLD deprecated warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,8 +12,15 @@ endif(WIN32)
 # neither do we with autotools; don't do so with CMake, either, and
 # suppress warnings about that.
 #
+# Setting CMAKE_MACOSX_RPATH to FALSE uses the old behavior,
+# but removes the POLICY CMP0042 OLD deprecated warning.
+# See https://cmake.org/cmake/help/latest/policy/CMP0042.html
+#
+if (NOT DEFINED CMAKE_MACOSX_RPATH)
+    set(CMAKE_MACOSX_RPATH FALSE)
+endif()
 if(POLICY CMP0042)
-    cmake_policy(SET CMP0042 OLD)
+    cmake_policy(SET CMP0042 NEW)
 endif()
 
 #


### PR DESCRIPTION
Suppresses the CMake CMP0042 OLD deprecation warning (closes #1094)

The CMP0042 NEW behaviour sets the target property `MACOSX_RPATH` to TRUE by default.
However, this behaviour can also be controlled by `CMAKE_MACOSX_RPATH`, which `MAXOSX_RPATH` will default to, if set.

For more information, see CMake docs on [CMP0042](https://cmake.org/cmake/help/latest/policy/CMP0042.html) and [MACOSX_RPATH](https://cmake.org/cmake/help/latest/prop_tgt/MACOSX_RPATH.html#prop_tgt:MACOSX_RPATH).

`CMAKE_MACOSX_RPATH` is only set if undefined, allowing users to change this option.

According to the CMake docs, it should be exactly the same behaviour, but it might be worth somebody with a MacOS device testing this, since I don't have a MacOS device.