### PR TITLE
Numeric truncation at `pcap-usb-linux-common.c:95`

### DIFF
--- a/pcap-usb-linux-common.c
+++ b/pcap-usb-linux-common.c
@@ -55,7 +55,8 @@ fix_linux_usb_mmapped_length(struct pcap_pkthdr *pkth, const u_char *bp)
 	    pkth->len == sizeof(pcap_usb_header_mmapped) +
 	                 (hdr->ndesc * sizeof (usb_isodesc)) + hdr->urb_len) {
 		usb_isodesc *descs;
-		u_int pre_truncation_data_len, pre_truncation_len;
+		u_int pre_truncation_data_len;
+		unsigned long pre_truncation_len;
 
 		descs = (usb_isodesc *) (bp + sizeof(pcap_usb_header_mmapped));
 

--- a/pcap-usb-linux-common.c
+++ b/pcap-usb-linux-common.c
@@ -56,7 +56,7 @@ fix_linux_usb_mmapped_length(struct pcap_pkthdr *pkth, const u_char *bp)
 	                 (hdr->ndesc * sizeof (usb_isodesc)) + hdr->urb_len) {
 		usb_isodesc *descs;
 		u_int pre_truncation_data_len;
-		unsigned long pre_truncation_len;
+		size_t pre_truncation_len;
 
 		descs = (usb_isodesc *) (bp + sizeof(pcap_usb_header_mmapped));
 


### PR DESCRIPTION
Hi! We've been fuzzing `libpcap` with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `pcap-usb-linux-common.c:95`.

In function `fix_linux_usb_mmapped_length` on line 95 variable `pre_truncation_len` has type `u_int` (aka unsigned int), on the right side of operator= `sizeof` promotes type to `unsigned long`, so the numeric truncation may occur. Then `pre_truncation_len` is used in if operator on line 103, so the truncation may cause wrong behavior. We suggest to change the type `u_int` of the variable `pre_truncation_len` to type `unsigned long`. 

Or if this truncation was made by design, please inform about this. 

### Environment

- OS: ubuntu 20.04
- commit: cff41e58f2fcd2c2ee77e9e25c63813e879657e1

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/libpcap):

    ```
    sudo docker build -t oss-sydr-fuzz-libpcap .

    ```

2. Run docker container:

    ```
    sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-libpcap /bin/bash

    ```

3. Run on the following [input](https://github.com/the-tcpdump-group/libpcap/files/12071318/sydr_f722d3ad2bfa6692ec8d54402099e2afc5d99826_num_trunc_0_unsigned.txt):

    ```
     /libpcap/libfuzzer/fuzz_pcap sydr_f722d3ad2bfa6692ec8d54402099e2afc5d99826_num_trunc_0_unsigned.txt

    ```
4. Output:

    ```
    ../pcap-usb-linux-common.c:95:24: runtime error: implicit conversion from type 'unsigned long' of value 8589934574 (64-bit, unsigned) to type 'u_int' (aka 'unsigned int') changed the value to 4294967278 (32-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../pcap-usb-linux-common.c:95:24
    ```