### PR TITLE
allow "tcp[tcpflags]" access to all flag bits, including tcp-ae

### DIFF
--- a/grammar.y.in
+++ b/grammar.y.in
@@ -389,7 +389,7 @@ DIAG_OFF_BISON_BYACC
 
 %token  DST SRC HOST GATEWAY
 %token  NET NETMASK PORT PORTRANGE LESS GREATER PROTO PROTOCHAIN CBYTE
-%token  ARP RARP IP SCTP TCP UDP ICMP IGMP IGRP PIM VRRP CARP
+%token  ARP RARP IP SCTP TCP TCPFLAGS UDP ICMP IGMP IGRP PIM VRRP CARP
 %token  ATALK AARP DECNET LAT SCA MOPRC MOPDL
 %token  TK_BROADCAST TK_MULTICAST
 %token  NUM INBOUND OUTBOUND
@@ -852,7 +852,10 @@ irelop:	  LEQ			{ $$ = BPF_JGT; }
 arth:	  pnum			{ CHECK_PTR_VAL(($$ = gen_loadi(cstate, $1))); }
 	| narth
 	;
-narth:	  pname '[' arth ']'		{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, $3, 1))); }
+tcpflags: TCPFLAGS
+	;
+narth:	  pname '[' tcpflags ']'	{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, gen_loadi(cstate, 12), 2))); }
+	| pname '[' arth ']'		{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, $3, 1))); }
 	| pname '[' arth ':' NUM ']'	{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, $3, $5))); }
 	| arth '+' arth			{ CHECK_PTR_VAL(($$ = gen_arth(cstate, BPF_ADD, $1, $3))); }
 	| arth '-' arth			{ CHECK_PTR_VAL(($$ = gen_arth(cstate, BPF_SUB, $1, $3))); }

--- a/grammar.y.in
+++ b/grammar.y.in
@@ -854,7 +854,10 @@ arth:	  pnum			{ CHECK_PTR_VAL(($$ = gen_loadi(cstate, $1))); }
 	;
 tcpflags: TCPFLAGS
 	;
-narth:	  pname '[' tcpflags ']'	{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, gen_loadi(cstate, 12), 2))); }
+narth:	  pname '[' tcpflags ']'	{ CHECK_PTR_VAL(($$ =
+						gen_arth(cstate, BPF_AND,
+						    gen_load(cstate, $1, gen_loadi(cstate, 12), 2),
+						    gen_loadi(cstate, 0x0FFF)))); }
 	| pname '[' arth ']'		{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, $3, 1))); }
 	| pname '[' arth ':' NUM ']'	{ CHECK_PTR_VAL(($$ = gen_load(cstate, $1, $3, $5))); }
 	| arth '+' arth			{ CHECK_PTR_VAL(($$ = gen_arth(cstate, BPF_ADD, $1, $3))); }

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -18,7 +18,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP-FILTER @MAN_MISC_INFO@ "12 February 2024"
+.TH PCAP-FILTER @MAN_MISC_INFO@ "28 March 2024"
 .SH NAME
 pcap-filter \- packet filter syntax
 .br
@@ -1030,10 +1030,15 @@ The following ICMPv6 type field values are available:
 .BR \%icmp6-multicastroutersolicit ,
 .BR \%icmp6-multicastrouterterm .
 .IP
-The following TCP flags field values are available: \fBtcp-fin\fP,
-\fBtcp-syn\fP, \fBtcp-rst\fP, \fBtcp-push\fP,
-\fBtcp-ack\fP, \fBtcp-urg\fP, \fBtcp-ece\fP,
-\fBtcp-cwr\fP.
+The following TCP flags field values are available:
+\fBtcp-fin\fP, \fBtcp-syn\fP, \fBtcp-rst\fP,
+\fBtcp-push\fP, \fBtcp-ack\fP, \fBtcp-urg\fP,
+\fBtcp-ece\fP, \fBtcp-cwr\fP, \fBtcp-ae\fP,
+\fBtcp-res1\fP, \fBtcp-res2\fP, \fBtcp-res3\fP and
+\fBtcp-res\fP.
+Among these, \fBtcp-res\fP is special as it can be
+used to check when any of the reserved TCP header
+flags is non-zero.
 .LP
 Primitives may be combined using:
 .IP

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -1187,6 +1187,10 @@ keyword became available in libpcap 1.8.0.
 The
 .B ifindex
 keyword became available in libpcap 1.10.0.
+.PP
+The \fBtcp-ae\fP, \fBtcp-res1\fP, \fBtcp-res2\fP, \fBtcp-res3\fP and \fBtcp-res\fP
+became available in libpcap 1.11. Also, \fBtcp[tcpflags]\fP was expanded to allow
+access to all 12 TCP header flags.
 .SH SEE ALSO
 .BR pcap (3PCAP)
 .SH BUGS

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -1033,12 +1033,7 @@ The following ICMPv6 type field values are available:
 The following TCP flags field values are available:
 \fBtcp-fin\fP, \fBtcp-syn\fP, \fBtcp-rst\fP,
 \fBtcp-push\fP, \fBtcp-ack\fP, \fBtcp-urg\fP,
