### PR TITLE
Integer Overflow at `pcap-usb-linux-common.c:39`

### DIFF
--- a/pcap-usb-linux-common.c
+++ b/pcap-usb-linux-common.c
@@ -36,7 +36,7 @@
 static inline u_int
 u_int_sum(u_int a, u_int b)
 {
-	return (((b) <= UINT_MAX - (b)) ? (a) + (b) : UINT_MAX);
+	return (((b) <= UINT_MAX - (a)) ? (a) + (b) : UINT_MAX);
 }
 
 /*


### PR DESCRIPTION
Hi! We've been fuzzing `libpcap` with [sydr-fuzz](https://github.com/ispras/oss-sydr-fuzz) security predicates and we found numeric truncation error in `pcap-usb-linux-common.c:39`.

```
static inline u_int
u_int_sum(u_int a, u_int b)
{
    return (((b) <= UINT_MAX - (b)) ? (a) + (b) : UINT_MAX);
}
```

In this function on line 39 variable name `b` was confused with variable `a` in `(b) <= UINT_MAX - (b)` expression and integer overflow occurs here when `b` is quite small and `a` is close to `UINT_MAX`.


### Environment

- OS: ubuntu 20.04
- commit: f225f8d7464569c7b917015c26ad30a37a5fbbe2

### Ubsan log
 
```
pcap-usb-linux-common.c:39:40: runtime error: unsigned integer overflow: 4294967292 + 32261 cannot be represented in type 'unsigned int'
```