### PR TITLE
cmake: Update the minimum required version to 2.8.12 (except Windows)

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,7 @@ Monthday, Month DD, YYYY:
     Building and testing:
       Remove awk code from mkdep.
       Apply GNU Hurd support patch from the Debian package.
+      cmake: Update the minimum required version to 2.8.12 (except Windows).
 
 Monthday, Month DD, YYYY:
   Summary for 1.10.2 libpcap release (so far!)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ if(WIN32)
     # below.
     cmake_minimum_required(VERSION 3.12)
 else(WIN32)
-    cmake_minimum_required(VERSION 2.8.6)
+    cmake_minimum_required(VERSION 2.8.12)
 endif(WIN32)
 
 #


### PR DESCRIPTION
This change is used to check the CI with cmake minimal 2.8.12.