### PR TITLE
pcap-bpf: fix handling of FreeBSD zero-copy BPF.

### DIFF
--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -75,16 +75,6 @@ static const char usbus_prefix[] = "usbus";
 #include <net/bpf.h>
 #define _AIX
 
-/*
- * If both BIOCROTZBUF and BPF_BUFMODE_ZBUF are defined, we have
- * zero-copy BPF.
- */
-#if defined(BIOCROTZBUF) && defined(BPF_BUFMODE_ZBUF)
-  #define HAVE_ZEROCOPY_BPF
-  #include <sys/mman.h>
-  #include <machine/atomic.h>
-#endif
-
 #include <net/if_types.h>		/* for IFT_ values */
 #include <sys/sysconfig.h>
 #include <sys/device.h>
@@ -125,6 +115,16 @@ static int bpf_load(char *errbuf);
 
 #ifdef SIOCGIFMEDIA
 # include <net/if_media.h>
+#endif
+
+/*
+ * If both BIOCROTZBUF and BPF_BUFMODE_ZBUF are defined, we have
+ * zero-copy BPF.
+ */
+#if defined(BIOCROTZBUF) && defined(BPF_BUFMODE_ZBUF)
+  #define HAVE_ZEROCOPY_BPF
+  #include <sys/mman.h>
+  #include <machine/atomic.h>
 #endif
 
 #include "pcap-int.h"
@@ -291,7 +291,7 @@ pcap_setnonblock_bpf(pcap_t *p, int nonblock)
  * buffer filled for a fresh BPF session.
  */
 static int
-pcap_next_zbuf_shm(pcap_t *p, int *cc)
+pcap_next_zbuf_shm(pcap_t *p, ssize_t *cc)
 {
 	struct pcap_bpf *pb = p->priv;
 	struct bpf_zbuf_header *bzh;
@@ -329,7 +329,7 @@ pcap_next_zbuf_shm(pcap_t *p, int *cc)
  * work.
  */
 static int
-pcap_next_zbuf(pcap_t *p, int *cc)
+pcap_next_zbuf(pcap_t *p, ssize_t *cc)
 {
 	struct pcap_bpf *pb = p->priv;
 	struct bpf_zbuf bz;
@@ -337,7 +337,7 @@ pcap_next_zbuf(pcap_t *p, int *cc)
 	struct timespec cur;
 	fd_set r_set;
 	int data, r;
-	int expire, tmout;
+	long expire, tmout;
 
 #define TSTOMILLI(ts) (((ts)->tv_sec * 1000) + ((ts)->tv_nsec / 1000000))
 	/*
@@ -2176,7 +2176,7 @@ pcap_activate_bpf(pcap_t *p)
 			status = PCAP_ERROR;
 			goto bad;
 		}
-		status = bpf_bind(fd, p->opt.device, ifnamsiz, p->errbuf);
+		status = bpf_bind(fd, p->opt.device, p->errbuf);
 		if (status != BPF_BIND_SUCCEEDED) {
 			if (status == BPF_BIND_BUFFER_TOO_BIG) {
 				/*


### PR DESCRIPTION
Pull the code to test for it and include the necessary header files *outside* the test for compiling on AIX; it's not an AIX feature, it's a FreeBSD feature.

Fix errors in the zero-copy code.