### PR TITLE
Fix resource leak caused by mismatch between pcap_create and pcap_close

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -346,6 +346,7 @@ pcapint_create_interface(const char *device, char *ebuf)
 
 	handle->activate_op = pcap_activate_linux;
 	handle->can_set_rfmon_op = pcap_can_set_rfmon_linux;
+	handle->cleanup_op = pcap_cleanup_linux;
 
 	/*
 	 * See what time stamp types we support.


### PR DESCRIPTION
See issue: #1233
This commit initializes the cleanup_op callback of handler in pcap_create.
This avoid the resource leak caused by the mismatch of resource allocation and deallocation.