### PR TITLE
Add Visual Studio 2022 images to AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,6 +82,31 @@ environment:
       PLATFORM: x64
       SDK: npcap-sdk-1.12
       AIRPCAP: -DDISABLE_AIRPCAP=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: Win32
+      SDK: WpdPack
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: WpdPack
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: Win32
+      SDK: npcap-sdk-1.12
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: npcap-sdk-1.12
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: npcap-sdk-1.12
+      AIRPCAP: -DDISABLE_AIRPCAP=NO
 
 build_script:
   #

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -50,7 +50,7 @@ macos_task:
   name: macos-aarch64
   only_if: $CIRRUS_BRANCH != 'coverity_scan'
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.1 # macOS 13 with Xcode 14.1
+    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.3 # macOS 13 with Xcode 14.3
   env:
     MAKEFLAGS: '-j 4' # macOS VMs run on 4 cores
   script:

--- a/doc/README.windows.md
+++ b/doc/README.windows.md
@@ -100,7 +100,7 @@ include built-in support for CMake-based projects:
   https://devblogs.microsoft.com/cppblog/cmake-support-in-visual-studio/
 
 For Visual Studio 2017, make sure "Visual C++ tools for CMake" is
-installed; for Visual Studio 2019, make sure "C++ CMake tools for
+installed; for Visual Studio 2019 or later, make sure "C++ CMake tools for
 Windows" is installed.
 
 ### winflexbison ###
@@ -152,7 +152,7 @@ with control-S.
 Visual Studio will then re-run CMake.  If that completes without errors,
 you can build with CMake > "Build All".
 
-### Visual Studio 2019 ###
+### Visual Studio 2019 or later ###
 
 Open the folder containing the libpcap source with Open > Folder.
 Visual Studio will run CMake; however, you will need to indicate where


### PR DESCRIPTION
The current version of Visual Studio is 2022, so we should add images of Visual Studio 2022.

Update Xcode as well.