### PR TITLE
Add DLT and linktype for MDB

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1269,7 +1269,19 @@
  */
 #define LINKTYPE_FIRA_UCI	299
 
-#define LINKTYPE_HIGH_MATCHING_MAX	299		/* highest value in the "matching" range */
+/*
+ * MDB (Multi-Drop Bus) protocol between a vending machine controller and
+ * peripherals inside the vending machine. See
+ *
+ *	https://www.kaiser.cx/pcap-mdb.html
+ *
+ * for the specification.
+ *
+ * Requested by Martin Kaiser <martin@kaiser.cx>.
+ */
+#define LINKTYPE_MDB		300
+
+#define LINKTYPE_HIGH_MATCHING_MAX	300		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3374,6 +3374,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(ZWAVE_TAP, "Z-Wave packets with a TAP meta-data header"),
 	DLT_CHOICE(SILABS_DEBUG_CHANNEL, "Silicon Labs debug channel protocol"),
 	DLT_CHOICE(FIRA_UCI, "Ultra-wideband controller interface protocol"),
+	DLT_CHOICE(MDB, "Multi-Drop Bus"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1639,6 +1639,18 @@
 #define DLT_FIRA_UCI		299
 
 /*
+ * MDB (Multi-Drop Bus) protocol between a vending machine controller and
+ * peripherals inside the vending machine. See
+ *
+ *	https://www.kaiser.cx/pcap-mdb.html
+ *
+ * for the specification.
+ *
+ * Requested by Martin Kaiser <martin@kaiser.cx>.
+ */
+#define DLT_MDB			300
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_HIGH_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1649,6 +1661,6 @@
 #undef DLT_HIGH_MATCHING_MAX
 #endif
 
-#define DLT_HIGH_MATCHING_MAX	299	/* highest value in the "matching" range */
+#define DLT_HIGH_MATCHING_MAX	300	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
Add a link-layer header type for the MDB (Multi-Drop Bus) protocol.

The MDB protocol defines messages between a vending machine controller and peripherals inside the vending machine, e.g. a card reader that processes payments.

Packets with DLT_MDB use a pseudo-header as defined in

https://www.kaiser.cx/pcap-mdb.html