-\fBtcp-ece\fP, \fBtcp-cwr\fP, \fBtcp-ae\fP,
-\fBtcp-res1\fP, \fBtcp-res2\fP, \fBtcp-res3\fP and
-\fBtcp-res\fP.
-Among these, \fBtcp-res\fP is special as it can be
-used to check when any of the reserved TCP header
-flags is non-zero.
+\fBtcp-ece\fP, \fBtcp-cwr\fP, and \fBtcp-ae\fP.
 .LP
 Primitives may be combined using:
 .IP
@@ -1188,8 +1183,8 @@ The
 .B ifindex
 keyword became available in libpcap 1.10.0.
 .PP
-The \fBtcp-ae\fP, \fBtcp-res1\fP, \fBtcp-res2\fP, \fBtcp-res3\fP and \fBtcp-res\fP
-became available in libpcap 1.11. Also, \fBtcp[tcpflags]\fP was expanded to allow
+The \fBtcp-ae\fP keyword became available in libpcap 1.11.
+Also, \fBtcp[tcpflags]\fP was expanded to allow
 access to all 12 TCP header flags.
 .SH SEE ALSO
 .BR pcap (3PCAP)

--- a/scanner.l
+++ b/scanner.l
@@ -493,6 +493,10 @@ tcp-urg			{ yylval->h = 0x20; return NUM; }
 tcp-ece			{ yylval->h = 0x40; return NUM; }
 tcp-cwr			{ yylval->h = 0x80; return NUM; }
 tcp-ae			{ yylval->h = 0x100; return NUM; }
+tcp-res3		{ yylval->h = 0x200; return NUM; }
+tcp-res2		{ yylval->h = 0x400; return NUM; }
+tcp-res1		{ yylval->h = 0x800; return NUM; }
+tcp-res			{ yylval->h = 0xE00; return NUM; }
 [A-Za-z0-9]([-_.A-Za-z0-9]*[.A-Za-z0-9])? {
 			 yylval->s = sdup(yyextra, (char *)yytext); return ID; }
 "\\"[^ !()\n\t]+	{ yylval->s = sdup(yyextra, (char *)yytext + 1); return ID; }

--- a/scanner.l
+++ b/scanner.l
@@ -276,6 +276,7 @@ rarp		return RARP;
 ip		return IP;
 sctp		return SCTP;
 tcp		return TCP;
+tcpflags	return TCPFLAGS;
 udp		return UDP;
 icmp		return ICMP;
 igmp		return IGMP;
@@ -483,7 +484,6 @@ icmp6-multicastrouteradvert     { yylval->h = 151; return NUM; }
 icmp6-multicastroutersolicit    { yylval->h = 152; return NUM; }
 icmp6-multicastrouterterm       { yylval->h = 153; return NUM; }
 
-tcpflags		{ yylval->h = 13; return NUM; }
 tcp-fin			{ yylval->h = 0x01; return NUM; }
 tcp-syn			{ yylval->h = 0x02; return NUM; }
 tcp-rst			{ yylval->h = 0x04; return NUM; }
@@ -492,6 +492,7 @@ tcp-ack			{ yylval->h = 0x10; return NUM; }
 tcp-urg			{ yylval->h = 0x20; return NUM; }
 tcp-ece			{ yylval->h = 0x40; return NUM; }
 tcp-cwr			{ yylval->h = 0x80; return NUM; }
+tcp-ae			{ yylval->h = 0x100; return NUM; }
 [A-Za-z0-9]([-_.A-Za-z0-9]*[.A-Za-z0-9])? {
 			 yylval->s = sdup(yyextra, (char *)yytext); return ID; }
 "\\"[^ !()\n\t]+	{ yylval->s = sdup(yyextra, (char *)yytext + 1); return ID; }

--- a/scanner.l
+++ b/scanner.l
@@ -493,10 +493,6 @@ tcp-urg			{ yylval->h = 0x20; return NUM; }
 tcp-ece			{ yylval->h = 0x40; return NUM; }
 tcp-cwr			{ yylval->h = 0x80; return NUM; }
 tcp-ae			{ yylval->h = 0x100; return NUM; }
-tcp-res3		{ yylval->h = 0x200; return NUM; }
-tcp-res2		{ yylval->h = 0x400; return NUM; }
-tcp-res1		{ yylval->h = 0x800; return NUM; }
-tcp-res			{ yylval->h = 0xE00; return NUM; }
 [A-Za-z0-9]([-_.A-Za-z0-9]*[.A-Za-z0-9])? {
 			 yylval->s = sdup(yyextra, (char *)yytext); return ID; }
 "\\"[^ !()\n\t]+	{ yylval->s = sdup(yyextra, (char *)yytext + 1); return ID; }


### PR DESCRIPTION
This is the adjacent patch to libpcap, to introduce the 9th TCP flag bit (tcp-ae). 

Also handle tcp[tcpflags] specially to allow access to all TCP header flags without having to 
revert to tcp[12:2] which is much less readable, so that existing scripts can easily be extended
to check for the AE flag in an easy to understand manner.