### PR TITLE
Allow build on OS X pre 10.5

### DIFF
--- a/pcap/funcattrs.h
+++ b/pcap/funcattrs.h
@@ -181,7 +181,11 @@
  * I've never seen earlier releases.
  */
 #ifdef __APPLE__
-#include <Availability.h>
+#ifndef __MAC_OS_X_VERSION_MIN_REQUIRED
+#if __ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ >= 1050
+ # include <Availability.h>
+#endif
+#endif
 /*
  * When building as part of macOS, define this as __API_AVAILABLE(__VA_ARGS__).
  *


### PR DESCRIPTION
Availability.h was introduced in 10.5 (Leopard)
Guard off the inclusion so that it is possible to build libpcap on older releases such as 10.4 (Tiger)