### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/README.Win32.md
+++ b/doc/README.Win32.md
@@ -174,6 +174,18 @@ with control-S.
 Visual Studio will then re-run CMake.  If that completes without errors,
 you can build with Build > "Build All".
 
+Building libpcap - Using vcpkg
+
+You can download and install libpcap using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install libpcap
+
+The libpcap port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 Building from the command line
 ------------------------------
 

--- a/doc/README.Win32.md
+++ b/doc/README.Win32.md
@@ -174,7 +174,7 @@ with control-S.
 Visual Studio will then re-run CMake.  If that completes without errors,
 you can build with Build > "Build All".
 
-Building libpcap - Using vcpkg
+### Building libpcap - Using vcpkg ###
 
 You can download and install libpcap using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
 


### PR DESCRIPTION
libpcap is available as a port in [vcpkg](https://github.com/microsoft/vcpkg), a C++ library manager that simplifies installation for libpcap and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build libpcap, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and [here is what the port script looks like](https://github.com/microsoft/vcpkg/blob/master/ports/libpcap/portfile.cmake). We try to keep the library maintained as close as possible to the original library. :)