### PR TITLE
Fix two null pointer crashes of breakloop and can_set_rfmon

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -4212,6 +4212,14 @@ pcap_read_dead(pcap_t *p, int cnt _U_, pcap_handler callback _U_,
 }
 
 static int
+pcap_breakloop_dead(pcap_t *p)
+{
+	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+	    "A breakloop cannot be set on a pcap_open_dead pcap_t");
+	return (-1);
+}
+
+static int
 pcap_inject_dead(pcap_t *p, const void *buf _U_, int size _U_)
 {
 	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
@@ -4424,6 +4432,7 @@ pcap_open_dead_with_tstamp_precision(int linktype, int snaplen, u_int precision)
 	p->live_dump_ended_op = pcap_live_dump_ended_dead;
 	p->get_airpcap_handle_op = pcap_get_airpcap_handle_dead;
 #endif
+	p->breakloop_op = pcap_breakloop_dead;
 	p->cleanup_op = pcap_cleanup_dead;
 
 	/*

--- a/pcap.c
+++ b/pcap.c
@@ -4211,12 +4211,10 @@ pcap_read_dead(pcap_t *p, int cnt _U_, pcap_handler callback _U_,
 	return (-1);
 }
 
-static int
-pcap_breakloop_dead(pcap_t *p)
+static void
+pcap_breakloop_dead(pcap_t *p _U_)
 {
-	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
-	    "A breakloop cannot be set on a pcap_open_dead pcap_t");
-	return (-1);
+	/* A breakloop should not be set on a pcap_open_dead pcap_t. */
 }
 
 static int

--- a/savefile.c
+++ b/savefile.c
@@ -112,6 +112,16 @@ sf_setnonblock(pcap_t *p, int nonblock _U_)
 }
 
 static int
+sf_cant_set_rfmon(pcap_t *p _U_)
+{
+	/*
+	 * This is a savefile, not a live capture file, so never say
+	 * it's monitor mode.
+	 */
+	return (0);
+}
+
+static int
 sf_stats(pcap_t *p, struct pcap_stat *ps _U_)
 {
 	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
@@ -551,6 +561,7 @@ found:
 	p->selectable_fd = fileno(fp);
 #endif
 
+	p->can_set_rfmon_op = sf_cant_set_rfmon;
 	p->read_op = pcap_offline_read;
 	p->inject_op = sf_inject;
 	p->setfilter_op = install_bpf_program;


### PR DESCRIPTION
`pcap_open_dead` and `pcap_fopen_offline` has not initialized the `breakloop_op` and `can_set_rfmon_op` callback respectively, if `pcap_breakloop()` is called followed by `pcap_open_dead()` and `pcap_can_set_rfmon()` is called followed by `pcap_fopen_offline()` then the null function pointer crashes will happen.

This commit adds two default implementations `pcap_breakloop_dead` and `sf_cant_set_rfmon` and uses them to initialize those two missed callbacks.

fixes: #1146

Signed-off-by: hopper-vul <hopper.vul@gmail.com>