### PR TITLE
Prefix functions declared in pcap-int.h with pcapint_

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,9 +50,9 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Use correct data types rather than int in some cases.
       Squelch compiler warning in grammar.c.
       Fix findalldevtest compilation if IPv6 isn't enabled.
-      Rename helper routines for pcap modules to have names
-        beginning with pcap_, to avoid namespace collisions for code
-        linking statically with libpcap.
+      Rename helper routines for pcap modules to have names beginning with
+      pcapint_, to avoid namespace collisions for code linking statically
+      with libpcap.
       Avoid casting hack for the Windows cleanup-on-exit routine.
       Use %zu format for one case of printing a size_t.
       Fix some Coverity errors.

--- a/fad-getad.c
+++ b/fad-getad.c
@@ -263,7 +263,7 @@ pcap_findalldevs_interfaces(pcap_if_list_t *devlistp, char *errbuf,
 		/*
 		 * Add information for this address to the list.
 		 */
-		if (pcap_add_addr_to_if(devlistp, ifa->ifa_name, ifa->ifa_flags,
+		if (pcapint_add_addr_to_if(devlistp, ifa->ifa_name, ifa->ifa_flags,
 		    get_flags_func,
 		    addr, addr_size, netmask, addr_size,
 		    broadaddr, broadaddr_size, dstaddr, dstaddr_size,

--- a/fad-gifc.c
+++ b/fad-gifc.c
@@ -409,7 +409,7 @@ pcap_findalldevs_interfaces(pcap_if_list_t *devlistp, char *errbuf,
 		/*
 		 * Add information for this address to the list.
 		 */
-		if (pcap_add_addr_to_if(devlistp, ifrp->ifr_name,
+		if (pcapint_add_addr_to_if(devlistp, ifrp->ifr_name,
 		    ifrflags.ifr_flags, get_flags_func,
 		    &ifrp->ifr_addr, SA_LEN(&ifrp->ifr_addr),
 		    netmask, netmask_size, broadaddr, broadaddr_size,

--- a/fad-glifc.c
+++ b/fad-glifc.c
@@ -326,7 +326,7 @@ pcap_findalldevs_interfaces(pcap_if_list_t *devlistp, char *errbuf,
 		/*
 		 * Add information for this address to the list.
 		 */
-		if (pcap_add_addr_to_if(devlistp, ifrp->lifr_name,
+		if (pcapint_add_addr_to_if(devlistp, ifrp->lifr_name,
 		    ifrflags.lifr_flags, get_flags_func,
 		    (struct sockaddr *)&ifrp->lifr_addr,
 		    sizeof (struct sockaddr_storage),

--- a/optimize.c
+++ b/optimize.c
@@ -2928,7 +2928,7 @@ conv_error(conv_state_t *conv_state, const char *fmt, ...)
  * otherwise, return 0.
  */
 int
-pcap_install_bpf_program(pcap_t *p, struct bpf_program *fp)
+pcapint_install_bpf_program(pcap_t *p, struct bpf_program *fp)
 {
 	size_t prog_size;
 

--- a/pcap-airpcap.c
+++ b/pcap-airpcap.c
@@ -275,11 +275,11 @@ airpcap_setfilter(pcap_t *p, struct bpf_program *fp)
 		 */
 
 		/*
-		 * pcap_install_bpf_program() validates the program.
+		 * pcapint_install_bpf_program() validates the program.
 		 *
 		 * XXX - what if we already have a filter in the kernel?
 		 */
-		if (pcap_install_bpf_program(p, fp) < 0)
+		if (pcapint_install_bpf_program(p, fp) < 0)
 			return (-1);
 		pa->filtering_in_kernel = 0;	/* filtering in userland */
 		return (0);
@@ -1043,7 +1043,7 @@ airpcap_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 
 	for (airpcap_device = airpcap_devices; airpcap_device != NULL;
 	    airpcap_device = airpcap_device->next) {
-		if (pcap_add_dev(devlistp, airpcap_device->Name, 0,
+		if (pcapint_add_dev(devlistp, airpcap_device->Name, 0,
 		    airpcap_device->Description, errbuf) == NULL) {
 			/*
 			 * Failure.

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -2933,7 +2933,7 @@ finddevs_usb(pcap_if_list_t *devlistp, char *errbuf)
 		 * so we need to avoid adding multiple capture devices
 		 * for each bus.
 		 */
-		if (pcap_find_or_add_dev(devlistp, name, PCAP_IF_UP,
+		if (pcapint_find_or_add_dev(devlistp, name, PCAP_IF_UP,
 		    get_usb_if_flags, NULL, errbuf) == NULL) {
 			free(name);
 			closedir(usbdir);
@@ -3476,11 +3476,11 @@ pcap_setfilter_bpf(pcap_t *p, struct bpf_program *fp)
 	}
 
 	/*
-	 * pcap_install_bpf_program() validates the program.
+	 * pcapint_install_bpf_program() validates the program.
 	 *
 	 * XXX - what if we already have a filter in the kernel?
 	 */
-	if (pcap_install_bpf_program(p, fp) < 0)
+	if (pcapint_install_bpf_program(p, fp) < 0)
 		return (-1);
 	pb->filtering_in_kernel = 0;	/* filtering in userland */
 	return (0);

--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -131,7 +131,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 		 * the status to PCAP_IF_CONNECTION_STATUS_CONNECTED
 		 * or PCAP_IF_CONNECTION_STATUS_DISCONNECTED.
 		 */
-		if (pcap_add_dev(devlistp, dev_name, PCAP_IF_WIRELESS, dev_descr, err_str)  == NULL)
+		if (pcapint_add_dev(devlistp, dev_name, PCAP_IF_WIRELESS, dev_descr, err_str)  == NULL)
 		{
 			ret = -1;
 			break;
@@ -225,7 +225,7 @@ bt_activate(pcap_t* handle)
 
 	handle->read_op = bt_read_linux;
 	handle->inject_op = bt_inject_linux;
-	handle->setfilter_op = pcap_install_bpf_program; /* no kernel filtering */
+	handle->setfilter_op = pcapint_install_bpf_program; /* no kernel filtering */
 	handle->setdirection_op = bt_setdirection_linux;
 	handle->set_datalink_op = NULL;	/* can't change data link type */
 	handle->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -80,7 +80,7 @@ bt_monitor_findalldevs(pcap_if_list_t *devlistp, char *err_str)
      * more than there's a notion of "connected" or "disconnected"
      * for the "any" device.
      */
-    if (pcap_add_dev(devlistp, INTERFACE_NAME,
+    if (pcapint_add_dev(devlistp, INTERFACE_NAME,
                 PCAP_IF_WIRELESS|PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
                 "Bluetooth Linux Monitor", err_str) == NULL)
     {
@@ -204,7 +204,7 @@ bt_monitor_activate(pcap_t* handle)
 
     handle->read_op = bt_monitor_read;
     handle->inject_op = bt_monitor_inject;
-    handle->setfilter_op = pcap_install_bpf_program; /* no kernel filtering */
+    handle->setfilter_op = pcapint_install_bpf_program; /* no kernel filtering */
     handle->setdirection_op = NULL; /* Not implemented */
     handle->set_datalink_op = NULL; /* can't change data link type */
     handle->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -996,7 +996,7 @@ static int dag_activate(pcap_t* p)
 
 	p->read_op = dag_read;
 	p->inject_op = dag_inject;
-	p->setfilter_op = pcap_install_bpf_program;
+	p->setfilter_op = pcapint_install_bpf_program;
 	p->setdirection_op = NULL; /* Not implemented.*/
 	p->set_datalink_op = dag_set_datalink;
 	p->getnonblock_op = pcap_getnonblock_fd;
@@ -1179,7 +1179,7 @@ dag_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 			 *
 			 * Also, are there notions of "up" and "running"?
 			 */
-			if (pcap_add_dev(devlistp, name, 0, description, errbuf) == NULL) {
+			if (pcapint_add_dev(devlistp, name, 0, description, errbuf) == NULL) {
 				/*
 				 * Failure.
 				 */
@@ -1191,7 +1191,7 @@ dag_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 					dag_detach_stream(dagfd, stream);
 
 					snprintf(name,  10, "dag%d:%d", c, stream);
-					if (pcap_add_dev(devlistp, name, 0, description, errbuf) == NULL) {
+					if (pcapint_add_dev(devlistp, name, 0, description, errbuf) == NULL) {
 						/*
 						 * Failure.
 						 */

--- a/pcap-dbus.c
+++ b/pcap-dbus.c
@@ -227,7 +227,7 @@ dbus_activate(pcap_t *handle)
 	handle->linktype = DLT_DBUS;
 	handle->read_op = dbus_read;
 	handle->inject_op = dbus_write;
-	handle->setfilter_op = pcap_install_bpf_program; /* XXX, later add support for dbus_bus_add_match() */
+	handle->setfilter_op = pcapint_install_bpf_program; /* XXX, later add support for dbus_bus_add_match() */
 	handle->setdirection_op = NULL;
 	handle->set_datalink_op = NULL;      /* can't change data link type */
 	handle->getnonblock_op = dbus_getnonblock;
@@ -338,11 +338,11 @@ dbus_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 	 * The notion of "connected" vs. "disconnected" doesn't apply.
 	 * XXX - what about the notions of "up" and "running"?
 	 */
-	if (pcap_add_dev(devlistp, "dbus-system",
+	if (pcapint_add_dev(devlistp, "dbus-system",
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE, "D-Bus system bus",
 	    err_str) == NULL)
 		return -1;
-	if (pcap_add_dev(devlistp, "dbus-session",
+	if (pcapint_add_dev(devlistp, "dbus-session",
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE, "D-Bus session bus",
 	    err_str) == NULL)
 		return -1;

--- a/pcap-dlpi.c
+++ b/pcap-dlpi.c
@@ -865,7 +865,7 @@ pcap_activate_dlpi(pcap_t *p)
 
 	p->read_op = pcap_read_dlpi;
 	p->inject_op = pcap_inject_dlpi;
-	p->setfilter_op = pcap_install_bpf_program;	/* no kernel filtering */
+	p->setfilter_op = pcapint_install_bpf_program;	/* no kernel filtering */
 	p->setdirection_op = NULL;	/* Not implemented.*/
 	p->set_datalink_op = NULL;	/* can't change data link type */
 	p->getnonblock_op = pcap_getnonblock_fd;
@@ -1148,7 +1148,7 @@ pcap_platform_finddevs(pcap_if_list_t *devlistp, char *errbuf)
 		 * And is there a way to determine whether the
 		 * interface is plugged into a network?
 		 */
-		if (pcap_add_dev(devlistp, baname, 0, NULL, errbuf) == NULL)
+		if (pcapint_add_dev(devlistp, baname, 0, NULL, errbuf) == NULL)
 			return (-1);
 	}
 #endif

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -949,7 +949,7 @@ static int pcap_dpdk_activate(pcap_t *p)
 		p->read_op = pcap_dpdk_dispatch;
 		p->inject_op = pcap_dpdk_inject;
 		// using pcap_filter currently, though DPDK provides their own BPF function. Because DPDK BPF needs load a ELF file as a filter.
-		p->setfilter_op = pcap_install_bpf_program;
+		p->setfilter_op = pcapint_install_bpf_program;
 		p->setdirection_op = NULL;
 		p->set_datalink_op = NULL;
 		p->getnonblock_op = pcap_dpdk_getnonblock;
@@ -1041,7 +1041,7 @@ int pcap_dpdk_findalldevs(pcap_if_list_t *devlistp, char *ebuf)
 			// PCI addr
 			rte_eth_dev_get_name_by_port(i,pci_addr);
 			snprintf(dpdk_desc,DPDK_DEV_DESC_MAX-1,"%s %s, MAC:%s, PCI:%s", DPDK_DESC, dpdk_name, mac_addr, pci_addr);
-			if (pcap_add_dev(devlistp, dpdk_name, 0, dpdk_desc, ebuf)==NULL){
+			if (pcapint_add_dev(devlistp, dpdk_name, 0, dpdk_desc, ebuf)==NULL){
 				ret = PCAP_ERROR;
 				break;
 			}

--- a/pcap-haiku.c
+++ b/pcap-haiku.c
@@ -151,7 +151,7 @@ pcap_activate_haiku(pcap_t *handle)
 	const char* device = handle->opt.device;
 
 	handle->read_op = pcap_read_haiku;
-	handle->setfilter_op = pcap_install_bpf_program; /* no kernel filtering */
+	handle->setfilter_op = pcapint_install_bpf_program; /* no kernel filtering */
 	handle->inject_op = pcap_inject_haiku;
 	handle->stats_op = pcap_stats_haiku;
 

--- a/pcap-hurd.c
+++ b/pcap-hurd.c
@@ -230,7 +230,7 @@ pcap_activate_hurd(pcap_t *p)
 
 	p->read_op = pcap_read_hurd;
 	p->inject_op = pcap_inject_hurd;
-	p->setfilter_op = pcap_install_bpf_program;
+	p->setfilter_op = pcapint_install_bpf_program;
 	p->stats_op = pcap_stats_hurd;
 
 	return 0;

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -517,13 +517,13 @@ void	pcap_breakloop_common(pcap_t *);
  * "pcap_findalldevs_interfaces()" is a helper to find those interfaces
  * using the "standard" mechanisms (SIOCGIFCONF, "getifaddrs()", etc.).
  *
- * "pcap_add_dev()" adds an entry to a pcap_if_list_t.
+ * "pcapint_add_dev()" adds an entry to a pcap_if_list_t.
  *
  * "pcap_add_any_dev()" adds an entry for the "any" device to a pcap_if_list_t.
  *
- * "pcap_find_dev()" tries to find a device, by name, in a pcap_if_list_t.
+ * "pcapint_find_dev()" tries to find a device, by name, in a pcap_if_list_t.
  *
- * "pcap_find_or_add_dev()" checks whether a device is already in a
+ * "pcapint_find_or_add_dev()" checks whether a device is already in a
  * pcap_if_list_t and, if not, adds an entry for it.
  */
 struct pcap_if_list;
@@ -534,19 +534,19 @@ int	pcap_platform_finddevs(pcap_if_list_t *, char *);
 int	pcap_findalldevs_interfaces(pcap_if_list_t *, char *,
 	    int (*)(const char *), get_if_flags_func);
 #endif
-pcap_if_t *pcap_find_or_add_dev(pcap_if_list_t *, const char *, bpf_u_int32,
+pcap_if_t *pcapint_find_or_add_dev(pcap_if_list_t *, const char *, bpf_u_int32,
 	    get_if_flags_func, const char *, char *);
-pcap_if_t *pcap_find_dev(pcap_if_list_t *, const char *);
-pcap_if_t *pcap_add_dev(pcap_if_list_t *, const char *, bpf_u_int32,
+pcap_if_t *pcapint_find_dev(pcap_if_list_t *, const char *);
+pcap_if_t *pcapint_add_dev(pcap_if_list_t *, const char *, bpf_u_int32,
 	    const char *, char *);
 pcap_if_t *pcap_add_any_dev(pcap_if_list_t *, char *);
-int	pcap_add_addr_to_dev(pcap_if_t *, struct sockaddr *, size_t,
+int	pcapint_add_addr_to_dev(pcap_if_t *, struct sockaddr *, size_t,
 	    struct sockaddr *, size_t, struct sockaddr *, size_t,
 	    struct sockaddr *dstaddr, size_t, char *errbuf);
 #ifndef _WIN32
-pcap_if_t *pcap_find_or_add_if(pcap_if_list_t *, const char *, bpf_u_int32,
+pcap_if_t *pcapint_find_or_add_if(pcap_if_list_t *, const char *, bpf_u_int32,
 	    get_if_flags_func, char *);
-int	pcap_add_addr_to_if(pcap_if_list_t *, const char *, bpf_u_int32,
+int	pcapint_add_addr_to_if(pcap_if_list_t *, const char *, bpf_u_int32,
 	    get_if_flags_func,
 	    struct sockaddr *, size_t, struct sockaddr *, size_t,
 	    struct sockaddr *, size_t, struct sockaddr *, size_t, char *);
@@ -562,11 +562,11 @@ int	pcap_add_addr_to_if(pcap_if_list_t *, const char *, bpf_u_int32,
  * "pcap_adjust_snapshot()" adjusts the snapshot to be non-zero and
  * fit within an int.
  *
- * "pcap_sf_cleanup()" closes the file handle associated with a pcap_t, if
+ * "pcapint_sf_cleanup()" closes the file handle associated with a pcap_t, if
  * appropriate, and frees all data common to all modules for handling
  * savefile types.
  *
- * "pcap_charset_fopen()", in UTF-8 mode on Windows, does an fopen() that
+ * "pcapint_charset_fopen()", in UTF-8 mode on Windows, does an fopen() that
  * treats the pathname as being in UTF-8, rather than the local
  * code page, on Windows.
  */
@@ -585,14 +585,14 @@ int	pcap_add_addr_to_if(pcap_if_list_t *, const char *, bpf_u_int32,
 pcap_t	*pcap_open_offline_common(char *ebuf, size_t total_size,
     size_t private_data);
 bpf_u_int32 pcap_adjust_snapshot(bpf_u_int32 linktype, bpf_u_int32 snaplen);
-void	pcap_sf_cleanup(pcap_t *p);
+void	pcapint_sf_cleanup(pcap_t *p);
 #ifdef _WIN32
-FILE	*pcap_charset_fopen(const char *path, const char *mode);
+FILE	*pcapint_charset_fopen(const char *path, const char *mode);
 #else
 /*
  * On other OSes, just use Boring Old fopen().
  */
-#define pcap_charset_fopen(path, mode)	fopen((path), (mode))
+#define pcapint_charset_fopen(path, mode)	fopen((path), (mode))
 #endif
 
 /*
@@ -646,7 +646,7 @@ int	pcap_validate_filter(const struct bpf_insn *, int);
  */
 void	pcap_oneshot(u_char *, const struct pcap_pkthdr *, const u_char *);
 
-int	pcap_install_bpf_program(pcap_t *, struct bpf_program *);
+int	pcapint_install_bpf_program(pcap_t *, struct bpf_program *);
 
 int	pcap_strcasecmp(const char *, const char *);
 

--- a/pcap-libdlpi.c
+++ b/pcap-libdlpi.c
@@ -248,7 +248,7 @@ pcap_activate_libdlpi(pcap_t *p)
 
 	p->read_op = pcap_read_libdlpi;
 	p->inject_op = pcap_inject_libdlpi;
-	p->setfilter_op = pcap_install_bpf_program;	/* No kernel filtering */
+	p->setfilter_op = pcapint_install_bpf_program;	/* No kernel filtering */
 	p->setdirection_op = NULL;	/* Not implemented */
 	p->set_datalink_op = NULL;	/* Can't change data link type */
 	p->getnonblock_op = pcap_getnonblock_fd;
@@ -377,7 +377,7 @@ pcap_platform_finddevs(pcap_if_list_t *devlistp, char *errbuf)
 		 * If it isn't already in the list of devices, try to
 		 * add it.
 		 */
-		if (pcap_find_or_add_dev(devlistp, entry->linkname, 0, get_if_flags,
+		if (pcapint_find_or_add_dev(devlistp, entry->linkname, 0, get_if_flags,
 		    NULL, errbuf) == NULL)
 			retv = -1;
 	}

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -4327,8 +4327,8 @@ pcap_setfilter_linux(pcap_t *handle, struct bpf_program *filter)
 
 	/* Make our private copy of the filter */
 
-	if (pcap_install_bpf_program(handle, filter) < 0)
-		/* pcap_install_bpf_program() filled in errbuf */
+	if (pcapint_install_bpf_program(handle, filter) < 0)
+		/* pcapint_install_bpf_program() filled in errbuf */
 		return -1;
 
 	/*

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -595,7 +595,7 @@ netfilter_activate(pcap_t* handle)
 	handle->offset = 0;
 	handle->read_op = netfilter_read_linux;
 	handle->inject_op = netfilter_inject_linux;
-	handle->setfilter_op = pcap_install_bpf_program; /* no kernel filtering */
+	handle->setfilter_op = pcapint_install_bpf_program; /* no kernel filtering */
 	handle->setdirection_op = NULL;
 	handle->set_datalink_op = netfilter_set_datalink;
 	handle->getnonblock_op = pcap_getnonblock_fd;
@@ -784,11 +784,11 @@ netfilter_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 	 * The notion of "connected" vs. "disconnected" doesn't apply.
 	 * XXX - what about "up" and "running"?
 	 */
-	if (pcap_add_dev(devlistp, NFLOG_IFACE,
+	if (pcapint_add_dev(devlistp, NFLOG_IFACE,
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 	    "Linux netfilter log (NFLOG) interface", err_str) == NULL)
 		return -1;
-	if (pcap_add_dev(devlistp, NFQUEUE_IFACE,
+	if (pcapint_add_dev(devlistp, NFQUEUE_IFACE,
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 	    "Linux netfilter queue (NFQUEUE) interface", err_str) == NULL)
 		return -1;

--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -266,7 +266,7 @@ pcap_netmap_activate(pcap_t *p)
 	p->selectable_fd = p->fd;
 	p->read_op = pcap_netmap_dispatch;
 	p->inject_op = pcap_netmap_inject;
-	p->setfilter_op = pcap_install_bpf_program;
+	p->setfilter_op = pcapint_install_bpf_program;
 	p->setdirection_op = NULL;
 	p->set_datalink_op = NULL;
 	p->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap-nit.c
+++ b/pcap-nit.c
@@ -355,7 +355,7 @@ pcap_activate_nit(pcap_t *p)
 
 	p->read_op = pcap_read_nit;
 	p->inject_op = pcap_inject_nit;
-	p->setfilter_op = pcap_install_bpf_program;	/* no kernel filtering */
+	p->setfilter_op = pcapint_install_bpf_program;	/* no kernel filtering */
 	p->setdirection_op = NULL;	/* Not implemented. */
 	p->set_datalink_op = NULL;	/* can't change data link type */
 	p->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -1945,11 +1945,11 @@ pcap_setfilter_npf(pcap_t *p, struct bpf_program *fp)
 		 */
 
 		/*
-		 * pcap_install_bpf_program() validates the program.
+		 * pcapint_install_bpf_program() validates the program.
 		 *
 		 * XXX - what if we already have a filter in the kernel?
 		 */
-		if (pcap_install_bpf_program(p, fp) < 0)
+		if (pcapint_install_bpf_program(p, fp) < 0)
 			return (-1);
 		pw->filtering_in_kernel = 0;	/* filtering in userland */
 		return (0);
@@ -1983,7 +1983,7 @@ pcap_setfilter_win32_dag(pcap_t *p, struct bpf_program *fp) {
 	}
 
 	/* Install a user level filter */
-	if (pcap_install_bpf_program(p, fp) < 0)
+	if (pcapint_install_bpf_program(p, fp) < 0)
 		return (-1);
 
 	return (0);
@@ -2048,7 +2048,7 @@ pcap_add_if_npf(pcap_if_list_t *devlistp, char *name, bpf_u_int32 flags,
 	/*
 	 * Add an entry for this interface, with no addresses.
 	 */
-	curdev = pcap_add_dev(devlistp, name, flags, description, errbuf);
+	curdev = pcapint_add_dev(devlistp, name, flags, description, errbuf);
 	if (curdev == NULL) {
 		/*
 		 * Failure.
@@ -2080,7 +2080,7 @@ pcap_add_if_npf(pcap_if_list_t *devlistp, char *name, bpf_u_int32 flags,
 		 * "curdev" is an entry for this interface; add an entry for
 		 * this address to its list of addresses.
 		 */
-		res = pcap_add_addr_to_dev(curdev,
+		res = pcapint_add_addr_to_dev(curdev,
 		    (struct sockaddr *)&if_addrs[if_addr_size].IPAddress,
 		    sizeof (struct sockaddr_storage),
 		    (struct sockaddr *)&if_addrs[if_addr_size].SubnetMask,

--- a/pcap-pf.c
+++ b/pcap-pf.c
@@ -660,7 +660,7 @@ pcap_setfilter_pf(pcap_t *p, struct bpf_program *fp)
 	/*
 	 * We couldn't do filtering in the kernel; do it in userland.
 	 */
-	if (pcap_install_bpf_program(p, fp) < 0)
+	if (pcapint_install_bpf_program(p, fp) < 0)
 		return (-1);
 
 	/*

--- a/pcap-rdmasniff.c
+++ b/pcap-rdmasniff.c
@@ -323,7 +323,7 @@ rdmasniff_activate(pcap_t *handle)
 	handle->read_op = rdmasniff_read;
 	handle->stats_op = rdmasniff_stats;
 	handle->cleanup_op = rdmasniff_cleanup;
-	handle->setfilter_op = pcap_install_bpf_program;
+	handle->setfilter_op = pcapint_install_bpf_program;
 	handle->setdirection_op = NULL;
 	handle->set_datalink_op = NULL;
 	handle->getnonblock_op = pcap_getnonblock_fd;
@@ -444,7 +444,7 @@ rdmasniff_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 		 * XXX - do the notions of "up", "running", or
 		 * "connected" apply here?
 		 */
-		if (!pcap_add_dev(devlistp, dev_list[i]->name, 0, "RDMA sniffer", err_str)) {
+		if (!pcapint_add_dev(devlistp, dev_list[i]->name, 0, "RDMA sniffer", err_str)) {
 			ret = -1;
 			break;
 		}

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1707,7 +1707,7 @@ static int pcap_setfilter_rpcap(pcap_t *fp, struct bpf_program *prog)
 	if (!pr->rmt_capstarted)
 	{
 		/* copy filter into the pcap_t structure */
-		if (pcap_install_bpf_program(fp, prog) == -1)
+		if (pcapint_install_bpf_program(fp, prog) == -1)
 			return -1;
 		return 0;
 	}

--- a/pcap-septel.c
+++ b/pcap-septel.c
@@ -207,7 +207,7 @@ static pcap_t *septel_activate(pcap_t* handle) {
 
   handle->read_op = septel_read;
   handle->inject_op = septel_inject;
-  handle->setfilter_op = pcap_install_bpf_program;
+  handle->setfilter_op = pcapint_install_bpf_program;
   handle->set_datalink_op = NULL; /* can't change data link type */
   handle->getnonblock_op = septel_getnonblock;
   handle->setnonblock_op = septel_setnonblock;
@@ -267,7 +267,7 @@ septel_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
   /*
    * XXX - do the notions of "up", "running", or "connected" apply here?
    */
-  if (pcap_add_dev(devlistp,"septel",0,"Intel/Septel device",errbuf) == NULL)
+  if (pcapint_add_dev(devlistp,"septel",0,"Intel/Septel device",errbuf) == NULL)
     return -1;
   return 0;
 }

--- a/pcap-snf.c
+++ b/pcap-snf.c
@@ -320,7 +320,7 @@ snf_activate(pcap_t* p)
 	p->linktype = DLT_EN10MB;
 	p->read_op = snf_read;
 	p->inject_op = snf_inject;
-	p->setfilter_op = pcap_install_bpf_program;
+	p->setfilter_op = pcapint_install_bpf_program;
 	p->setdirection_op = NULL; /* Not implemented.*/
 	p->set_datalink_op = snf_set_datalink;
 	p->getnonblock_op = snf_getnonblock;
@@ -413,7 +413,7 @@ snf_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 		 * See if there's already an entry for the device
 		 * with the name ifa->snf_ifa_name.
 		 */
-		dev = pcap_find_dev(devlistp, ifa->snf_ifa_name);
+		dev = pcapint_find_dev(devlistp, ifa->snf_ifa_name);
 		if (dev != NULL) {
 			/*
 			 * Yes.  Update its description.
@@ -439,7 +439,7 @@ snf_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 			 * PCAP_IF_CONNECTION_STATUS_CONNECTED or
 			 * PCAP_IF_CONNECTION_STATUS_DISCONNECTED?
 			 */
-			dev = pcap_add_dev(devlistp, ifa->snf_ifa_name, 0, desc,
+			dev = pcapint_add_dev(devlistp, ifa->snf_ifa_name, 0, desc,
 			    errbuf);
 			if (dev == NULL)
 				return -1;
@@ -454,7 +454,7 @@ snf_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 				 * to IPv4 address.
 				 */
 				addr.sin_family = AF_INET;
-				if (pcap_add_addr_to_dev(dev, &addr, sizeof(addr),
+				if (pcapint_add_addr_to_dev(dev, &addr, sizeof(addr),
 				    NULL, 0, NULL, 0, NULL, 0, errbuf) == -1)
 					return -1;
                         } else if (ret == -1) {
@@ -489,7 +489,7 @@ snf_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 		 * "disconnected", as "is this plugged into a network?"
 		 * would be a per-port property.
 		 */
-		if (pcap_add_dev(devlistp, name,
+		if (pcapint_add_dev(devlistp, name,
 		    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE, desc,
 		    errbuf) == NULL)
 			return (-1);

--- a/pcap-snit.c
+++ b/pcap-snit.c
@@ -449,7 +449,7 @@ pcap_activate_snit(pcap_t *p)
 
 	p->read_op = pcap_read_snit;
 	p->inject_op = pcap_inject_snit;
-	p->setfilter_op = pcap_install_bpf_program;	/* no kernel filtering */
+	p->setfilter_op = pcapint_install_bpf_program;	/* no kernel filtering */
 	p->setdirection_op = NULL;	/* Not implemented. */
 	p->set_datalink_op = NULL;	/* can't change data link type */
 	p->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap-snoop.c
+++ b/pcap-snoop.c
@@ -403,7 +403,7 @@ pcap_activate_snoop(pcap_t *p)
 
 	p->read_op = pcap_read_snoop;
 	p->inject_op = pcap_inject_snoop;
-	p->setfilter_op = pcap_install_bpf_program;	/* no kernel filtering */
+	p->setfilter_op = pcapint_install_bpf_program;	/* no kernel filtering */
 	p->setdirection_op = NULL;	/* Not implemented. */
 	p->set_datalink_op = NULL;	/* can't change data link type */
 	p->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap-tc.c
+++ b/pcap-tc.c
@@ -419,7 +419,7 @@ TcFindAllDevs(pcap_if_list_t *devlist, char *errbuf)
 			dev = TcCreatePcapIfFromPort(pPorts[i]);
 
 			if (dev != NULL)
-				pcap_add_dev(devlist, dev->name, dev->flags, dev->description, errbuf);
+				pcapint_add_dev(devlist, dev->name, dev->flags, dev->description, errbuf);
 		}
 
 		if (numPorts > 0)
@@ -610,7 +610,7 @@ TcActivate(pcap_t *p)
 	}
 
 	p->read_op = TcRead;
-	p->setfilter_op = pcap_install_bpf_program;
+	p->setfilter_op = pcapint_install_bpf_program;
 	p->setdirection_op = NULL;	/* Not implemented. */
 	p->set_datalink_op = TcSetDatalink;
 	p->getnonblock_op = TcGetNonBlock;

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -157,7 +157,7 @@ usb_dev_add(pcap_if_list_t *devlistp, int n, char *err_str)
 		 * "connected" vs. "disconnected", as that's a property
 		 * that would apply to a particular USB interface.
 		 */
-		if (pcap_add_dev(devlistp, dev_name,
+		if (pcapint_add_dev(devlistp, dev_name,
 		    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 		    "Raw USB traffic, all USB buses", err_str) == NULL)
 			return -1;
@@ -169,7 +169,7 @@ usb_dev_add(pcap_if_list_t *devlistp, int n, char *err_str)
 		 * PCAP_IF_CONNECTION_STATUS_DISCONNECTED?
 		 */
 		snprintf(dev_descr, 30, "Raw USB traffic, bus number %d", n);
-		if (pcap_add_dev(devlistp, dev_name, 0, dev_descr, err_str) == NULL)
+		if (pcapint_add_dev(devlistp, dev_name, 0, dev_descr, err_str) == NULL)
 			return -1;
 	}
 
@@ -482,7 +482,7 @@ usb_activate(pcap_t* handle)
 	handle->linktype = DLT_USB_LINUX;
 
 	handle->inject_op = usb_inject_linux;
-	handle->setfilter_op = pcap_install_bpf_program; /* no kernel filtering */
+	handle->setfilter_op = pcapint_install_bpf_program; /* no kernel filtering */
 	handle->setdirection_op = usb_setdirection_linux;
 	handle->set_datalink_op = NULL;	/* can't change data link type */
 	handle->getnonblock_op = pcap_getnonblock_fd;

--- a/pcap.c
+++ b/pcap.c
@@ -1032,7 +1032,7 @@ get_if_description(const char *name _U_)
  * the new entry, otherwise return NULL and set errbuf to an error message.
  */
 pcap_if_t *
-pcap_find_or_add_if(pcap_if_list_t *devlistp, const char *name,
+pcapint_find_or_add_if(pcap_if_list_t *devlistp, const char *name,
     bpf_u_int32 if_flags, get_if_flags_func get_flags_func, char *errbuf)
 {
 	bpf_u_int32 pcap_flags;
@@ -1066,7 +1066,7 @@ pcap_find_or_add_if(pcap_if_list_t *devlistp, const char *name,
 	 * Attempt to find an entry for this device; if we don't find one,
 	 * attempt to add one.
 	 */
-	return (pcap_find_or_add_dev(devlistp, name, pcap_flags,
+	return (pcapint_find_or_add_dev(devlistp, name, pcap_flags,
 	    get_flags_func, get_if_description(name), errbuf));
 }
 
@@ -1089,7 +1089,7 @@ pcap_find_or_add_if(pcap_if_list_t *devlistp, const char *name,
  * add interfaces even if they have no addresses.)
  */
 int
-pcap_add_addr_to_if(pcap_if_list_t *devlistp, const char *name,
+pcapint_add_addr_to_if(pcap_if_list_t *devlistp, const char *name,
     bpf_u_int32 if_flags, get_if_flags_func get_flags_func,
     struct sockaddr *addr, size_t addr_size,
     struct sockaddr *netmask, size_t netmask_size,
@@ -1102,7 +1102,7 @@ pcap_add_addr_to_if(pcap_if_list_t *devlistp, const char *name,
 	/*
 	 * Check whether the device exists and, if not, add it.
 	 */
-	curdev = pcap_find_or_add_if(devlistp, name, if_flags, get_flags_func,
+	curdev = pcapint_find_or_add_if(devlistp, name, if_flags, get_flags_func,
 	    errbuf);
 	if (curdev == NULL) {
 		/*
@@ -1124,7 +1124,7 @@ pcap_add_addr_to_if(pcap_if_list_t *devlistp, const char *name,
 	 * address for it; add an entry for that address to the
 	 * interface's list of addresses.
 	 */
-	return (pcap_add_addr_to_dev(curdev, addr, addr_size, netmask,
+	return (pcapint_add_addr_to_dev(curdev, addr, addr_size, netmask,
 	    netmask_size, broadaddr, broadaddr_size, dstaddr,
 	    dstaddr_size, errbuf));
 }
@@ -1135,7 +1135,7 @@ pcap_add_addr_to_if(pcap_if_list_t *devlistp, const char *name,
  * "curdev" is the entry for that interface.
  */
 int
-pcap_add_addr_to_dev(pcap_if_t *curdev,
+pcapint_add_addr_to_dev(pcap_if_t *curdev,
     struct sockaddr *addr, size_t addr_size,
     struct sockaddr *netmask, size_t netmask_size,
     struct sockaddr *broadaddr, size_t broadaddr_size,
@@ -1250,7 +1250,7 @@ pcap_add_addr_to_dev(pcap_if_t *curdev,
  * return -1 and set errbuf to an error message.
  */
 pcap_if_t *
-pcap_find_or_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 flags,
+pcapint_find_or_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 flags,
     get_if_flags_func get_flags_func, const char *description, char *errbuf)
 {
 	pcap_if_t *curdev;
@@ -1258,7 +1258,7 @@ pcap_find_or_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 fla
 	/*
 	 * Is there already an entry in the list for this device?
 	 */
-	curdev = pcap_find_dev(devlistp, name);
+	curdev = pcapint_find_dev(devlistp, name);
 	if (curdev != NULL) {
 		/*
 		 * Yes, return it.
@@ -1283,7 +1283,7 @@ pcap_find_or_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 fla
 	/*
 	 * Now, try to add it to the list of devices.
 	 */
-	return (pcap_add_dev(devlistp, name, flags, description, errbuf));
+	return (pcapint_add_dev(devlistp, name, flags, description, errbuf));
 }
 
 /*
@@ -1291,7 +1291,7 @@ pcap_find_or_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 fla
  * the entry for it if we find it or NULL if we don't.
  */
 pcap_if_t *
-pcap_find_dev(pcap_if_list_t *devlistp, const char *name)
+pcapint_find_dev(pcap_if_list_t *devlistp, const char *name)
 {
 	pcap_if_t *curdev;
 
@@ -1325,7 +1325,7 @@ pcap_find_dev(pcap_if_list_t *devlistp, const char *name)
  * If we weren't given a description, try to get one.
  */
 pcap_if_t *
-pcap_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 flags,
+pcapint_add_dev(pcap_if_list_t *devlistp, const char *name, bpf_u_int32 flags,
     const char *description, char *errbuf)
 {
 	pcap_if_t *curdev, *prevdev, *nextdev;
@@ -1457,7 +1457,7 @@ pcap_add_any_dev(pcap_if_list_t *devlistp, char *errbuf)
 	 * network device, the notion of "connected" vs. "disconnected"
 	 * doesn't apply to the "any" device.
 	 */
-	return pcap_add_dev(devlistp, "any",
+	return pcapint_add_dev(devlistp, "any",
 	    PCAP_IF_UP|PCAP_IF_RUNNING|PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 	    any_descr, errbuf);
 }

--- a/savefile.c
+++ b/savefile.c
@@ -242,7 +242,7 @@ sf_setdirection(pcap_t *p, pcap_direction_t d _U_)
 }
 
 void
-pcap_sf_cleanup(pcap_t *p)
+pcapint_sf_cleanup(pcap_t *p)
 {
 	if (p->rfile != stdin)
 		(void)fclose(p->rfile);
@@ -262,7 +262,7 @@ pcap_sf_cleanup(pcap_t *p)
  * local code page.
  */
 FILE *
-pcap_charset_fopen(const char *path, const char *mode)
+pcapint_charset_fopen(const char *path, const char *mode)
 {
 	wchar_t *utf16_path;
 #define MAX_MODE_LEN	16
@@ -369,7 +369,7 @@ pcap_open_offline_with_tstamp_precision(const char *fname, u_int precision,
 	}
 	else {
 		/*
-		 * Use pcap_charset_fopen(); on Windows, it tests whether we're
+		 * Use pcapint_charset_fopen(); on Windows, it tests whether we're
 		 * in "local code page" or "UTF-8" mode, and treats the
 		 * pathname appropriately, and on other platforms, it just
 		 * wraps fopen().
@@ -378,7 +378,7 @@ pcap_open_offline_with_tstamp_precision(const char *fname, u_int precision,
 		 * support it, even though it does nothing.  For MS-DOS,
 		 * we again need it.
 		 */
-		fp = pcap_charset_fopen(fname, "rb");
+		fp = pcapint_charset_fopen(fname, "rb");
 		if (fp == NULL) {
 			pcap_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
 			    errno, "%s", fname);
@@ -558,7 +558,7 @@ found:
 	p->can_set_rfmon_op = sf_cant_set_rfmon;
 	p->read_op = pcap_offline_read;
 	p->inject_op = sf_inject;
-	p->setfilter_op = pcap_install_bpf_program;
+	p->setfilter_op = pcapint_install_bpf_program;
 	p->setdirection_op = sf_setdirection;
 	p->set_datalink_op = NULL;	/* we don't support munging link-layer headers */
 	p->getnonblock_op = sf_getnonblock;

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -412,7 +412,7 @@ pcap_check_header(const uint8_t *magic, FILE *fp, u_int precision, char *errbuf,
 		return (NULL);
 	}
 
-	p->cleanup_op = pcap_sf_cleanup;
+	p->cleanup_op = pcapint_sf_cleanup;
 
 	return (p);
 }
@@ -858,7 +858,7 @@ pcap_dump_open(pcap_t *p, const char *fname)
 		 * required on Windows, as the file is a binary file
 		 * and must be written in binary mode.
 		 */
-		f = pcap_charset_fopen(fname, "wb");
+		f = pcapint_charset_fopen(fname, "wb");
 		if (f == NULL) {
 			pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 			    errno, "%s", fname);
@@ -958,7 +958,7 @@ pcap_dump_open_append(pcap_t *p, const char *fname)
 	 * even though it does nothing.  It's required on Windows, as the
 	 * file is a binary file and must be read in binary mode.
 	 */
-	f = pcap_charset_fopen(fname, "ab+");
+	f = pcapint_charset_fopen(fname, "ab+");
 	if (f == NULL) {
 		pcap_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "%s", fname);

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -1090,7 +1090,7 @@ pcap_ng_cleanup(pcap_t *p)
 	struct pcap_ng_sf *ps = p->priv;
 
 	free(ps->ifaces);
-	pcap_sf_cleanup(p);
+	pcapint_sf_cleanup(p);
 }
 
 /*


### PR DESCRIPTION
Keep pcap_ prefix for external functions.

It is a follow-up to commit d14fb11d0dfc06ee5dac58146497aa5b0aa7c6fa.