### PR TITLE
Don't define SOCKET ourselves.

### DIFF
--- a/pcap-rpcap-int.h
+++ b/pcap-rpcap-int.h
@@ -35,7 +35,7 @@
 #define __PCAP_RPCAP_INT_H__
 
 #include "pcap.h"
-#include "sockutils.h"	/* Needed for some structures (like SOCKET, sockaddr_in) which are used here */
+#include "sockutils.h"	/* Needed for some data types (such as PCAP_SOCKET, sockaddr_in) that are used here */
 
 /*
  * \file pcap-rpcap-int.h
@@ -70,6 +70,6 @@
  *                                                       *
  *********************************************************/
 void rpcap_createhdr(struct rpcap_header *header, uint8 type, uint16 value, uint32 length);
-int rpcap_senderror(SOCKET sock, char *error, unsigned short errcode, char *errbuf);
+int rpcap_senderror(PCAP_SOCKET sock, char *error, unsigned short errcode, char *errbuf);
 
 #endif

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -127,7 +127,7 @@
   #include <sys/time.h>
 #endif /* _WIN32/MSDOS/UN*X */
 
-#include <pcap/socket.h>	/* for SOCKET, as the active-mode rpcap APIs use it */
+#include <pcap/socket.h>	/* for PCAP_SOCKET, as the active-mode rpcap APIs use it */
 
 #ifndef PCAP_DONT_INCLUDE_PCAP_BPF_H
 #include <pcap/bpf.h>
@@ -1195,12 +1195,12 @@ PCAP_API struct pcap_samp *pcap_setsampling(pcap_t *p);
 #define RPCAP_HOSTLIST_SIZE 1024
 
 PCAP_AVAILABLE_1_9_REMOTE
