### PR TITLE
If we can't allocate a DLT_ list, fail.

### DIFF
--- a/dlpisubs.c
+++ b/dlpisubs.c
@@ -246,14 +246,14 @@ pcap_process_mactype(pcap_t *p, u_int mactype)
 		 * Ethernet framing).
 		 */
 		p->dlt_list = (u_int *)malloc(sizeof(u_int) * 2);
-		/*
-		 * If that fails, just leave the list empty.
-		 */
-		if (p->dlt_list != NULL) {
-			p->dlt_list[0] = DLT_EN10MB;
-			p->dlt_list[1] = DLT_DOCSIS;
-			p->dlt_count = 2;
+		if (p->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+			    errno, "malloc");
+			return (-1);
 		}
+		p->dlt_list[0] = DLT_EN10MB;
+		p->dlt_list[1] = DLT_DOCSIS;
+		p->dlt_count = 2;
 		break;
 
 	case DL_FDDI:

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -2460,14 +2460,15 @@ pcap_activate_bpf(pcap_t *p)
 	 */
 	if (v == DLT_EN10MB && p->dlt_count == 0) {
 		p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-		/*
-		 * If that fails, just leave the list empty.
-		 */
-		if (p->dlt_list != NULL) {
-			p->dlt_list[0] = DLT_EN10MB;
-			p->dlt_list[1] = DLT_DOCSIS;
-			p->dlt_count = 2;
+		if (p->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+			    errno, "malloc");
+			status = PCAP_ERROR;
+			goto bad;
 		}
+		p->dlt_list[0] = DLT_EN10MB;
+		p->dlt_list[1] = DLT_DOCSIS;
+		p->dlt_count = 2;
 	}
 #ifdef PCAP_FDDIPAD
 	if (v == DLT_FDDI)

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -221,7 +221,7 @@ struct pcap_linux {
  */
 static int get_if_flags(const char *, bpf_u_int32 *, char *);
 static int is_wifi(const char *);
-static void map_arphrd_to_dlt(pcap_t *, int, const char *, int);
+static int map_arphrd_to_dlt(pcap_t *, int, const char *, int);
 static int pcap_activate_linux(pcap_t *);
 static int setup_socket(pcap_t *, int);
 static int setup_mmapped(pcap_t *);
@@ -1835,9 +1835,11 @@ is_wifi(const char *device)
  *  to pick some type that works in raw mode, or fail.
  *
  *  Sets the link type to -1 if unable to map the type.
+ *
+ *  Returns 0 on success or a PCAP_ERROR_ value on error.
  */
-static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
-			      const char *device, int cooked_ok)
+static int map_arphrd_to_dlt(pcap_t *handle, int arptype,
+			     const char *device, int cooked_ok)
 {
 	static const char cdma_rmnet[] = "cdma_rmnet";
 
@@ -1858,7 +1860,7 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
 		 */
 		if (strncmp(device, cdma_rmnet, sizeof cdma_rmnet - 1) == 0) {
 			handle->linktype = DLT_RAW;
-			return;
+			return 0;
 		}
 
 		/*
@@ -1888,7 +1890,7 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
 			 */
 			ret = iface_dsa_get_proto_info(device, handle);
 			if (ret < 0)
-				return;
+				return ret;
 
 			if (ret == 1) {
 				/*
@@ -1905,14 +1907,14 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
 			 * It's not a Wi-Fi device; offer DOCSIS.
 			 */
 			handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-			/*
-			 * If that fails, just leave the list empty.
-			 */
-			if (handle->dlt_list != NULL) {
-				handle->dlt_list[0] = DLT_EN10MB;
-				handle->dlt_list[1] = DLT_DOCSIS;
-				handle->dlt_count = 2;
+			if (handle->dlt_list == NULL) {
+				pcap_fmt_errmsg_for_errno(handle->errbuf,
+				    PCAP_ERRBUF_SIZE, errno, "malloc");
+				return (PCAP_ERROR);
 			}
+			handle->dlt_list[0] = DLT_EN10MB;
+			handle->dlt_list[1] = DLT_DOCSIS;
+			handle->dlt_count = 2;
 		}
 		/* FALLTHROUGH */
 
@@ -2201,17 +2203,17 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
 		 * IP-over-FC on which somebody wants to capture
 		 * packets.
 		 */
-		handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 3);
-		/*
-		 * If that fails, just leave the list empty.
-		 */
-		if (handle->dlt_list != NULL) {
-			handle->dlt_list[0] = DLT_FC_2;
-			handle->dlt_list[1] = DLT_FC_2_WITH_FRAME_DELIMS;
-			handle->dlt_list[2] = DLT_IP_OVER_FC;
-			handle->dlt_count = 3;
-		}
 		handle->linktype = DLT_FC_2;
+		handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 3);
+		if (handle->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(handle->errbuf,
+			    PCAP_ERRBUF_SIZE, errno, "malloc");
+			return (PCAP_ERROR);
+		}
+		handle->dlt_list[0] = DLT_FC_2;
+		handle->dlt_list[1] = DLT_FC_2_WITH_FRAME_DELIMS;
+		handle->dlt_list[2] = DLT_IP_OVER_FC;
+		handle->dlt_count = 3;
 		break;
 
 #ifndef ARPHRD_IRDA
