### PR TITLE
Add DLT and linktype for DECT_NR.

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1281,7 +1281,13 @@
  */
 #define LINKTYPE_MDB		300
 
-#define LINKTYPE_HIGH_MATCHING_MAX	300		/* highest value in the "matching" range */
+/*
+ * DECT-2020 New Radio (NR) - ETSI TS 103 636.
+ * Requested by Stig Bjorlykke <stig@bjorlykke.org>.
+ */
+#define LINKTYPE_DECT_NR	301
+
+#define LINKTYPE_HIGH_MATCHING_MAX	301		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3382,6 +3382,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(SILABS_DEBUG_CHANNEL, "Silicon Labs debug channel protocol"),
 	DLT_CHOICE(FIRA_UCI, "Ultra-wideband controller interface protocol"),
 	DLT_CHOICE(MDB, "Multi-Drop Bus"),
+	DLT_CHOICE(DECT_NR, "DECT New Radio"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1651,6 +1651,12 @@
 #define DLT_MDB			300
 
 /*
+ * DECT-2020 New Radio (NR) - ETSI TS 103 636.
+ * Requested by Stig Bjorlykke <stig@bjorlykke.org>.
+ */
+#define DLT_DECT_NR		301
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_HIGH_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1661,6 +1667,6 @@
 #undef DLT_HIGH_MATCHING_MAX
 #endif
 
-#define DLT_HIGH_MATCHING_MAX	300	/* highest value in the "matching" range */
+#define DLT_HIGH_MATCHING_MAX	301	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
Add a link-layer header type for the DECT New Radio protocol defined in ETSI TS 103 636-4.