### PR TITLE
pcap-linux: squelch a warning.

### DIFF
--- a/diag-control.h
+++ b/diag-control.h
@@ -278,6 +278,24 @@
   #endif
 #endif
 
+#if PCAP_IS_AT_LEAST_CLANG_VERSION(2,8)
+  /*
+   * Clang appears to let you ignore a result without a warning by
+   * casting the function result to void, so we don't appear to
+   * need this for Clang.
+   */
+#elif PCAP_IS_AT_LEAST_GNUC_VERSION(4,5)
+  /*
+   * GCC warns about unused return values if a function is marked as
+   * "warn about ignoring this function's return value".
+   */
+  #define DIAG_OFF_WARN_UNUSED_RESULT \
+    PCAP_DO_PRAGMA(GCC diagnostic push) \
+    PCAP_DO_PRAGMA(GCC diagnostic ignored "-Wunused-result")
+  #define DIAG_ON_WARN_UNUSED_RESULT \
+    PCAP_DO_PRAGMA(GCC diagnostic pop)
+#endif
+
 /*
  * GCC needs this on AIX for longjmp().
  */
@@ -330,6 +348,12 @@
 #endif
 #ifndef DIAG_OFF_BISON_BYACC
 #define DIAG_OFF_BISON_BYACC
+#endif
+#ifndef DIAG_ON_WARN_UNUSED_RESULT
+#define DIAG_ON_WARN_UNUSED_RESULT
+#endif
+#ifndef DIAG_OFF_WARN_UNUSED_RESULT
+#define DIAG_OFF_WARN_UNUSED_RESULT
 #endif
 #ifndef PCAP_UNREACHABLE
 #define PCAP_UNREACHABLE

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -947,9 +947,16 @@ static void pcap_breakloop_linux(pcap_t *handle)
 	struct pcap_linux *handlep = handle->priv;
 
 	uint64_t value = 1;
-	/* XXX - what if this fails? */
-	if (handlep->poll_breakloop_fd != -1)
+
+	if (handlep->poll_breakloop_fd != -1) {
+		/*
+		 * XXX - pcap_breakloop() doesn't have a return value,
+		 * so we can't indicate an error.
+		 */
+DIAG_OFF_WARN_UNUSED_RESULT
 		(void)write(handlep->poll_breakloop_fd, &value, sizeof(value));
+DIAG_ON_WARN_UNUSED_RESULT
+	}
 }
 
 /*


### PR DESCRIPTION
Unfortunaely, pcap_breakloop() doesn't return a status, so we can't report an error.  Thus, we ignore the return value of write() on the event FD, and GCC doesn't accept casting that return value to void as a way of saying "I'm deliberately ignoring this return value, don't complain about it".

Suppress that warning with a pragma.