-PCAP_API SOCKET	pcap_remoteact_accept(const char *address, const char *port,
+PCAP_API PCAP_SOCKET	pcap_remoteact_accept(const char *address, const char *port,
 	    const char *hostlist, char *connectinghost,
 	    struct pcap_rmtauth *auth, char *errbuf);
 
 PCAP_AVAILABLE_1_10_REMOTE
-PCAP_API SOCKET	pcap_remoteact_accept_ex(const char *address, const char *port,
+PCAP_API PCAP_SOCKET	pcap_remoteact_accept_ex(const char *address, const char *port,
 	    const char *hostlist, char *connectinghost,
 	    struct pcap_rmtauth *auth, int uses_ssl, char *errbuf);
 

--- a/pcap/socket.h
+++ b/pcap/socket.h
@@ -48,6 +48,26 @@
   #include <winsock2.h>
   #include <ws2tcpip.h>
 
+  /*!
+   * \brief In Winsock, a socket handle is of type SOCKET; in UN*X, it's
+   * a file descriptor, and therefore a signed integer.
+   * We define PCAP_SOCKET to be a signed integer on UN*X and a
+   * SOCKET on Windows, so that it can be used on both platforms.
+   *
+   * We used to use SOCKET rather than PCAP_SOCKET, but that collided
+   * with other software, such as barnyard2, which had their own
+   * definitions of SOCKET, so we changed it to PCAP_SOCKET.
+   *
+   * On Windows, this shouldn't break any APIs, as any code using
+   * the two active-mode APIs that return a socket handle would
+   * probably be assigning their return values to a SOCKET, and
+   * as, on Windows, we're defining PCAP_SOCKET as SOCKET, there
+   * would be no type clash.
+   */
+  #ifndef PCAP_SOCKET
+    #define PCAP_SOCKET SOCKET
+  #endif
+
   /*
    * Winsock doesn't have this POSIX type; it's used for the
    * tv_usec value of struct timeval.
@@ -61,13 +81,37 @@
   #include <arpa/inet.h>
 
   /*!
-   * \brief In Winsock, a socket handle is of type SOCKET; in UN*X, it's
-   * a file descriptor, and therefore a signed integer.
-   * We define SOCKET to be a signed integer on UN*X, so that it can
-   * be used on both platforms.
+   * \brief In Winsock, a socket handle is of type SOCKET; in UN*Xes,
+   * it's a file descriptor, and therefore a signed integer.
+   * We define PCAP_SOCKET to be a signed integer on UN*X and a
+   * SOCKET on Windows, so that it can be used on both platforms.
+   *
+   * We used to use SOCKET rather than PCAP_SOCKET, but that collided
+   * with other software, such as barnyard2, which had their own
+   * definitions of SOCKET, so we changed it to PCAP_SOCKET.
+   *
+   * On UN*Xes, this might break code that uses one of the two
+   * active-mode APIs that return a socket handle if those programs
+   * were written to assign the return values of those APIs to a
+   * SOCKET, as we're no longer defining SOCKET.  However, as
+   * those APIs are only provided if libpcap is built with remote
+   * capture support - which is not the default - and as they're
+   * somewhat painful to use, there's probably little if any code
+   * that needs to compile for UN*X and that uses them.  If there
+   * *is* any such code, it could do
+   *
+   *    #ifndef PCAP_SOCKET
+   *        #ifdef _WIN32
+   *            #define PCAP_SOCKET SOCKET
+   *        #else
+   *            #defube PCAP_SOCKET int
+   *        #endif
+   *    #endif
+   *
+   * and use PCAP_SOCKET.
    */
-  #ifndef SOCKET
-    #define SOCKET int
+  #ifndef PCAP_SOCKET
+    #define PCAP_SOCKET int
   #endif
 
   /*!

--- a/rpcap-protocol.c
+++ b/rpcap-protocol.c
@@ -80,7 +80,7 @@
  * error message is returned in the 'errbuf' variable.
  */
 int
-rpcap_senderror(SOCKET sock, SSL *ssl, uint8 ver, unsigned short errcode, const char *error, char *errbuf)
+rpcap_senderror(PCAP_SOCKET sock, SSL *ssl, uint8 ver, unsigned short errcode, const char *error, char *errbuf)
 {
 	char sendbuf[RPCAP_NETBUF_SIZE];	/* temporary buffer in which data to be sent is buffered */
 	int sendbufidx = 0;			/* index which keeps the number of bytes currently buffered */

--- a/rpcap-protocol.h
+++ b/rpcap-protocol.h
@@ -444,6 +444,6 @@ struct rpcap_sampling
 
 extern void rpcap_createhdr(struct rpcap_header *header, uint8 ver, uint8 type, uint16 value, uint32 length);
 extern const char *rpcap_msg_type_string(uint8 type);
-extern int rpcap_senderror(SOCKET sock, SSL *ssl, uint8 ver, uint16 errcode, const char *error, char *errbuf);
+extern int rpcap_senderror(PCAP_SOCKET sock, SSL *ssl, uint8 ver, uint16 errcode, const char *error, char *errbuf);
 
 #endif

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -95,7 +95,7 @@
 // Parameters for the service loop.
 struct daemon_slpars
 {
-	SOCKET sockctrl;	//!< SOCKET ID of the control connection
+	PCAP_SOCKET sockctrl;	//!< PCAP_SOCKET ID of the control connection
 	SSL *ssl;		//!< Optional SSL handler for the controlling sockets
 	int isactive;		//!< Not null if the daemon has to run in active mode
 	int nullAuthAllowed;	//!< '1' if we permit NULL authentication, '0' otherwise
@@ -110,8 +110,8 @@ struct daemon_slpars
 // value for a pthread_t on UN*X.
 //
 struct session {
-	SOCKET sockctrl;
-	SOCKET sockdata;
+	PCAP_SOCKET sockctrl;
+	PCAP_SOCKET sockdata;
 	SSL *ctrl_ssl, *data_ssl; // optional SSL handlers for sockctrl and sockdata.
 	uint8 protocol_version;
 	pcap_t *fp;
@@ -125,7 +125,7 @@ struct session {
 };
 
 // Locally defined functions
-static int daemon_msg_err(SOCKET sockctrl, SSL *, uint32 plen);
+static int daemon_msg_err(PCAP_SOCKET sockctrl, SSL *, uint32 plen);
 static int daemon_msg_auth_req(struct daemon_slpars *pars, uint32 plen);
 static int daemon_AuthUserPwd(char *username, char *password, char *errbuf);
 
@@ -142,7 +142,7 @@ static int daemon_msg_endcap_req(uint8 ver, struct daemon_slpars *pars,
 
 static int daemon_msg_updatefilter_req(uint8 ver, struct daemon_slpars *pars,
     struct session *session, uint32 plen);
-static int daemon_unpackapplyfilter(SOCKET sockctrl, SSL *, struct session *session, uint32 *plenp, char *errbuf);
+static int daemon_unpackapplyfilter(PCAP_SOCKET sockctrl, SSL *, struct session *session, uint32 *plenp, char *errbuf);
 
 static int daemon_msg_stats_req(uint8 ver, struct daemon_slpars *pars,
     struct session *session, uint32 plen, struct pcap_stat *stats,
@@ -159,9 +159,9 @@ static void *daemon_thrdatamain(void *ptr);
 static void noop_handler(int sign);
 #endif
 
-static int rpcapd_recv_msg_header(SOCKET sock, SSL *, struct rpcap_header *headerp);
-static int rpcapd_recv(SOCKET sock, SSL *, char *buffer, size_t toread, uint32 *plen, char *errmsgbuf);
-static int rpcapd_discard(SOCKET sock, SSL *, uint32 len);
+static int rpcapd_recv_msg_header(PCAP_SOCKET sock, SSL *, struct rpcap_header *headerp);
+static int rpcapd_recv(PCAP_SOCKET sock, SSL *, char *buffer, size_t toread, uint32 *plen, char *errmsgbuf);
+static int rpcapd_discard(PCAP_SOCKET sock, SSL *, uint32 len);
 static void session_close(struct session *);
 
 //
@@ -211,7 +211,7 @@ static int is_url(const char *source);
 #endif
 
 int
-daemon_serviceloop(SOCKET sockctrl, int isactive, char *passiveClients,
+daemon_serviceloop(PCAP_SOCKET sockctrl, int isactive, char *passiveClients,
     int nullAuthAllowed, int uses_ssl)
 {
 	uint8 first_octet;
@@ -1138,7 +1138,7 @@ end:
  * This handles the RPCAP_MSG_ERR message.
  */
 static int
-daemon_msg_err(SOCKET sockctrl, SSL *ssl, uint32 plen)
+daemon_msg_err(PCAP_SOCKET sockctrl, SSL *ssl, uint32 plen)
 {
 	char errbuf[PCAP_ERRBUF_SIZE];
 	char remote_errbuf[PCAP_ERRBUF_SIZE];
@@ -2179,7 +2179,7 @@ daemon_msg_startcap_req(uint8 ver, struct daemon_slpars *pars, uint32 plen,
 
 	if (!serveropen_dp)
 	{
-		SOCKET socktemp;	// We need another socket, since we're going to accept() a connection
+		PCAP_SOCKET socktemp;	// We need another socket, since we're going to accept() a connection
 
 		// Connection creation
 		saddrlen = sizeof(struct sockaddr_storage);
@@ -2333,7 +2333,7 @@ daemon_msg_endcap_req(uint8 ver, struct daemon_slpars *pars,
 #define RPCAP_BPF_MAXINSNS	8192
 
 static int
-daemon_unpackapplyfilter(SOCKET sockctrl, SSL *ctrl_ssl, struct session *session, uint32 *plenp, char *errmsgbuf)
+daemon_unpackapplyfilter(PCAP_SOCKET sockctrl, SSL *ctrl_ssl, struct session *session, uint32 *plenp, char *errmsgbuf)
 {
 	int status;
 	struct rpcap_filter filter;
@@ -2912,7 +2912,7 @@ void sleep_secs(int secs)
  * Read the header of a message.
  */
 static int
-rpcapd_recv_msg_header(SOCKET sock, SSL *ssl, struct rpcap_header *headerp)
+rpcapd_recv_msg_header(PCAP_SOCKET sock, SSL *ssl, struct rpcap_header *headerp)
 {
 	int nread;
 	char errbuf[PCAP_ERRBUF_SIZE];		// buffer for network errors
@@ -2944,7 +2944,7 @@ rpcapd_recv_msg_header(SOCKET sock, SSL *ssl, struct rpcap_header *headerp)
  * error.
  */
 static int
-rpcapd_recv(SOCKET sock, SSL *ssl, char *buffer, size_t toread, uint32 *plen, char *errmsgbuf)
+rpcapd_recv(PCAP_SOCKET sock, SSL *ssl, char *buffer, size_t toread, uint32 *plen, char *errmsgbuf)
 {
 	int nread;
 	char errbuf[PCAP_ERRBUF_SIZE];		// buffer for network errors
@@ -2973,7 +2973,7 @@ rpcapd_recv(SOCKET sock, SSL *ssl, char *buffer, size_t toread, uint32 *plen, ch
  * error.
  */
 static int
-rpcapd_discard(SOCKET sock, SSL *ssl, uint32 len)
+rpcapd_discard(PCAP_SOCKET sock, SSL *ssl, uint32 len)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
 

--- a/rpcapd/daemon.h
+++ b/rpcapd/daemon.h
@@ -44,7 +44,7 @@
 // otherwise; the return value is used only by callers that call us
 // for active mode.
 //
-int daemon_serviceloop(SOCKET sockctrl, int isactive, char *passiveClients,
+int daemon_serviceloop(PCAP_SOCKET sockctrl, int isactive, char *passiveClients,
     int nullAuthAllowed, int uses_ssl);
 
 void sleep_secs(int secs);

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -74,7 +74,7 @@
 //
 struct listen_sock {
 	struct listen_sock *next;
-	SOCKET sock;
+	PCAP_SOCKET sock;
 };
 
 // Global variables
@@ -106,7 +106,7 @@ static void main_terminate(int sign);
 static void main_reread_config(int sign);
 #endif
 static void accept_connections(void);
-static void accept_connection(SOCKET listen_sock);
+static void accept_connection(PCAP_SOCKET listen_sock);
 #ifndef _WIN32
 static void main_reap_children(int sign);
 #endif
@@ -622,7 +622,7 @@ void main_startup(void)
 		for (tempaddrinfo = addrinfo; tempaddrinfo;
 		     tempaddrinfo = tempaddrinfo->ai_next)
 		{
-			SOCKET sock;
+			PCAP_SOCKET sock;
 			struct listen_sock *sock_info;
 
 			if ((sock = sock_open(NULL, tempaddrinfo, SOCKOPEN_SERVER, SOCKET_MAXCONN, errbuf, PCAP_ERRBUF_SIZE)) == INVALID_SOCKET)
@@ -1123,7 +1123,7 @@ accept_connections(void)
 // fork "inherits" the parent stack.)
 //
 struct params_copy {
-	SOCKET sockctrl;
+	PCAP_SOCKET sockctrl;
 	char *hostlist;
 };
 #endif
@@ -1133,10 +1133,10 @@ struct params_copy {
 // worker process, on UN*X, to handle the connection.
 //
 static void
-accept_connection(SOCKET listen_sock)
+accept_connection(PCAP_SOCKET listen_sock)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
-	SOCKET sockctrl;			// keeps the socket ID for this control connection
+	PCAP_SOCKET sockctrl;			// keeps the socket ID for this control connection
 	struct sockaddr_storage from;		// generic sockaddr_storage variable
 	socklen_t fromlen;			// keeps the length of the sockaddr_storage variable
 
@@ -1330,7 +1330,7 @@ static void *
 main_active(void *ptr)
 {
 	char errbuf[PCAP_ERRBUF_SIZE + 1];	// keeps the error string, prior to be printed
-	SOCKET sockctrl;			// keeps the socket ID for this control connection
+	PCAP_SOCKET sockctrl;			// keeps the socket ID for this control connection
 	struct addrinfo hints;			// temporary struct to keep settings needed to open the new socket
 	struct addrinfo *addrinfo;		// keeps the addrinfo chain; required to open a new socket
 	struct active_pars *activepars;

--- a/sockutils.c
+++ b/sockutils.c
@@ -432,10 +432,10 @@ static int compare_addrs_to_try_by_status(const void *a, const void *b)
 	return addr_a->errtype - addr_b->errtype;
 }
 
-static SOCKET sock_create_socket(struct addrinfo *addrinfo, char *errbuf,
+static PCAP_SOCKET sock_create_socket(struct addrinfo *addrinfo, char *errbuf,
     int errbuflen)
 {
-	SOCKET sock;
+	PCAP_SOCKET sock;
 #ifdef SO_NOSIGPIPE
 	int on = 1;
 #endif
@@ -501,9 +501,10 @@ static SOCKET sock_create_socket(struct addrinfo *addrinfo, char *errbuf,
  * if everything is fine, INVALID_SOCKET if some errors occurred. The error message is returned
  * in the 'errbuf' variable.
  */
-SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server, int nconn, char *errbuf, int errbuflen)
+PCAP_SOCKET sock_open(const char *host, struct addrinfo *addrinfo,
+    int server, int nconn, char *errbuf, int errbuflen)
 {
-	SOCKET sock;
+	PCAP_SOCKET sock;
 
 	/* This is a server socket */
 	if (server)
@@ -872,7 +873,7 @@ SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server, int nc
  * \return '0' if everything is fine, '-1' if some errors occurred. The error message is returned
  * in the 'errbuf' variable.
  */
-int sock_close(SOCKET sock, char *errbuf, int errbuflen)
+int sock_close(PCAP_SOCKET sock, char *errbuf, int errbuflen)
 {
 	/*
 	 * SHUT_WR: subsequent calls to the send function are disallowed.
@@ -1212,8 +1213,8 @@ struct addrinfo *sock_initaddress(const char *host, const char *port,
  * '-2' if we got one of those errors.
  * For errors, an error message is returned in the 'errbuf' variable.
  */
-int sock_send(SOCKET sock, SSL *ssl _U_NOSSL_, const char *buffer, size_t size,
-    char *errbuf, int errbuflen)
+int sock_send(PCAP_SOCKET sock, SSL *ssl _U_NOSSL_, const char *buffer,
+    size_t size, char *errbuf, int errbuflen)
 {
 	int remaining;
 	ssize_t nsent;
@@ -1416,7 +1417,7 @@ int sock_bufferize(const void *data, int size, char *outbuf, int *offset, int to
  * The error message is returned in the 'errbuf' variable.
  */
 
-int sock_recv(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
+int sock_recv(PCAP_SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
     int flags, char *errbuf, int errbuflen)
 {
 	int recv_flags = 0;
@@ -1523,8 +1524,8 @@ int sock_recv(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
  *
  * Returns the size of the datagram on success or -1 on error.
  */
-int sock_recv_dgram(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
-    char *errbuf, int errbuflen)
+int sock_recv_dgram(PCAP_SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer,
+    size_t size, char *errbuf, int errbuflen)
 {
 	ssize_t nread;
 #ifndef _WIN32
@@ -1671,7 +1672,8 @@ int sock_recv_dgram(SOCKET sock, SSL *ssl _U_NOSSL_, void *buffer, size_t size,
  * \return '0' if everything is fine, '-1' if some errors occurred.
  * The error message is returned in the 'errbuf' variable.
  */
-int sock_discard(SOCKET sock, SSL *ssl, int size, char *errbuf, int errbuflen)
+int sock_discard(PCAP_SOCKET sock, SSL *ssl, int size, char *errbuf,
+    int errbuflen)
 {
 #define TEMP_BUF_SIZE 32768
 
@@ -1929,7 +1931,8 @@ int sock_cmpaddr(struct sockaddr_storage *first, struct sockaddr_storage *second
  * \warning If the socket is using a connectionless protocol, the address may not be available
  * until I/O occurs on the socket.
  */
-int sock_getmyinfo(SOCKET sock, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, int errbuflen)
+int sock_getmyinfo(PCAP_SOCKET sock, char *address, int addrlen, char *port,
+    int portlen, int flags, char *errbuf, int errbuflen)
 {
 	struct sockaddr_storage mysockaddr;
 	socklen_t sockaddrlen;

--- a/sockutils.h
+++ b/sockutils.h
@@ -140,21 +140,24 @@ void sock_geterrmsg(char *errbuf, size_t errbuflen,
     PCAP_FORMAT_STRING(const char *fmt), ...)  PCAP_PRINTFLIKE(3, 4);
 struct addrinfo *sock_initaddress(const char *address, const char *port,
     struct addrinfo *hints, char *errbuf, int errbuflen);
-int sock_recv(SOCKET sock, SSL *, void *buffer, size_t size, int receiveall,
+int sock_recv(PCAP_SOCKET sock, SSL *, void *buffer, size_t size,
+    int receiveall, char *errbuf, int errbuflen);
+int sock_recv_dgram(PCAP_SOCKET sock, SSL *, void *buffer, size_t size,
     char *errbuf, int errbuflen);
-int sock_recv_dgram(SOCKET sock, SSL *, void *buffer, size_t size,
-    char *errbuf, int errbuflen);
-SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server, int nconn, char *errbuf, int errbuflen);
-int sock_close(SOCKET sock, char *errbuf, int errbuflen);
+PCAP_SOCKET sock_open(const char *host, struct addrinfo *addrinfo, int server,
+    int nconn, char *errbuf, int errbuflen);
+int sock_close(PCAP_SOCKET sock, char *errbuf, int errbuflen);
 
-int sock_send(SOCKET sock, SSL *, const char *buffer, size_t size,
+int sock_send(PCAP_SOCKET sock, SSL *, const char *buffer, size_t size,
     char *errbuf, int errbuflen);
 int sock_bufferize(const void *data, int size, char *outbuf, int *offset, int totsize, int checkonly, char *errbuf, int errbuflen);
-int sock_discard(SOCKET sock, SSL *, int size, char *errbuf, int errbuflen);
+int sock_discard(PCAP_SOCKET sock, SSL *, int size, char *errbuf,
+    int errbuflen);
 int	sock_check_hostlist(char *hostlist, const char *sep, struct sockaddr_storage *from, char *errbuf, int errbuflen);
 int sock_cmpaddr(struct sockaddr_storage *first, struct sockaddr_storage *second);
 
-int sock_getmyinfo(SOCKET sock, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, int errbuflen);
+int sock_getmyinfo(PCAP_SOCKET sock, char *address, int addrlen, char *port,
+    int portlen, int flags, char *errbuf, int errbuflen);
 
 int sock_getascii_addrport(const struct sockaddr_storage *sockaddr, char *address, int addrlen, char *port, int portlen, int flags, char *errbuf, size_t errbuflen);
 int sock_present2network(const char *address, struct sockaddr_storage *sockaddr, int addr_family, char *errbuf, int errbuflen);

--- a/sslutils.c
+++ b/sslutils.c
@@ -133,7 +133,7 @@ die:
 	return -1;
 }
 
-SSL *ssl_promotion(int is_server, SOCKET s, char *errbuf, size_t errbuflen)
+SSL *ssl_promotion(int is_server, PCAP_SOCKET s, char *errbuf, size_t errbuflen)
 {
 	if (ssl_init_once(is_server, 1, errbuf, errbuflen) < 0) {
 		return NULL;

--- a/sslutils.h
+++ b/sslutils.h
@@ -34,7 +34,7 @@
 #define __SSLUTILS_H__
 
 #ifdef HAVE_OPENSSL
-#include "pcap/socket.h"  // for SOCKET
+#include "pcap/socket.h"  // for PCAP_SOCKET
 #include <openssl/ssl.h>
 #include <openssl/err.h>
 
@@ -45,7 +45,7 @@
 void ssl_set_certfile(const char *certfile);
 void ssl_set_keyfile(const char *keyfile);
 int ssl_init_once(int is_server, int enable_compression, char *errbuf, size_t errbuflen);
-SSL *ssl_promotion(int is_server, SOCKET s, char *errbuf, size_t errbuflen);
+SSL *ssl_promotion(int is_server, PCAP_SOCKET s, char *errbuf, size_t errbuflen);
 void ssl_finish(SSL *ssl);
 int ssl_send(SSL *, char const *buffer, int size, char *errbuf, size_t errbuflen);
 int ssl_recv(SSL *, char *buffer, int size, char *errbuf, size_t errbuflen);


### PR DESCRIPTION
Doing so can cause namespace collisions, as per, for example, https://github.com/firnsy/barnyard2/issues/245.

Instead, define PCAP_SOCKET, and use that.

On Windows, this shouldn't break any APIs, as any code using the two active-mode APIs that return a socket handle would probably be assigning their return values to a SOCKET, and as, on Windows, we're defining PCAP_SOCKET as SOCKET, there would be no type clash.

On UN\*Xes, this might break code that uses one of the two active-mode APIs that return a socket handle if those programs were written to assign the return values of those APIs to a SOCKET, as we're no longer defining SOCKET.  However, as those APIs are only provided if libpcap is built with remote capture support - which is not the default - and as they're somewhat painful to use, there's probably little if any code that needs to compile for UN*X and that uses them.  If there *is* any such code, it could do

    #ifndef PCAP_SOCKET
        #ifdef _WIN32
            #define PCAP_SOCKET SOCKET
        #else
            #defube PCAP_SOCKET int
        #endif
    #endif

and use PCAP_SOCKET.

(backported from commit 93bac35f01137cb83de165fb1b60da700cd0bac0)