### PR TITLE
Use the intended date types for variables passed as or compared to other types

### DIFF
--- a/instrument-functions.c
+++ b/instrument-functions.c
@@ -77,7 +77,7 @@ static void print_debug(void *this_fn, void *call_site, action_type action)
 	static int instrument_set;
 	static int instrument_off;
 	static int instrument_global;
-	int i;
+	long i;
 
 	if (!instrument_set) {
 		static char *instrument_type;

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -1061,7 +1061,7 @@ static int
 pcap_read_bpf(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 {
 	struct pcap_bpf *pb = p->priv;
-	int cc;
+	ssize_t cc;
 	int n = 0;
 	register u_char *bp, *ep;
 	u_char *datap;
@@ -1107,7 +1107,7 @@ pcap_read_bpf(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 		} else
 #endif
 		{
-			cc = (int)read(p->fd, p->buffer, p->bufsize);
+			cc = read(p->fd, p->buffer, p->bufsize);
 		}
 		if (cc < 0) {
 			/* Don't choke when we get ptraced */

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -529,8 +529,8 @@ static void eth_addr_str(ETHER_ADDR_TYPE *addrp, char* mac_str, int len)
 static uint16_t portid_by_device(char * device)
 {
 	uint16_t ret = DPDK_PORTID_MAX;
-	int len = strlen(device);
-	int prefix_len = strlen(DPDK_PREFIX);
+	size_t len = strlen(device);
+	size_t prefix_len = strlen(DPDK_PREFIX);
 	unsigned long ret_ul = 0L;
 	char *pEnd;
 	if (len<=prefix_len || strncmp(device, DPDK_PREFIX, prefix_len)) // check prefix dpdk:


### PR DESCRIPTION
This prevents unnecessary casting.