### PR TITLE
Jump to "quit" label if scanner cannot be initialized

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -739,22 +739,23 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 	yyscan_t scanner = NULL;
 	volatile YY_BUFFER_STATE in_buffer = NULL;
 	u_int len;
-	int  rc;
+	int rc;
 
 	/*
 	 * If this pcap_t hasn't been activated, it doesn't have a
 	 * link-layer type, so we can't use it.
 	 */
 	if (!p->activated) {
-		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		(void)snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 		    "not-yet-activated pcap_t passed to pcap_compile");
 		return (PCAP_ERROR);
 	}
 
 #ifdef _WIN32
-	if (!done)
+	if (!done) {
 		pcap_wsockinit();
-	done = 1;
+		done = 1;
+	}
 #endif
 
 #ifdef ENABLE_REMOTE
@@ -794,15 +795,18 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 
 	cstate.snaplen = pcap_snapshot(p);
 	if (cstate.snaplen == 0) {
-		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		(void)snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 			 "snaplen of 0 rejects all packets");
 		rc = PCAP_ERROR;
 		goto quit;
 	}
 
-	if (pcap_lex_init(&scanner) != 0)
+	if (pcap_lex_init(&scanner) != 0) {
 		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "can't initialize scanner");
+		rc = PCAP_ERROR;
+		goto quit;
+	}
 	in_buffer = pcap__scan_string(xbuf ? xbuf : "", scanner);
 
 	/*


### PR DESCRIPTION
With the current behavior, we log the error but try to scan the string anyway. We need to quit if the scanner cannot be initialized.