@@ -2281,6 +2283,7 @@ static void map_arphrd_to_dlt(pcap_t *handle, int arptype,
 		handle->linktype = -1;
 		break;
 	}
+	return (0);
 }
 
 /*
@@ -2401,7 +2404,9 @@ setup_socket(pcap_t *handle, int is_any_device)
 			close(sock_fd);
 			return arptype;
 		}
-		map_arphrd_to_dlt(handle, arptype, device, 1);
+		status = map_arphrd_to_dlt(handle, arptype, device, 1);
+		if (status < 0)
+			return status;
 		if (handle->linktype == -1 ||
 		    handle->linktype == DLT_LINUX_SLL ||
 		    handle->linktype == DLT_LINUX_IRDA ||
@@ -2513,14 +2518,14 @@ setup_socket(pcap_t *handle, int is_any_device)
 		handlep->cooked = 1;
 		handle->linktype = DLT_LINUX_SLL;
 		handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-		/*
-		 * If that failed, just leave the list empty.
-		 */
-		if (handle->dlt_list != NULL) {
-			handle->dlt_list[0] = DLT_LINUX_SLL;
-			handle->dlt_list[1] = DLT_LINUX_SLL2;
-			handle->dlt_count = 2;
+		if (handle->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(handle->errbuf,
+			    PCAP_ERRBUF_SIZE, errno, "malloc");
+			return (PCAP_ERROR);
 		}
+		handle->dlt_list[0] = DLT_LINUX_SLL;
+		handle->dlt_list[1] = DLT_LINUX_SLL2;
+		handle->dlt_count = 2;
 
 		/*
 		 * We're not bound to a device.

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -613,12 +613,15 @@ netfilter_activate(pcap_t* handle)
 	if (type == NFLOG) {
 		handle->linktype = DLT_NFLOG;
 		handle->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-		if (handle->dlt_list != NULL) {
-			handle->dlt_list[0] = DLT_NFLOG;
-			handle->dlt_list[1] = DLT_IPV4;
-			handle->dlt_count = 2;
+		if (handle->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(handle->errbuf,
+			    PCAP_ERRBUF_SIZE, errno,
+			    "Can't allocate DLT list");
+			goto close_fail;
 		}
-
+		handle->dlt_list[0] = DLT_NFLOG;
+		handle->dlt_list[1] = DLT_IPV4;
+		handle->dlt_count = 2;
 	} else
 		handle->linktype = DLT_IPV4;
 

--- a/pcap-nit.c
+++ b/pcap-nit.c
@@ -344,14 +344,14 @@ pcap_activate_nit(pcap_t *p)
 	 * Ethernet framing).
 	 */
 	p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-	/*
-	 * If that fails, just leave the list empty.
-	 */
-	if (p->dlt_list != NULL) {
-		p->dlt_list[0] = DLT_EN10MB;
-		p->dlt_list[1] = DLT_DOCSIS;
-		p->dlt_count = 2;
+	if (p->dlt_list == NULL) {
+		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "malloc");
+		goto bad;
 	}
+	p->dlt_list[0] = DLT_EN10MB;
+	p->dlt_list[1] = DLT_DOCSIS;
+	p->dlt_count = 2;
 
 	p->read_op = pcap_read_nit;
 	p->inject_op = pcap_inject_nit;

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -1142,14 +1142,15 @@ pcap_activate_npf(pcap_t *p)
 		 * Ethernet framing).
 		 */
 		p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-		/*
-		 * If that fails, just leave the list empty.
-		 */
-		if (p->dlt_list != NULL) {
-			p->dlt_list[0] = DLT_EN10MB;
-			p->dlt_list[1] = DLT_DOCSIS;
-			p->dlt_count = 2;
+		if (p->dlt_list == NULL)
+		{
+			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+			    errno, "malloc");
+			goto bad;
 		}
