### PR TITLE
Document why we do not do error handling if dlt_list is NULL

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -1886,7 +1886,7 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
 			 */
 			handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
 			/*
-			 * If that fails, just leave the list empty.
+			 * If that failed, just leave the list empty.
 			 */
 			if (handle->dlt_list != NULL) {
 				handle->dlt_list[0] = DLT_EN10MB;

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -613,6 +613,10 @@ netfilter_activate(pcap_t* handle)
 	if (type == NFLOG) {
 		handle->linktype = DLT_NFLOG;
 		handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
+
+		/*
+		 * If that failed, just leave the list empty.
+		 */
 		if (handle->dlt_list != NULL) {
 			handle->dlt_list[0] = DLT_NFLOG;
 			handle->dlt_list[1] = DLT_IPV4;


### PR DESCRIPTION
We can leave the dlt_list empty instead of populating it.