### PR TITLE
Do not have variables be unsigned if they are passed as signed variables

### DIFF
--- a/etherent.c
+++ b/etherent.c
@@ -157,7 +157,7 @@ pcap_next_etherent(FILE *fp)
 		/* Use 'namesize' to prevent buffer overflow. */
 		namesize = sizeof(e.name) - 1;
 		do {
-			*bp++ = (u_char)c;
+			*bp++ = (char)c;
 			c = getc(fp);
 			if (c == EOF)
 				return (NULL);


### PR DESCRIPTION
The results are implementation defined and confuses the compiler