+		p->dlt_list[0] = DLT_EN10MB;
+		p->dlt_list[1] = DLT_DOCSIS;
+		p->dlt_count = 2;
 		break;
 
 	case NdisMedium802_5:

--- a/pcap-pf.c
+++ b/pcap-pf.c
@@ -404,14 +404,15 @@ pcap_activate_pf(pcap_t *p)
 		 * Ethernet framing).
 		 */
 		p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-		/*
-		 * If that fails, just leave the list empty.
-		 */
-		if (p->dlt_list != NULL) {
-			p->dlt_list[0] = DLT_EN10MB;
-			p->dlt_list[1] = DLT_DOCSIS;
-			p->dlt_count = 2;
+		if (p->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+			    errno, "malloc");
+			err = PCAP_ERROR;
+			goto bad;
 		}
+		p->dlt_list[0] = DLT_EN10MB;
+		p->dlt_list[1] = DLT_DOCSIS;
+		p->dlt_count = 2;
 		break;
 
 	case ENDT_FDDI:

--- a/pcap-snit.c
+++ b/pcap-snit.c
@@ -437,14 +437,15 @@ pcap_activate_snit(pcap_t *p)
 	 * Ethernet framing).
 	 */
 	p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-	/*
-	 * If that fails, just leave the list empty.
-	 */
-	if (p->dlt_list != NULL) {
-		p->dlt_list[0] = DLT_EN10MB;
-		p->dlt_list[1] = DLT_DOCSIS;
-		p->dlt_count = 2;
+	if (p->dlt_list == NULL) {
+		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "malloc");
+		err = PCAP_ERROR;
+		goto bad;
 	}
+	p->dlt_list[0] = DLT_EN10MB;
+	p->dlt_list[1] = DLT_DOCSIS;
+	p->dlt_count = 2;
 
 	p->read_op = pcap_read_snit;
 	p->inject_op = pcap_inject_snit;

--- a/pcap-snoop.c
+++ b/pcap-snoop.c
@@ -283,14 +283,14 @@ pcap_activate_snoop(pcap_t *p)
 		 * Classical IP devices?
 		 */
 		p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-		/*
-		 * If that fails, just leave the list empty.
-		 */
-		if (p->dlt_list != NULL) {
-			p->dlt_list[0] = DLT_EN10MB;
-			p->dlt_list[1] = DLT_DOCSIS;
-			p->dlt_count = 2;
+		if (p->dlt_list == NULL) {
+			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+			    errno, "malloc");
+			goto bad;
 		}
+		p->dlt_list[0] = DLT_EN10MB;
+		p->dlt_list[1] = DLT_DOCSIS;
+		p->dlt_count = 2;
 	} else if (strncmp("ipg", p->opt.device, 3) == 0 ||
 		   strncmp("rns", p->opt.device, 3) == 0 ||	/* O2/200/2000 FDDI */
 		   strncmp("xpi", p->opt.device, 3) == 0) {

--- a/pcap-tc.c
+++ b/pcap-tc.c
@@ -540,14 +540,14 @@ TcActivate(pcap_t *p)
 
 	p->linktype = DLT_EN10MB;
 	p->dlt_list = (u_int *) malloc(sizeof(u_int) * 2);
-	/*
-	 * If that fails, just leave the list empty.
-	 */
-	if (p->dlt_list != NULL) {
-		p->dlt_list[0] = DLT_EN10MB;
-		p->dlt_list[1] = DLT_PPI;
-		p->dlt_count = 2;
+	if (p->dlt_list == NULL)
+	{
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE, "Error allocating memory");
+		return PCAP_ERROR;
 	}
+	p->dlt_list[0] = DLT_EN10MB;
+	p->dlt_list[1] = DLT_PPI;
+	p->dlt_count = 2;
 
 	/*
 	 * ignore promiscuous mode


### PR DESCRIPTION
Some code already was doing that (for example, pcap-bpf.c if fetching the DLT list with an ioctl), and, if you can't allocate a DLT_ list, which is usually pretty small, you may have other memory allocation problems later, so letting the program open an interface (and not get a correct list of all link-layer types supported) may not be worth it.