### PR TITLE
Don't define SOCKET ourselves.

### DIFF
--- a/pcap-rpcap-int.h
+++ b/pcap-rpcap-int.h
@@ -35,7 +35,7 @@
 #define __PCAP_RPCAP_INT_H__
 
 #include "pcap.h"
-#include "sockutils.h"	/* Needed for some structures (like SOCKET, sockaddr_in) which are used here */
+#include "sockutils.h"	/* Needed for some data types (such as PCAP_SOCKET, sockaddr_in) that are used here */
 
 /*
  * \file pcap-rpcap-int.h
@@ -70,6 +70,6 @@
  *                                                       *
  *********************************************************/
 void rpcap_createhdr(struct rpcap_header *header, uint8_t type, uint16_t value, uint32_t length);
-int rpcap_senderror(SOCKET sock, char *error, unsigned short errcode, char *errbuf);
+int rpcap_senderror(PCAP_SOCKET sock, char *error, unsigned short errcode, char *errbuf);
 
 #endif

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -93,7 +93,7 @@
 struct activehosts
 {
 	struct sockaddr_storage host;
-	SOCKET sockctrl;
+	PCAP_SOCKET sockctrl;
 	SSL *ssl;
 	uint8_t protocol_version;
 	int byte_swapped;
@@ -109,7 +109,7 @@ static struct activehosts *activeHosts;
  * See the documentation of pcap_remoteact_accept() and
  * pcap_remoteact_cleanup() for more details.
  */
-static SOCKET sockmain;
+static PCAP_SOCKET sockmain;
 static SSL *ssl_main;
 
 /*
@@ -123,8 +123,8 @@ struct pcap_rpcap {
 	 */
 	int rmt_clientside;
 
-	SOCKET rmt_sockctrl;		/* socket ID of the socket used for the control connection */
-	SOCKET rmt_sockdata;		/* socket ID of the socket used for the data connection */
+	PCAP_SOCKET rmt_sockctrl;	/* socket ID of the socket used for the control connection */
+	PCAP_SOCKET rmt_sockdata;	/* socket ID of the socket used for the data connection */
 	SSL *ctrl_ssl, *data_ssl;	/* optional transport of rmt_sockctrl and rmt_sockdata via TLS */
 	int rmt_flags;			/* we have to save flags, since they are passed by the pcap_open_live(), but they are used by the pcap_startcapture() */
 	int rmt_capstarted;		/* 'true' if the capture is already started (needed to know if we have to call the pcap_startcapture() */
@@ -172,13 +172,13 @@ static void pcap_save_current_filter_rpcap(pcap_t *fp, const char *filter);
 static int pcap_setfilter_rpcap(pcap_t *fp, struct bpf_program *prog);
 static int pcap_setsampling_remote(pcap_t *fp);
 static int pcap_startcapture_remote(pcap_t *fp);
-static int rpcap_recv_msg_header(SOCKET sock, SSL *, struct rpcap_header *header, char *errbuf);
-static int rpcap_check_msg_ver(SOCKET sock, SSL *, uint8_t expected_ver, struct rpcap_header *header, char *errbuf);
-static int rpcap_check_msg_type(SOCKET sock, SSL *, uint8_t request_type, struct rpcap_header *header, uint16_t *errcode, char *errbuf);
-static int rpcap_process_msg_header(SOCKET sock, SSL *, uint8_t ver, uint8_t request_type, struct rpcap_header *header, char *errbuf);
-static int rpcap_recv(SOCKET sock, SSL *, void *buffer, size_t toread, uint32_t *plen, char *errbuf);
-static void rpcap_msg_err(SOCKET sockctrl, SSL *, uint32_t plen, char *remote_errbuf);
-static int rpcap_discard(SOCKET sock, SSL *, uint32_t len, char *errbuf);
+static int rpcap_recv_msg_header(PCAP_SOCKET sock, SSL *, struct rpcap_header *header, char *errbuf);
+static int rpcap_check_msg_ver(PCAP_SOCKET sock, SSL *, uint8_t expected_ver, struct rpcap_header *header, char *errbuf);
+static int rpcap_check_msg_type(PCAP_SOCKET sock, SSL *, uint8_t request_type, struct rpcap_header *header, uint16_t *errcode, char *errbuf);
+static int rpcap_process_msg_header(PCAP_SOCKET sock, SSL *, uint8_t ver, uint8_t request_type, struct rpcap_header *header, char *errbuf);
+static int rpcap_recv(PCAP_SOCKET sock, SSL *, void *buffer, size_t toread, uint32_t *plen, char *errbuf);
+static void rpcap_msg_err(PCAP_SOCKET sockctrl, SSL *, uint32_t plen, char *remote_errbuf);
+static int rpcap_discard(PCAP_SOCKET sock, SSL *, uint32_t len, char *errbuf);
 static int rpcap_read_packet_msg(struct pcap_rpcap const *, pcap_t *p, size_t size);
 
 /****************************************************
@@ -1096,7 +1096,7 @@ static int pcap_startcapture_remote(pcap_t *fp)
 	/* socket-related variables*/
 	struct addrinfo hints;			/* temp, needed to open a socket connection */
 	struct addrinfo *addrinfo;		/* temp, needed to open a socket connection */
-	SOCKET sockdata = 0;			/* socket descriptor of the data connection */
+	PCAP_SOCKET sockdata = 0;		/* socket descriptor of the data connection */
 	struct sockaddr_storage saddr;		/* temp, needed to retrieve the network data port chosen on the local machine */
 	socklen_t saddrlen;			/* temp, needed to retrieve the network data port chosen on the local machine */
 	int ai_family;				/* temp, keeps the address family used by the control connection */
@@ -1326,7 +1326,7 @@ static int pcap_startcapture_remote(pcap_t *fp)
 		}
 		else
 		{
-			SOCKET socktemp;	/* We need another socket, since we're going to accept() a connection */
+			PCAP_SOCKET socktemp;	/* We need another socket, since we're going to accept() a connection */
 
 			/* Connection creation */
 			saddrlen = sizeof(struct sockaddr_storage);
@@ -1973,7 +1973,7 @@ static int pcap_setsampling_remote(pcap_t *fp)
  * \return '0' if everything is fine, '-1' for an error.  For errors,
  * an error message string is returned in the 'errbuf' variable.
  */
-static int rpcap_doauth(SOCKET sockctrl, SSL *ssl, uint8_t *ver,
+static int rpcap_doauth(PCAP_SOCKET sockctrl, SSL *ssl, uint8_t *ver,
     int *byte_swapped, struct pcap_rmtauth *auth, char *errbuf)
 {
 	char sendbuf[RPCAP_NETBUF_SIZE];	/* temporary buffer in which data that has to be sent is buffered */
@@ -2253,7 +2253,7 @@ static const char userinfo_allowed_symbols[] = "-._~!&'()*+,;=";
  * struct created from a username and password parsed out of the userinfo
  * portion of a URI.
  */
-static int rpcap_doauth_userinfo(SOCKET sockctrl, SSL *ssl, uint8_t *ver,
+static int rpcap_doauth_userinfo(PCAP_SOCKET sockctrl, SSL *ssl, uint8_t *ver,
     int *byte_swapped, const char *userinfo, char *errbuf)
 {
 	struct pcap_rmtauth auth;
@@ -2339,7 +2339,7 @@ pcap_setnonblock_rpcap(pcap_t *p, int nonblock _U_)
 
 static int
 rpcap_setup_session(const char *source, struct pcap_rmtauth *auth,
-    int *activep, SOCKET *sockctrlp, uint8_t *uses_sslp, SSL **sslp,
+    int *activep, PCAP_SOCKET *sockctrlp, uint8_t *uses_sslp, SSL **sslp,
     int rmt_flags, uint8_t *protocol_versionp, int *byte_swappedp,
     char *host, char *port, char *iface, char *errbuf)
 {
@@ -2535,7 +2535,7 @@ pcap_t *pcap_open_rpcap(const char *source, int snaplen, int flags, int read_tim
 	char *source_str;
 	struct pcap_rpcap *pr;		/* structure used when doing a remote live capture */
 	char host[PCAP_BUF_SIZE], ctrlport[PCAP_BUF_SIZE], iface[PCAP_BUF_SIZE];
-	SOCKET sockctrl;
+	PCAP_SOCKET sockctrl;
 	SSL *ssl = NULL;
 	uint8_t protocol_version;		/* negotiated protocol version */
 	int byte_swapped;			/* server is known to be byte-swapped */
@@ -2707,7 +2707,7 @@ pcap_findalldevs_ex_remote(const char *source, struct pcap_rmtauth *auth, pcap_i
 {
 	uint8_t protocol_version;	/* protocol version */
 	int byte_swapped;		/* Server byte order is swapped from ours */
-	SOCKET sockctrl;		/* socket descriptor of the control connection */
+	PCAP_SOCKET sockctrl;		/* socket descriptor of the control connection */
 	SSL *ssl = NULL;		/* optional SSL handler for sockctrl */
 	uint32_t plen;
 	struct rpcap_header header;	/* structure that keeps the general header of the rpcap protocol */
@@ -3011,14 +3011,14 @@ error_nodiscard:
  * to implement; we provide some APIs for it that work only with rpcap.
  */
 
-SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const char *hostlist, char *connectinghost, struct pcap_rmtauth *auth, int uses_ssl, char *errbuf)
+PCAP_SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const char *hostlist, char *connectinghost, struct pcap_rmtauth *auth, int uses_ssl, char *errbuf)
 {
 	/* socket-related variables */
 	struct addrinfo hints;			/* temporary struct to keep settings needed to open the new socket */
 	struct addrinfo *addrinfo;		/* keeps the addrinfo chain; required to open a new socket */
 	struct sockaddr_storage from;	/* generic sockaddr_storage variable */
 	socklen_t fromlen;				/* keeps the length of the sockaddr_storage variable */
-	SOCKET sockctrl;				/* keeps the main socket identifier */
+	PCAP_SOCKET sockctrl;			/* keeps the main socket identifier */
 	SSL *ssl = NULL;				/* Optional SSL handler for sockctrl */
 	uint8_t protocol_version;		/* negotiated protocol version */
 	int byte_swapped;			/* 1 if server byte order is known to be the reverse of ours */
@@ -3036,7 +3036,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 	/* Warning: this call can be the first one called by the user. */
 	/* For this reason, we have to initialize the Winsock support. */
 	if (sock_init(errbuf, PCAP_ERRBUF_SIZE) == -1)
-		return (SOCKET)-1;
+		return (PCAP_SOCKET)-1;
 
 	/* Do the work */
 	if ((port == NULL) || (port[0] == 0))
@@ -3052,13 +3052,13 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 	}
 	if (addrinfo == NULL)
 	{
-		return (SOCKET)-2;
+		return (PCAP_SOCKET)-2;
 	}
 
 	if ((sockmain = sock_open(NULL, addrinfo, SOCKOPEN_SERVER, 1, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
 	{
 		freeaddrinfo(addrinfo);
-		return (SOCKET)-2;
+		return (PCAP_SOCKET)-2;
 	}
 	freeaddrinfo(addrinfo);
 
@@ -3075,7 +3075,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 	if (sockctrl == INVALID_SOCKET)
 	{
 		sock_geterrmsg(errbuf, PCAP_ERRBUF_SIZE, "accept() failed");
-		return (SOCKET)-2;
+		return (PCAP_SOCKET)-2;
 	}
 
 	/* Promote to SSL early before any error message may be sent */
@@ -3086,12 +3086,12 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 		if (! ssl)
 		{
 			sock_close(sockctrl, NULL, 0);
-			return (SOCKET)-1;
+			return (PCAP_SOCKET)-1;
 		}
 #else
 		snprintf(errbuf, PCAP_ERRBUF_SIZE, "No TLS support");
 		sock_close(sockctrl, NULL, 0);
-		return (SOCKET)-1;
+		return (PCAP_SOCKET)-1;
 #endif
 	}
 
@@ -3110,7 +3110,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 		}
 #endif
 		sock_close(sockctrl, NULL, 0);
-		return (SOCKET)-1;
+		return (PCAP_SOCKET)-1;
 	}
 
 	/* checks if the connecting host is among the ones allowed */
@@ -3126,7 +3126,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 		}
 #endif
 		sock_close(sockctrl, NULL, 0);
-		return (SOCKET)-1;
+		return (PCAP_SOCKET)-1;
 	}
 
 	/*
@@ -3146,7 +3146,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 		}
 #endif
 		sock_close(sockctrl, NULL, 0);
-		return (SOCKET)-3;
+		return (PCAP_SOCKET)-3;
 	}
 
 	/* Checks that this host does not already have a cntrl connection in place */
@@ -3191,7 +3191,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 		}
 #endif
 		sock_close(sockctrl, NULL, 0);
-		return (SOCKET)-1;
+		return (PCAP_SOCKET)-1;
 	}
 
 	memcpy(&temp->host, &from, fromlen);
@@ -3204,7 +3204,7 @@ SOCKET pcap_remoteact_accept_ex(const char *address, const char *port, const cha
 	return sockctrl;
 }
 
-SOCKET pcap_remoteact_accept(const char *address, const char *port, const char *hostlist, char *connectinghost, struct pcap_rmtauth *auth, char *errbuf)
+PCAP_SOCKET pcap_remoteact_accept(const char *address, const char *port, const char *hostlist, char *connectinghost, struct pcap_rmtauth *auth, char *errbuf)
 {
 	return pcap_remoteact_accept_ex(address, port, hostlist, connectinghost, auth, 0, errbuf);
 }
@@ -3393,7 +3393,7 @@ int pcap_remoteact_list(char *hostlist, char sep, int size, char *errbuf)
 /*
  * Receive the header of a message.
  */
-static int rpcap_recv_msg_header(SOCKET sock, SSL *ssl, struct rpcap_header *header, char *errbuf)
+static int rpcap_recv_msg_header(PCAP_SOCKET sock, SSL *ssl, struct rpcap_header *header, char *errbuf)
 {
 	int nrecv;
 
@@ -3413,7 +3413,7 @@ static int rpcap_recv_msg_header(SOCKET sock, SSL *ssl, struct rpcap_header *hea
  * Make sure the protocol version of a received message is what we were
  * expecting.
  */
-static int rpcap_check_msg_ver(SOCKET sock, SSL *ssl, uint8_t expected_ver, struct rpcap_header *header, char *errbuf)
+static int rpcap_check_msg_ver(PCAP_SOCKET sock, SSL *ssl, uint8_t expected_ver, struct rpcap_header *header, char *errbuf)
 {
 	/*
 	 * Did the server specify the version we negotiated?
@@ -3444,7 +3444,7 @@ static int rpcap_check_msg_ver(SOCKET sock, SSL *ssl, uint8_t expected_ver, stru
  * Check the message type of a received message, which should either be
  * the expected message type or RPCAP_MSG_ERROR.
  */
-static int rpcap_check_msg_type(SOCKET sock, SSL *ssl, uint8_t request_type, struct rpcap_header *header, uint16_t *errcode, char *errbuf)
+static int rpcap_check_msg_type(PCAP_SOCKET sock, SSL *ssl, uint8_t request_type, struct rpcap_header *header, uint16_t *errcode, char *errbuf)
 {
 	const char *request_type_string;
 	const char *msg_type_string;
@@ -3514,7 +3514,7 @@ static int rpcap_check_msg_type(SOCKET sock, SSL *ssl, uint8_t request_type, str
 /*
  * Receive and process the header of a message.
  */
-static int rpcap_process_msg_header(SOCKET sock, SSL *ssl, uint8_t expected_ver, uint8_t request_type, struct rpcap_header *header, char *errbuf)
+static int rpcap_process_msg_header(PCAP_SOCKET sock, SSL *ssl, uint8_t expected_ver, uint8_t request_type, struct rpcap_header *header, char *errbuf)
 {
 	uint16_t errcode;
 
@@ -3546,7 +3546,7 @@ static int rpcap_process_msg_header(SOCKET sock, SSL *ssl, uint8_t expected_ver,
  * Returns 0 on success, logs a message and returns -1 on a network
  * error.
  */
-static int rpcap_recv(SOCKET sock, SSL *ssl, void *buffer, size_t toread, uint32_t *plen, char *errbuf)
+static int rpcap_recv(PCAP_SOCKET sock, SSL *ssl, void *buffer, size_t toread, uint32_t *plen, char *errbuf)
 {
 	int nread;
 
@@ -3569,7 +3569,7 @@ static int rpcap_recv(SOCKET sock, SSL *ssl, void *buffer, size_t toread, uint32
 /*
  * This handles the RPCAP_MSG_ERROR message.
  */
-static void rpcap_msg_err(SOCKET sockctrl, SSL *ssl, uint32_t plen, char *remote_errbuf)
+static void rpcap_msg_err(PCAP_SOCKET sockctrl, SSL *ssl, uint32_t plen, char *remote_errbuf)
 {
 	char errbuf[PCAP_ERRBUF_SIZE];
 
@@ -3640,7 +3640,7 @@ static void rpcap_msg_err(SOCKET sockctrl, SSL *ssl, uint32_t plen, char *remote
  * Returns 0 on success, logs a message and returns -1 on a network
  * error.
  */
-static int rpcap_discard(SOCKET sock, SSL *ssl, uint32_t len, char *errbuf)
+static int rpcap_discard(PCAP_SOCKET sock, SSL *ssl, uint32_t len, char *errbuf)
 {
 	if (len != 0)
 	{

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -127,7 +127,7 @@
   #include <sys/time.h>
 #endif /* _WIN32/MSDOS/UN*X */
 
-#include <pcap/socket.h>	/* for SOCKET, as the active-mode rpcap APIs use it */
+#include <pcap/socket.h>	/* for PCAP_SOCKET, as the active-mode rpcap APIs use it */
 
 #ifndef PCAP_DONT_INCLUDE_PCAP_BPF_H
 #include <pcap/bpf.h>
@@ -1250,14 +1250,14 @@ PCAP_API struct pcap_samp *pcap_setsampling(pcap_t *p);
 #define RPCAP_HOSTLIST_SIZE 1024
 
 PCAP_AVAILABLE_1_9_REMOTE
-PCAP_API SOCKET	pcap_remoteact_accept(const char *address, const char *port,
-	    const char *hostlist, char *connectinghost,
+PCAP_API PCAP_SOCKET	pcap_remoteact_accept(const char *address,
+	    const char *port, const char *hostlist, char *connectinghost,
 	    struct pcap_rmtauth *auth, char *errbuf)
 	    PCAP_NONNULL(6);
 
 PCAP_AVAILABLE_1_10_REMOTE
-PCAP_API SOCKET	pcap_remoteact_accept_ex(const char *address, const char *port,
-	    const char *hostlist, char *connectinghost,
+PCAP_API PCAP_SOCKET	pcap_remoteact_accept_ex(const char *address,
+	    const char *port, const char *hostlist, char *connectinghost,
 	    struct pcap_rmtauth *auth, int uses_ssl, char *errbuf)
 	    PCAP_NONNULL(7);
 

--- a/pcap/socket.h
+++ b/pcap/socket.h
@@ -48,6 +48,26 @@
   #include <winsock2.h>
   #include <ws2tcpip.h>
 
+  /*!
+   * \brief In Winsock, a socket handle is of type SOCKET; in UN*X, it's
+   * a file descriptor, and therefore a signed integer.
+   * We define PCAP_SOCKET to be a signed integer on UN*X and a
+   * SOCKET on Windows, so that it can be used on both platforms.
+   *
+   * We used to use SOCKET rather than PCAP_SOCKET, but that collided
+   * with other software, such as barnyard2, which had their own
+   * definitions of SOCKET, so we changed it to PCAP_SOCKET.
+   *
+   * On Windows, this shouldn't break any APIs, as any code using
+   * the two active-mode APIs that return a socket handle would
+   * probably be assigning their return values to a SOCKET, and
+   * as, on Windows, we're defining PCAP_SOCKET as SOCKET, there
+   * would be no type clash.
+   */
+  #ifndef PCAP_SOCKET
+    #define PCAP_SOCKET SOCKET
+  #endif
+
   /*
    * Winsock doesn't have this POSIX type; it's used for the
    * tv_usec value of struct timeval.
@@ -61,13 +81,37 @@
   #include <arpa/inet.h>
 
   /*!
-   * \brief In Winsock, a socket handle is of type SOCKET; in UN*X, it's
-   * a file descriptor, and therefore a signed integer.
-   * We define SOCKET to be a signed integer on UN*X, so that it can
-   * be used on both platforms.
+   * \brief In Winsock, a socket handle is of type SOCKET; in UN*Xes,
+   * it's a file descriptor, and therefore a signed integer.
+   * We define PCAP_SOCKET to be a signed integer on UN*X and a
+   * SOCKET on Windows, so that it can be used on both platforms.
+   *
+   * We used to use SOCKET rather than PCAP_SOCKET, but that collided
+   * with other software, such as barnyard2, which had their own
+   * definitions of SOCKET, so we changed it to PCAP_SOCKET.
+   *
+   * On UN*Xes, this might break code that uses one of the two
+   * active-mode APIs that return a socket handle if those programs
+   * were written to assign the return values of those APIs to a
+   * SOCKET, as we're no longer defining SOCKET.  However, as
+   * those APIs are only provided if libpcap is built with remote
+   * capture support - which is not the default - and as they're
+   * somewhat painful to use, there's probably little if any code
+   * that needs to compile for UN*X and that uses them.  If there
+   * *is* any such code, it could do
+   *
+   *    #ifndef PCAP_SOCKET
+   *        #ifdef _WIN32
+   *            #define PCAP_SOCKET SOCKET
+   *        #else
+   *            #defube PCAP_SOCKET int
+   *        #endif
+   *    #endif
+   *
+   * and use PCAP_SOCKET.
    */
-  #ifndef SOCKET
-    #define SOCKET int
+  #ifndef PCAP_SOCKET
+    #define PCAP_SOCKET int
   #endif
 
   /*!

--- a/rpcap-protocol.c
+++ b/rpcap-protocol.c
@@ -81,7 +81,7 @@
  * error message is returned in the 'errbuf' variable.
  */
 int
-rpcap_senderror(SOCKET sock, SSL *ssl, uint8_t ver, unsigned short errcode, const char *error, char *errbuf)
+rpcap_senderror(PCAP_SOCKET sock, SSL *ssl, uint8_t ver, unsigned short errcode, const char *error, char *errbuf)
 {
 	char sendbuf[RPCAP_NETBUF_SIZE];	/* temporary buffer in which data to be sent is buffered */
 	int sendbufidx = 0;			/* index which keeps the number of bytes currently buffered */

--- a/rpcap-protocol.h
+++ b/rpcap-protocol.h
@@ -439,6 +439,6 @@ struct rpcap_sampling
 
 extern void rpcap_createhdr(struct rpcap_header *header, uint8_t ver, uint8_t type, uint16_t value, uint32_t length);
 extern const char *rpcap_msg_type_string(uint8_t type);
-extern int rpcap_senderror(SOCKET sock, SSL *ssl, uint8_t ver, uint16_t errcode, const char *error, char *errbuf);
+extern int rpcap_senderror(PCAP_SOCKET sock, SSL *ssl, uint8_t ver, uint16_t errcode, const char *error, char *errbuf);
 
 #endif

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -95,7 +95,7 @@
 // Parameters for the service loop.
 struct daemon_slpars
 {
-	SOCKET sockctrl;	//!< SOCKET ID of the control connection
+	PCAP_SOCKET sockctrl;	//!< PCAP_SOCKET ID of the control connection
 	SSL *ssl;		//!< Optional SSL handler for the controlling sockets
 	int isactive;		//!< Not null if the daemon has to run in active mode
 	int nullAuthAllowed;	//!< '1' if we permit NULL authentication, '0' otherwise
@@ -110,8 +110,8 @@ struct daemon_slpars
 // value for a pthread_t on UN*X.
 //
 struct session {
-	SOCKET sockctrl;
-	SOCKET sockdata;
+	PCAP_SOCKET sockctrl;
+	PCAP_SOCKET sockdata;
 	SSL *ctrl_ssl, *data_ssl; // optional SSL handlers for sockctrl and sockdata.
 	uint8_t protocol_version;
 	pcap_t *fp;
@@ -125,7 +125,7 @@ struct session {
 };
 
 // Locally defined functions
-static int daemon_msg_err(SOCKET sockctrl, SSL *, uint32_t plen);
+static int daemon_msg_err(PCAP_SOCKET sockctrl, SSL *, uint32_t plen);
 static int daemon_msg_auth_req(struct daemon_slpars *pars, uint32_t plen);
 static int daemon_AuthUserPwd(char *username, char *password, char *errbuf);
 
@@ -142,7 +142,7 @@ static int daemon_msg_endcap_req(uint8_t ver, struct daemon_slpars *pars,
 
 static int daemon_msg_updatefilter_req(uint8_t ver, struct daemon_slpars *pars,
     struct session *session, uint32_t plen);
-static int daemon_unpackapplyfilter(SOCKET sockctrl, SSL *, struct session *session, uint32_t *plenp, char *errbuf);
+static int daemon_unpackapplyfilter(PCAP_SOCKET sockctrl, SSL *, struct session *session, uint32_t *plenp, char *errbuf);
 
 static int daemon_msg_stats_req(uint8_t ver, struct daemon_slpars *pars,
     struct session *session, uint32_t plen, struct pcap_stat *stats,
@@ -159,9 +159,9 @@ static void *daemon_thrdatamain(void *ptr);
 static void noop_handler(int sign);
 #endif
 
-static int rpcapd_recv_msg_header(SOCKET sock, SSL *, struct rpcap_header *headerp);
-static int rpcapd_recv(SOCKET sock, SSL *, char *buffer, size_t toread, uint32_t *plen, char *errmsgbuf);
-static int rpcapd_discard(SOCKET sock, SSL *, uint32_t len);
+static int rpcapd_recv_msg_header(PCAP_SOCKET sock, SSL *, struct rpcap_header *headerp);
+static int rpcapd_recv(PCAP_SOCKET sock, SSL *, char *buffer, size_t toread, uint32_t *plen, char *errmsgbuf);
+static int rpcapd_discard(PCAP_SOCKET sock, SSL *, uint32_t len);
 static void session_close(struct session *);
 
 //
@@ -211,7 +211,7 @@ static int is_url(const char *source);
 #endif
 
 int
-daemon_serviceloop(SOCKET sockctrl, int isactive, char *passiveClients,
+daemon_serviceloop(PCAP_SOCKET sockctrl, int isactive, char *passiveClients,
     int nullAuthAllowed, char *data_port, int uses_ssl)
 {
 	uint8_t first_octet;
@@ -1138,7 +1138,7 @@ end:
  * This handles the RPCAP_MSG_ERR message.
  */
 static int
-daemon_msg_err(SOCKET sockctrl, SSL *ssl, uint32_t plen)
+daemon_msg_err(PCAP_SOCKET sockctrl, SSL *ssl, uint32_t plen)
 {
 	char errbuf[PCAP_ERRBUF_SIZE];
 	char remote_errbuf[PCAP_ERRBUF_SIZE];
@@ -2188,7 +2188,7 @@ daemon_msg_startcap_req(uint8_t ver, struct daemon_slpars *pars, uint32_t plen,
 
 	if (!serveropen_dp)
 	{
-		SOCKET socktemp;	// We need another socket, since we're going to accept() a connection
+		PCAP_SOCKET socktemp;	// We need another socket, since we're going to accept() a connection
 
 		// Connection creation
 		saddrlen = sizeof(struct sockaddr_storage);
@@ -2342,7 +2342,7 @@ daemon_msg_endcap_req(uint8_t ver, struct daemon_slpars *pars,
 #define RPCAP_BPF_MAXINSNS	8192
 
 static int
-daemon_unpackapplyfilter(SOCKET sockctrl, SSL *ctrl_ssl, struct session *session, uint32_t *plenp, char *errmsgbuf)
+daemon_unpackapplyfilter(PCAP_SOCKET sockctrl, SSL *ctrl_ssl, struct session *session, uint32_t *plenp, char *errmsgbuf)
 {
 	int status;
 	struct rpcap_filter filter;
@@ -2921,7 +2921,7 @@ void sleep_secs(int secs)
  * Read the header of a message.
  */
 static int
-rpcapd_recv_msg_header(SOCKET sock, SSL *ssl, struct rpcap_header *headerp)
+rpcapd_recv_msg_header(PCAP_SOCKET sock, SSL *ssl, struct rpcap_header *headerp)
 {
 	int nread;
 	char errbuf[PCAP_ERRBUF_SIZE];		// buffer for network errors
@@ -2953,7 +2953,7 @@ rpcapd_recv_msg_header(SOCKET sock, SSL *ssl, struct rpcap_header *headerp)
  * error.
  */
 static int
-rpcapd_recv(SOCKET sock, SSL *ssl, char *buffer, size_t toread, uint32_t *plen, char *errmsgbuf)
+rpcapd_recv(PCAP_SOCKET sock, SSL *ssl, char *buffer, size_t toread, uint32_t *plen, char *errmsgbuf)
 {
 	int nread;
 	char errbuf[PCAP_ERRBUF_SIZE];		// buffer for network errors
@@ -2982,7 +2982,7 @@ rpcapd_recv(SOCKET sock, SSL *ssl, char *buffer, size_t toread, uint32_t *plen, 
  * error.
  */
 static int
-rpcapd_discard(SOCKET sock, SSL *ssl, uint32_t len)
+rpcapd_discard(PCAP_SOCKET sock, SSL *ssl, uint32_t len)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
 

--- a/rpcapd/daemon.h
+++ b/rpcapd/daemon.h
@@ -44,7 +44,7 @@
 // otherwise; the return value is used only by callers that call us
 // for active mode.
 //
-int daemon_serviceloop(SOCKET sockctrl, int isactive, char *passiveClients,
+int daemon_serviceloop(PCAP_SOCKET sockctrl, int isactive, char *passiveClients,
     int nullAuthAllowed, char *data_port, int uses_ssl);
 
 void sleep_secs(int secs);

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -74,7 +74,7 @@
 //
 struct listen_sock {
 	struct listen_sock *next;
-	SOCKET sock;
+	PCAP_SOCKET sock;
 };
 
 // Global variables
@@ -107,7 +107,7 @@ static void main_terminate(int sign);
 static void main_reread_config(int sign);
 #endif
 static void accept_connections(void);
-static void accept_connection(SOCKET listen_sock);
+static void accept_connection(PCAP_SOCKET listen_sock);
 #ifndef _WIN32
 static void main_reap_children(int sign);
 #endif
@@ -629,7 +629,7 @@ void main_startup(void)
 		for (tempaddrinfo = addrinfo; tempaddrinfo;
 		     tempaddrinfo = tempaddrinfo->ai_next)
 		{
-			SOCKET sock;
+			PCAP_SOCKET sock;
 			struct listen_sock *sock_info;
 
 			if ((sock = sock_open(NULL, tempaddrinfo, SOCKOPEN_SERVER, SOCKET_MAXCONN, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
@@ -1130,7 +1130,7 @@ accept_connections(void)
 // fork "inherits" the parent stack.)
 //
 struct params_copy {
-	SOCKET sockctrl;
+	PCAP_SOCKET sockctrl;
 	char *hostlist;
 };
 #endif
@@ -1140,10 +1140,10 @@ struct params_copy {
 // worker process, on UN*X, to handle the connection.
 //
 static void
-accept_connection(SOCKET listen_sock)
+accept_connection(PCAP_SOCKET listen_sock)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
-	SOCKET sockctrl;			// keeps the socket ID for this control connection
+	PCAP_SOCKET sockctrl;			// keeps the socket ID for this control connection
 	struct sockaddr_storage from;		// generic sockaddr_storage variable
 	socklen_t fromlen;			// keeps the length of the sockaddr_storage variable
 
@@ -1337,7 +1337,7 @@ static void *
 main_active(void *ptr)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
-	SOCKET sockctrl;			// keeps the socket ID for this control connection
+	PCAP_SOCKET sockctrl;			// keeps the socket ID for this control connection
 	struct addrinfo hints;			// temporary struct to keep settings needed to open the new socket
 	struct addrinfo *addrinfo;		// keeps the addrinfo chain; required to open a new socket
 	struct active_pars *activepars;

--- a/sockutils.c
+++ b/sockutils.c
@@ -432,10 +432,10 @@ static int compare_addrs_to_try_by_status(const void *a, const void *b)
 	return addr_a->errtype - addr_b->errtype;
 }
 
-static SOCKET sock_create_socket(struct addrinfo *addrinfo, char *errbuf,
+static PCAP_SOCKET sock_create_socket(struct addrinfo *addrinfo, char *errbuf,
     int errbuflen)
 {
-	SOCKET sock;
+	PCAP_SOCKET sock;
 #ifdef SO_NOSIGPIPE
 	int on = 1;
 #endif
@@ -501,9 +501,10 @@ static SOCKET sock_create_socket(struct addrinfo *addrinfo, char *errbuf,
  * if everything is fine, INVALID_SOCKET if some errors occurred. The error message is returned
  * in the 'errbuf' variable.
  */
-SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server, int nconn, char *errbuf, int errbuflen)
+PCAP_SOCKET sock_open(const char *host, struct addrinfo *addrinfo,
+    int server, int nconn, char *errbuf, int errbuflen)
 {
-	SOCKET sock;
+	PCAP_SOCKET sock;
 
 	/* This is a server socket */
 	if (server)
@@ -872,7 +873,7 @@ SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server, int nc
  * \return '0' if everything is fine, '-1' if some errors occurred. The error message is returned
  * in the 'errbuf' variable.
  */
-int sock_close(SOCKET sock, char *errbuf, int errbuflen)
+int sock_close(PCAP_SOCKET sock, char *errbuf, int errbuflen)
 {
 	/*
 	 * SHUT_WR: subsequent calls to the send function are disallowed.
@@ -1212,8 +1213,8 @@ struct addrinfo *sock_initaddress(const char *host, const char *port,
  * '-2' if we got one of those errors.
  * For errors, an error message is returned in the 'errbuf' variable.
  */
-int sock_send(SOCKET sock, SSL *ssl _U_NOSSL_, const char *buffer, size_t size,
-    char *errbuf, int errbuflen)
+int sock_send(PCAP_SOCKET sock, SSL *ssl _U_NOSSL_, const char *buffer,
+    size_t size, char *errbuf, int errbuflen)
 {
 	int remaining;
 	ssize_t nsent;
@@ -1416,7 +1417,7 @@ int sock_bufferize(const void *data, int size, char *outbuf, int *offset, int to
  * The error message is returned in the 'errbuf' variable.
  */
 
-int sock_recv(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
+int sock_recv(PCAP_SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
     int flags, char *errbuf, int errbuflen)
 {
 	int recv_flags = 0;
@@ -1523,8 +1524,8 @@ int sock_recv(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
  *
  * Returns the size of the datagram on success or -1 on error.
  */
-int sock_recv_dgram(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
-    char *errbuf, int errbuflen)
+int sock_recv_dgram(PCAP_SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer,
+    size_t size, char *errbuf, int errbuflen)
 {
 	ssize_t nread;
 #ifndef _WIN32
@@ -1671,7 +1672,8 @@ int sock_recv_dgram(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
  * \return '0' if everything is fine, '-1' if some errors occurred.
  * The error message is returned in the 'errbuf' variable.
  */
-int sock_discard(SOCKET sock, SSL *ssl, int size, char *errbuf, int errbuflen)
+int sock_discard(PCAP_SOCKET sock, SSL *ssl, int size, char *errbuf,
+    int errbuflen)
 {
 #define TEMP_BUF_SIZE 32768
 
@@ -1929,7 +1931,8 @@ int sock_cmpaddr(struct sockaddr_storage *first, struct sockaddr_storage *second
  * \warning If the socket is using a connectionless protocol, the address may not be available
  * until I/O occurs on the socket.
  */
-int sock_getmyinfo(SOCKET sock, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, int errbuflen)
+int sock_getmyinfo(PCAP_SOCKET sock, char *address, int addrlen, char *port,
+    int portlen, int flags, char *errbuf, int errbuflen)
 {
 	struct sockaddr_storage mysockaddr;
 	socklen_t sockaddrlen;

--- a/sockutils.h
+++ b/sockutils.h
@@ -140,21 +140,24 @@ void sock_geterrmsg(char *errbuf, size_t errbuflen,
     PCAP_FORMAT_STRING(const char *fmt), ...)  PCAP_PRINTFLIKE(3, 4);
 struct addrinfo *sock_initaddress(const char *address, const char *port,
     struct addrinfo *hints, char *errbuf, int errbuflen);
-int sock_recv(SOCKET sock, SSL *, void *buffer, size_t size, int receiveall,
+int sock_recv(PCAP_SOCKET sock, SSL *, void *buffer, size_t size,
+    int receiveall, char *errbuf, int errbuflen);
+int sock_recv_dgram(PCAP_SOCKET sock, SSL *, void *buffer, size_t size,
     char *errbuf, int errbuflen);
-int sock_recv_dgram(SOCKET sock, SSL *, void *buffer, size_t size,
-    char *errbuf, int errbuflen);
-SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server, int nconn, char *errbuf, int errbuflen);
-int sock_close(SOCKET sock, char *errbuf, int errbuflen);
+PCAP_SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server,
+    int nconn, char *errbuf, int errbuflen);
+int sock_close(PCAP_SOCKET sock, char *errbuf, int errbuflen);
 
-int sock_send(SOCKET sock, SSL *, const char *buffer, size_t size,
+int sock_send(PCAP_SOCKET sock, SSL *, const char *buffer, size_t size,
     char *errbuf, int errbuflen);
 int sock_bufferize(const void *data, int size, char *outbuf, int *offset, int totsize, int checkonly, char *errbuf, int errbuflen);
-int sock_discard(SOCKET sock, SSL *, int size, char *errbuf, int errbuflen);
+int sock_discard(PCAP_SOCKET sock, SSL *, int size, char *errbuf,
+    int errbuflen);
 int	sock_check_hostlist(const char *hostlist, const char *sep, struct sockaddr_storage *from, char *errbuf, int errbuflen);
 int sock_cmpaddr(struct sockaddr_storage *first, struct sockaddr_storage *second);
 
-int sock_getmyinfo(SOCKET sock, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, int errbuflen);
+int sock_getmyinfo(PCAP_SOCKET sock, char *address, int addrlen, char *port,
+    int portlen, int flags, char *errbuf, int errbuflen);
 
 int sock_getascii_addrport(const struct sockaddr_storage *sockaddr, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, size_t errbuflen);
 int sock_present2network(const char *address, struct sockaddr_storage *sockaddr, int addr_family, char *errbuf, int errbuflen);

--- a/sslutils.c
+++ b/sslutils.c
@@ -133,7 +133,7 @@ die:
 	return -1;
 }
 
-SSL *ssl_promotion(int is_server, SOCKET s, char *errbuf, size_t errbuflen)
+SSL *ssl_promotion(int is_server, PCAP_SOCKET s, char *errbuf, size_t errbuflen)
 {
 	if (ssl_init_once(is_server, 1, errbuf, errbuflen) < 0) {
 		return NULL;

--- a/sslutils.h
+++ b/sslutils.h
@@ -34,7 +34,7 @@
 #define __SSLUTILS_H__
 
 #ifdef HAVE_OPENSSL
-#include "pcap/socket.h"  // for SOCKET
+#include "pcap/socket.h"  // for PCAP_SOCKET
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
@@ -45,7 +45,7 @@
 void ssl_set_certfile(const char *certfile);
 void ssl_set_keyfile(const char *keyfile);
 int ssl_init_once(int is_server, int enable_compression, char *errbuf, size_t errbuflen);
-SSL *ssl_promotion(int is_server, SOCKET s, char *errbuf, size_t errbuflen);
+SSL *ssl_promotion(int is_server, PCAP_SOCKET s, char *errbuf, size_t errbuflen);
 void ssl_finish(SSL *ssl);
 int ssl_send(SSL *, char const *buffer, int size, char *errbuf, size_t errbuflen);
 int ssl_recv(SSL *, char *buffer, int size, char *errbuf, size_t errbuflen);


### PR DESCRIPTION
Doing so can cause namespace collisions, as per, for example, https://github.com/firnsy/barnyard2/issues/245.

Instead, define PCAP_SOCKET, and use that.

On Windows, this shouldn't break any APIs, as any code using the two active-mode APIs that return a socket handle would probably be assigning their return values to a SOCKET, and as, on Windows, we're defining PCAP_SOCKET as SOCKET, there would be no type clash.

On UN\*Xes, this might break code that uses one of the two active-mode APIs that return a socket handle if those programs were written to assign the return values of those APIs to a SOCKET, as we're no longer defining SOCKET.  However, as those APIs are only provided if libpcap is built with remote capture support - which is not the default - and as they're somewhat painful to use, there's probably little if any code that needs to compile for UN*X and that uses them.  If there *is* any such code, it could do

    #ifndef PCAP_SOCKET
        #ifdef _WIN32
            #define PCAP_SOCKET SOCKET
        #else
            #defube PCAP_SOCKET int
        #endif
    #endif

and use PCAP_SOCKET.