### PR TITLE
struct pcap: Update buffer type from "void *" to "u_char *"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -7,6 +7,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Clean up DECnet address handling.
       Finalize moving of bpf_filter.c. (GH #1166)
       Address a few compiler warnings on Haiku.
+      struct pcap: Update buffer type from "void *" to "u_char *".
     Link-layer types:
       Add LINKTYPE_ETW/DLT_ETW.
       Add LINKTYPE_NETANALYZER_NG/DLT_NETANALYZER_NG (pull request

--- a/pcap-airpcap.c
+++ b/pcap-airpcap.c
@@ -621,7 +621,7 @@ airpcap_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			return (-1);
 		}
 		cc = bytes_read;
-		bp = (u_char *)p->buffer;
+		bp = p->buffer;
 	} else
 		bp = p->bp;
 

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -1181,7 +1181,7 @@ pcap_read_bpf(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			    errno, "read");
 			return (PCAP_ERROR);
 		}
-		bp = (u_char *)p->buffer;
+		bp = p->buffer;
 	} else
 		bp = p->bp;
 

--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -327,7 +327,7 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 	u_char *pktd;
 	int in = 0;
 
-	pktd = (u_char *)handle->buffer + BT_CTRL_SIZE;
+	pktd = handle->buffer + BT_CTRL_SIZE;
 	bthdr = (pcap_bluetooth_h4_header*)(void *)pktd;
 	iv.iov_base = pktd + sizeof(pcap_bluetooth_h4_header);
 	iv.iov_len  = handle->snapshot;

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -102,7 +102,7 @@ bt_monitor_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_ch
     u_char *pktd;
     struct hci_mon_hdr hdr;
 
-    pktd = (u_char *)handle->buffer + BT_CONTROL_SIZE;
+    pktd = handle->buffer + BT_CONTROL_SIZE;
     bthdr = (pcap_bluetooth_linux_monitor_header*)(void *)pktd;
 
     iv[0].iov_base = &hdr;

--- a/pcap-dlpi.c
+++ b/pcap-dlpi.c
@@ -238,7 +238,7 @@ pcap_read_dlpi(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			}
 			cc = data.len;
 		} while (cc == 0);
-		bp = (u_char *)p->buffer + p->offset;
+		bp = p->buffer + p->offset;
 	} else
 		bp = p->bp;
 

--- a/pcap-haiku.c
+++ b/pcap-haiku.c
@@ -52,7 +52,7 @@ pcap_read_haiku(pcap_t* handle, int maxPackets _U_, pcap_handler callback,
 {
 	// Receive a single packet
 
-	u_char* buffer = (u_char*)handle->buffer + handle->offset;
+	u_char* buffer = handle->buffer + handle->offset;
 	struct sockaddr_dl from;
 	ssize_t bytesReceived;
 	do {

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -241,7 +241,7 @@ struct pcap {
 	 * Read buffer.
 	 */
 	u_int bufsize;
-	void *buffer;
+	u_char *buffer;
 	u_char *bp;
 	int cc;
 

--- a/pcap-libdlpi.c
+++ b/pcap-libdlpi.c
@@ -423,7 +423,7 @@ pcap_read_libdlpi(pcap_t *p, int count, pcap_handler callback, u_char *user)
 		}
 
 		msglen = p->bufsize;
-		bufp = (u_char *)p->buffer + p->offset;
+		bufp = p->buffer + p->offset;
 
 		retv = dlpi_recv(pd->dlpi_hd, NULL, NULL, bufp,
 		    &msglen, -1, NULL);

--- a/pcap-nit.c
+++ b/pcap-nit.c
@@ -117,7 +117,7 @@ pcap_read_nit(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			    errno, "pcap_read");
 			return (-1);
 		}
-		bp = (u_char *)p->buffer;
+		bp = p->buffer;
 	} else
 		bp = p->bp;
 

--- a/pcap-pf.c
+++ b/pcap-pf.c
@@ -128,7 +128,7 @@ pcap_read_pf(pcap_t *pc, int cnt, pcap_handler callback, u_char *user)
 			    sizeof(pc->errbuf), errno, "pf read");
 			return (-1);
 		}
-		bp = (u_char *)pc->buffer + pc->offset;
+		bp = pc->buffer + pc->offset;
 	} else
 		bp = pc->bp;
 	/*

--- a/pcap-rdmasniff.c
+++ b/pcap-rdmasniff.c
@@ -169,7 +169,7 @@ rdmasniff_read(pcap_t *handle, int max_packets, pcap_handler callback, u_char *u
 		pkth.caplen = min(pkth.len, (u_int)handle->snapshot);
 		gettimeofday(&pkth.ts, NULL);
 
-		pktd = (u_char *) handle->buffer + wc.wr_id * RDMASNIFF_RECEIVE_SIZE;
+		pktd = handle->buffer + wc.wr_id * RDMASNIFF_RECEIVE_SIZE;
 
 		if (handle->fcode.bf_insns == NULL ||
 		    pcap_filter(handle->fcode.bf_insns, pktd, pkth.len, pkth.caplen)) {

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -456,7 +456,7 @@ static int pcap_read_nocb_remote(pcap_t *p, struct pcap_pkthdr *pkt_header, u_ch
 	 */
 	header = (struct rpcap_header *) p->buffer;
 	net_pkt_header = (struct rpcap_pkthdr *) ((char *)p->buffer + sizeof(struct rpcap_header));
