### PR TITLE
Make i, n, index, and max_stmts unsigned integers

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -604,7 +604,7 @@ static struct block *gen_msg_abbrev(compiler_state_t *, int type);
 static void
 initchunks(compiler_state_t *cstate)
 {
-	int i;
+	u_int i;
 
 	for (i = 0; i < NCHUNKS; i++) {
 		cstate->chunks[i].n_left = 0;
@@ -664,7 +664,7 @@ newchunk(compiler_state_t *cstate, size_t n)
 static void
 freechunks(compiler_state_t *cstate)
 {
-	int i;
+	u_int i;
 
 	for (i = 0; i < NCHUNKS; ++i)
 		if (cstate->chunks[i].m != NULL)

--- a/optimize.c
+++ b/optimize.c
@@ -2447,7 +2447,7 @@ slength(struct slist *s)
  * Return the number of nodes reachable by 'p'.
  * All nodes should be initially unmarked.
  */
-static int
+static u_int
 count_blocks(struct icode *ic, struct block *p)
 {
 	if (p == 0 || isMarked(ic, p))
@@ -2522,7 +2522,7 @@ static void
 opt_init(opt_state_t *opt_state, struct icode *ic)
 {
 	bpf_u_int32 *p;
-	int i, n, max_stmts;
+	u_int i, n, max_stmts;
 	u_int product;
 	size_t block_memsize, edge_memsize;
 

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -1271,10 +1271,9 @@ static int
 dag_get_datalink(pcap_t *p)
 {
 	struct pcap_dag *pd = p->priv;
-	int index=0, dlt_index=0;
-	uint8_t types[255];
-
-	memset(types, 0, 255);
+	size_t index=0;
+	int dlt_index=0;
+	uint8_t types[255] = {0};
 
 	if (p->dlt_list == NULL && (p->dlt_list = malloc(255*sizeof(*(p->dlt_list)))) == NULL) {
 		pcap_fmt_errmsg_for_errno(p->errbuf, sizeof(p->errbuf),

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -564,7 +564,7 @@ void main_startup(void)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
 	struct addrinfo *addrinfo;		// keeps the addrinfo chain; required to open a new socket
-	int i;
+	u_int i;
 #ifdef _WIN32
 	HANDLE threadId;			// handle for the subthread
 #else


### PR DESCRIPTION
This fixes compiler warnings  regarding signedness and avoids casting.

maxval should be an unsigned integer because slength, the result of which is added to this number, returns an unsigned value.

In addition, opt_state->maxval being an unsigned int that is assigned via multiplying max_stmts is also a good case for max_stmts being unsigned. Finally, count_blocks should be unsigned since the minimum number is 0, and it assigns to n, which "i" is compared to, and is used for pointer arithmetic.