### PR TITLE
Constify an argument.

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -3114,7 +3114,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 	}
 
 	/* checks if the connecting host is among the ones allowed */
-	if (sock_check_hostlist((char *)hostlist, RPCAP_HOSTLIST_SEP, &from, errbuf, PCAP_ERRBUF_SIZE) < 0)
+	if (sock_check_hostlist(hostlist, RPCAP_HOSTLIST_SEP, &from, errbuf, PCAP_ERRBUF_SIZE) < 0)
 	{
 		rpcap_senderror(sockctrl, ssl, 0, PCAP_ERR_REMOTEACCEPT, errbuf, NULL);
 #ifdef HAVE_OPENSSL

--- a/sockutils.c
+++ b/sockutils.c
@@ -1734,7 +1734,7 @@ int sock_discard(SOCKET sock, SSL *ssl, int size, char *errbuf, int errbuflen)
  * - '-1' in case the host does not belong to the host list (and therefore it is not allowed to connect
  * - '-2' in case or error. The error message is returned in the 'errbuf' variable.
  */
-int sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage *from, char *errbuf, int errbuflen)
+int sock_check_hostlist(const char *hostlist, const char *sep, struct sockaddr_storage *from, char *errbuf, int errbuflen)
 {
 	/* checks if the connecting host is among the ones allowed */
 	if ((hostlist) && (hostlist[0]))

--- a/sockutils.h
+++ b/sockutils.h
@@ -151,7 +151,7 @@ int sock_send(SOCKET sock, SSL *, const char *buffer, size_t size,
     char *errbuf, int errbuflen);
 int sock_bufferize(const void *data, int size, char *outbuf, int *offset, int totsize, int checkonly, char *errbuf, int errbuflen);
 int sock_discard(SOCKET sock, SSL *, int size, char *errbuf, int errbuflen);
-int	sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage *from, char *errbuf, int errbuflen);
+int	sock_check_hostlist(const char *hostlist, const char *sep, struct sockaddr_storage *from, char *errbuf, int errbuflen);
 int sock_cmpaddr(struct sockaddr_storage *first, struct sockaddr_storage *second);
 
 int sock_getmyinfo(SOCKET sock, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, int errbuflen);


### PR DESCRIPTION
THe hostlist argument to sock_check_hostlist() isn't modified, so make it const.  That eliminates the need for casting constness away in a call to it.