-	net_pkt_data = (u_char *)p->buffer + sizeof(struct rpcap_header) + sizeof(struct rpcap_pkthdr);
+	net_pkt_data = p->buffer + sizeof(struct rpcap_header) + sizeof(struct rpcap_pkthdr);
 
 	if (pr->rmt_flags & PCAP_OPENFLAG_DATATX_UDP)
 	{

--- a/pcap-sita.c
+++ b/pcap-sita.c
@@ -970,7 +970,7 @@ static int pcap_read_acn(pcap_t *handle, int max_packets, pcap_handler callback,
 	pcap_header.caplen		= ntohl(*(uint32_t *)&packet_header[8]);				/* caplen */
 	pcap_header.len			= ntohl(*(uint32_t *)&packet_header[12]);				/* len */
 
-	handle->bp = (u_char *)handle->buffer + handle->offset;									/* start off the receive pointer at the right spot */
+	handle->bp = handle->buffer + handle->offset;									/* start off the receive pointer at the right spot */
 	if (acn_read_n_bytes_with_timeout(handle, pcap_header.caplen) == -1) return 0;	/* then try to read in the rest of the data */
 
 	callback(user, &pcap_header, handle->bp);										/* call the user supplied callback function */

--- a/pcap-snit.c
+++ b/pcap-snit.c
@@ -133,7 +133,7 @@ pcap_read_snit(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			    errno, "pcap_read");
 			return (-1);
 		}
-		bp = (u_char *)p->buffer;
+		bp = p->buffer;
 	} else
 		bp = p->bp;
 

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -671,7 +671,7 @@ usb_read_linux_bin(pcap_t *handle, int max_packets _U_, pcap_handler callback, u
 
 	/* the usb header is going to be part of 'packet' data*/
 	info.hdr = (pcap_usb_header*) handle->buffer;
-	info.data = (u_char *)handle->buffer + sizeof(pcap_usb_header);
+	info.data = handle->buffer + sizeof(pcap_usb_header);
 	info.data_len = clen;
 
 	/* ignore interrupt system call errors */

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -352,7 +352,7 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 	 * of the block.
 	 */
 	memcpy(p->buffer, &bhdr, sizeof(bhdr));
-	bdata = (u_char *)p->buffer + sizeof(bhdr);
+	bdata = p->buffer + sizeof(bhdr);
 	data_remaining = bhdr.total_length - sizeof(bhdr);
 	if (read_bytes(fp, bdata, data_remaining, 1, errbuf) == -1)
 		return (-1);
@@ -943,12 +943,12 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 	 * of the SHB.
 	 */
 	bhdrp = (struct block_header *)p->buffer;
-	shbp = (struct section_header_block *)((u_char *)p->buffer + sizeof(struct block_header));
+	shbp = (struct section_header_block *)(p->buffer + sizeof(struct block_header));
 	bhdrp->block_type = magic_int;
 	bhdrp->total_length = total_length;
 	shbp->byte_order_magic = byte_order_magic;
 	if (read_bytes(fp,
-	    (u_char *)p->buffer + (sizeof(magic_int) + sizeof(total_length) + sizeof(byte_order_magic)),
+	    p->buffer + (sizeof(magic_int) + sizeof(total_length) + sizeof(byte_order_magic)),
 	    total_length - (sizeof(magic_int) + sizeof(total_length) + sizeof(byte_order_magic)),
 	    1, errbuf) == -1)
 		goto fail;


### PR DESCRIPTION
This change should avoid these cppcheck warnings:
```
pcap-hurd.c:77:18: warning: 'p->buffer' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined. [arithOperationsOnVoidPointer]
 pkt = p->buffer + offsetof(struct net_rcv_msg, packet)
                 ^
pcap-hurd.c:78:8: warning: 'p->buffer+offsetof(struct net_rcv_msg,packet)' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined. [arithOperationsOnVoidPointer]
       + sizeof(struct packet_header) - ETH_HLEN;
       ^
pcap-hurd.c:79:25: warning: 'p->buffer' is of type 'void *'. When using void pointers in calculations, the behaviour is undefined. [arithOperationsOnVoidPointer]
 memmove(pkt, p->buffer + offsetof(struct net_rcv_msg, header),
                        ^
```
Remove some '(u_char *)' casts accordingly.