### PR TITLE
Add a routine to use as an atexit() routine to clean up Winsock 2.

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -155,6 +155,19 @@ struct rtentry;		/* declarations in <net/if.h> */
  */
 
 /*
+ * Shut down Winsock.
+ *
+ * Ignores the return value of WSACleanup(); given that this is
+ * an atexit() routine, there's nothing much we can do about
+ * a failure.
+ */
+static void
+internal_wsockfini(void)
+{
+	WSACleanup();
+}
+
+/*
  * Start Winsock.
  * Internal routine.
  */
@@ -184,7 +197,7 @@ internal_wsockinit(char *errbuf)
 		}
 		return (err);
 	}
-	atexit ((void(*)(void))WSACleanup);
+	atexit(internal_wsockfini);
 	err = 0;
 	return (err);
 }


### PR DESCRIPTION
Wrap WSACleanup() in a routine that calls it but returns nothing, so that the wrapper has the right type for an atexit() routine.

This is cleaner that casting a pointer to WSACleanup(), and should avoid warnings from VS 2022.