### PR TITLE
Add an option to force memory-mapped buffers to be mapped as accessible to 32-bit code

### DIFF
--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -1790,6 +1790,7 @@ pcap_activate_bpf(pcap_t *p)
 #ifdef HAVE_ZEROCOPY_BPF
 	struct bpf_zbuf bz;
 	u_int bufmode, zbufmax;
+	int flags = MAP_ANON;
 #endif
 
 	fd = bpf_open(p->errbuf);
@@ -2092,10 +2093,13 @@ pcap_activate_bpf(pcap_t *p)
 		pb->zbufsize = roundup(v, getpagesize());
 		if (pb->zbufsize > zbufmax)
 			pb->zbufsize = zbufmax;
+#ifdef MAP_32BIT
+		if (pcap_mmap_32bit) flags |= MAP_32BIT;
+#endif
 		pb->zbuf1 = mmap(NULL, pb->zbufsize, PROT_READ | PROT_WRITE,
-		    MAP_ANON, -1, 0);
+		    flags, -1, 0);
 		pb->zbuf2 = mmap(NULL, pb->zbufsize, PROT_READ | PROT_WRITE,
-		    MAP_ANON, -1, 0);
+		    flags, -1, 0);
 		if (pb->zbuf1 == MAP_FAILED || pb->zbuf2 == MAP_FAILED) {
 			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 			    errno, "mmap");

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -108,6 +108,11 @@ extern int pcap_new_api;
 extern int pcap_utf_8_mode;
 
 /*
+ * Map packet buffers with 32-bit addresses.
+ */
+extern int pcap_mmap_32bit;
+
+/*
  * Swap byte ordering of unsigned long long timestamp on a big endian
  * machine.
  */

--- a/pcap.c
+++ b/pcap.c
@@ -230,6 +230,7 @@ pcap_wsockinit(void)
  */
 int pcap_new_api;		/* pcap_lookupdev() always fails */
 int pcap_utf_8_mode;		/* Strings should be in UTF-8. */
+int pcap_mmap_32bit;		/* Map packet buffers with 32-bit addresses. */
 
 int
 pcap_init(unsigned int opts, char *errbuf)
@@ -265,6 +266,10 @@ pcap_init(unsigned int opts, char *errbuf)
 			}
 		}
 		pcap_utf_8_mode = 1;
+		break;
+
+	case PCAP_MMAP_32BIT:
+		pcap_mmap_32bit = 1;
 		break;
 
 	default:

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -429,6 +429,7 @@ typedef void (*pcap_handler)(u_char *, const struct pcap_pkthdr *,
  */
 #define PCAP_CHAR_ENC_LOCAL	0x00000000U	/* strings are in the local character encoding */
 #define PCAP_CHAR_ENC_UTF_8	0x00000001U	/* strings are in UTF-8 */
+#define PCAP_MMAP_32BIT	0x00000002U	/* map packet buffers with 32-bit addresses */
 
 PCAP_AVAILABLE_1_10
 PCAP_API int	pcap_init(unsigned int, char *);

--- a/pcap_init.3pcap
+++ b/pcap_init.3pcap
@@ -49,6 +49,9 @@ caller, as being in the local character encoding.
 .B PCAP_CHAR_ENC_UTF_8
 Treat all strings supplied as arguments, and return all strings to the
 caller, as being in UTF-8.
+.B PCAP_MMAP_32BIT
+Map packet buffers with 32-bit addresses.
+.TP
 .PP
 On UNIX-like systems, the local character encoding is assumed to be
 UTF-8, so no character encoding transformations are done.


### PR DESCRIPTION
This is useful for Wine WoW64 support where 32-bit Windows applications run in a
64-bit Linux process. We can't pass 64-bit packet pointers back to the caller, obviously,
so we'd need to make a copy. The one shot buffer is a copy already so that would be
be copied twice, in libpcap and in Wine.

This option tells mmap() to allocate the buffers below 2GB so Wine can avoid copying them.
