### PR TITLE
Fix build on Haiku

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -580,6 +580,15 @@ else(WIN32)
             set(PCAP_LINK_LIBRARIES str ${PCAP_LINK_LIBRARIES})
         endif(LIBSTR_HAS_PUTMSG)
     endif(NOT STDLIBS_HAVE_PUTMSG)
+
+    # Haiku has getpass in libbsd
+    check_function_exists(getpass STDLIBS_HAVE_GETPASS)
+    if(NOT STDLIBS_HAVE_GETPASS)
+        check_library_exists(bsd getpass "" LIBBSD_HAS_GETPASS)
+        if(LIBBSD_HAS_GETPASS)
+            set(PCAP_LINK_LIBRARIES bsd ${PCAP_LINK_LIBRARIES})
+        endif(LIBBSD_HAS_GETPASS)
+    endif(NOT STDLIBS_HAVE_GETPASS)
 endif(WIN32)
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,10 @@ haiku*)
 	# Haiku needs _BSD_SOURCE for the _IO* macros because it doesn't use them.
 	#
 	CFLAGS="$CFLAGS -D_BSD_SOURCE"
+	#
+	# Haiku has getpass in libbsd.
+	#
+	AC_CHECK_LIB(bsd, getpass)
 	;;
 esac
 

--- a/pcap-haiku.cpp
+++ b/pcap-haiku.cpp
@@ -249,7 +249,11 @@ pcap_create_interface(const char *device, char *errorBuffer)
 		return NULL;
 	}
 
-	pcap_t* handle = PCAP_CREATE_COMMON(errorBuffer, struct pcap_haiku);
+	struct wrapper_struct { pcap_t __common; struct pcap_haiku __private; };
+	pcap_t* handle = pcap_create_common(errorBuffer,
+		sizeof (struct wrapper_struct),
+		offsetof (struct wrapper_struct, __private));
+
 	if (handle == NULL) {
 		snprintf(errorBuffer, PCAP_ERRBUF_SIZE, "malloc: %s", strerror(errno));
 		close(socket);

--- a/rpcap-protocol.h
+++ b/rpcap-protocol.h
@@ -132,10 +132,12 @@
  * XXX - use the C99 types?  Microsoft's newer versions of Visual Studio
  * support them.
  */
+#ifndef __HAIKU__
 typedef unsigned char uint8;	/* 8-bit unsigned integer */
 typedef unsigned short uint16;	/* 16-bit unsigned integer */
 typedef unsigned int uint32;	/* 32-bit unsigned integer */
 typedef int int32;		/* 32-bit signed integer */
+#endif
 
 /* Common header for all the RPCAP messages */
 struct rpcap_header


### PR DESCRIPTION
This fixes #1114.

C++11 forbids declaring types inside typeof and offsetof,
so we drop the macro call and declare the struct separately
for the only use of the call.