### PR TITLE
Added ALDL link-layer type 297

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1240,7 +1240,15 @@
  */
 #define LINKTYPE_AUERSWALD_LOG	296
 
-#define LINKTYPE_MATCHING_MAX	296		/* highest value in the "matching" range */
+/*
+ * ALDL - Assembly Line Diagnostic Link (8192 baud)
+ * Used in most pre-OBDII GM vehicles.
+ *
+ * Requested by Jake Mannens <jake@asger.xyz>
+ */
+#define LINKTYPE_ALDL 297
+
+#define LINKTYPE_MATCHING_MAX	297		/* highest value in the "matching" range */
 
 
 /*

--- a/pcap.c
+++ b/pcap.c
@@ -3330,6 +3330,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(USB_2_0_LOW_SPEED, "Low-Speed USB 2.0/1.1/1.0 as transmitted over the cable"),
 	DLT_CHOICE(USB_2_0_FULL_SPEED, "Full-Speed USB 2.0/1.1/1.0 as transmitted over the cable"),
 	DLT_CHOICE(USB_2_0_HIGH_SPEED, "High-Speed USB 2.0 as transmitted over the cable"),
+	DLT_CHOICE(ALDL, "GM Assembly Line Diagnostic Link"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1597,6 +1597,14 @@
 #define DLT_AUERSWALD_LOG	296
 
 /*
+ * ALDL - Assembly Line Diagnostic Link (8192 baud)
+ * Used in most pre-OBDII GM vehicles.
+ *
+ * Requested by Jake Mannens <jake@asger.xyz>
+ */
+#define DLT_ALDL 297
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1607,6 +1615,6 @@
 #undef DLT_MATCHING_MAX
 #endif
 
-#define DLT_MATCHING_MAX	296	/* highest value in the "matching" range */
+#define DLT_MATCHING_MAX	297	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
Added link-layer type 297 for GM ALDL as described here: [Holden - ALDL (8192 Baud)](https://holden.asger.xyz/wiki/Holden:ALDL_(8192_Baud))