### PR TITLE
Remove unused variable retval in sock_present2network

### DIFF
--- a/sockutils.c
+++ b/sockutils.c
@@ -2082,7 +2082,6 @@ int sock_getascii_addrport(const struct sockaddr_storage *sockaddr, char *addres
  */
 int sock_present2network(const char *address, struct sockaddr_storage *sockaddr, int addr_family, char *errbuf, int errbuflen)
 {
-	int retval;
 	struct addrinfo *addrinfo;
 	struct addrinfo hints;
 
@@ -2090,7 +2089,7 @@ int sock_present2network(const char *address, struct sockaddr_storage *sockaddr,
 
 	hints.ai_family = addr_family;
 
-	if ((retval = sock_initaddress(address, "22222" /* fake port */, &hints, &addrinfo, errbuf, errbuflen)) == -1)
+	if (sock_initaddress(address, "22222" /* fake port */, &hints, &addrinfo, errbuf, errbuflen) == -1)
 		return 0;
 
 	if (addrinfo->ai_family == PF_INET)


### PR DESCRIPTION
This quiets the compiler since it is not even returned anyway, and is a misleading variable name.