### PR TITLE
Numeric truncation at `pcap-util.c:374`

### DIFF
--- a/pcap-util.c
+++ b/pcap-util.c
@@ -344,7 +344,7 @@ swap_nflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 	nflog_tlv_t *tlv;
 	u_int caplen = hdr->caplen;
 	u_int length = hdr->len;
-	uint16_t size;
+	u_int size;
 
 	if (caplen < (u_int) sizeof(nflog_hdr_t) ||
 	    length < (u_int) sizeof(nflog_hdr_t)) {


### PR DESCRIPTION
Hi! We've been fuzzing `libpcap` with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `pcap-util.c:374`.

In function `swap_nflog_header` on line 374 variable `size` has type `uint16_t`, type of value on the right side of operator= is `int` (due to integer promotion), so the numeric truncation may occur. Our tool has found input where value of variable `size` truncates to zero. Then `size` is used in if operators on lines 377 and 383, so the truncation may cause wrong behavior. We suggest to change type `uint16_t` of the variable `size` to type `u_int`.

### Environment

- OS: ubuntu 20.04
- commit: cff41e58f2fcd2c2ee77e9e25c63813e879657e1

### How to reproduce this error

1. Build [docker container](https://github.com/ispras/oss-sydr-fuzz/tree/master/projects/libpcap):

    ```
    sudo docker build -t oss-sydr-fuzz-libpcap .

    ```

2. Run docker container:

    ```
    sudo docker run --privileged --network host -v /etc/localtime:/etc/localtime:ro --rm -it -v $PWD:/fuzz oss-sydr-fuzz-libpcap /bin/bash

    ```

3. Run on the following [input](https://github.com/the-tcpdump-group/libpcap/files/12071387/sydr_5f9add793596bb8b38dd4bc0b55021b9a0aa0a26_num_trunc_0.txt):

    ```
     /libpcap/libfuzzer/fuzz_pcap sydr_5f9add793596bb8b38dd4bc0b55021b9a0aa0a26_num_trunc_0.txt

    ```
4. Output:

    ```
    ../pcap-util.c:374:9: runtime error: implicit conversion from type 'int' of value 65536 (32-bit, signed) to type 'uint16_t' (aka 'unsigned short') changed the value to 0 (16-bit, unsigned)
    SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior ../pcap-util.c:374:9
    ```