### PR TITLE
Add support for filtering VXLAN packets

### DIFF
--- a/gencode.h
+++ b/gencode.h
@@ -357,6 +357,7 @@ struct block *gen_pppoed(compiler_state_t *);
 struct block *gen_pppoes(compiler_state_t *, bpf_u_int32, int);
 
 struct block *gen_geneve(compiler_state_t *, bpf_u_int32, int);
+struct block *gen_vxlan(compiler_state_t *, bpf_u_int32, int);
 
 struct block *gen_atmfield_code(compiler_state_t *, int, bpf_u_int32,
     int, int);

--- a/grammar.y.in
+++ b/grammar.y.in
@@ -405,7 +405,7 @@ DIAG_OFF_BISON_BYACC
 %token  LEN
 %token  IPV6 ICMPV6 AH ESP
 %token	VLAN MPLS
-%token	PPPOED PPPOES GENEVE
+%token	PPPOED PPPOES GENEVE VXLAN
 %token  ISO ESIS CLNP ISIS L1 L2 IIH LSP SNP CSNP PSNP
 %token  STP
 %token  IPX
@@ -702,6 +702,8 @@ other:	  pqual TK_BROADCAST	{ CHECK_PTR_VAL(($$ = gen_broadcast(cstate, $1))); }
 	| PPPOES		{ CHECK_PTR_VAL(($$ = gen_pppoes(cstate, 0, 0))); }
 	| GENEVE pnum		{ CHECK_PTR_VAL(($$ = gen_geneve(cstate, $2, 1))); }
 	| GENEVE		{ CHECK_PTR_VAL(($$ = gen_geneve(cstate, 0, 0))); }
+	| VXLAN pnum		{ CHECK_PTR_VAL(($$ = gen_vxlan(cstate, $2, 1))); }
+	| VXLAN			{ CHECK_PTR_VAL(($$ = gen_vxlan(cstate, 0, 0))); }
 	| pfvar			{ $$ = $1; }
 	| pqual p80211		{ $$ = $2; }
 	| pllc			{ $$ = $1; }

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -798,6 +798,20 @@ For example:
 filters IPv4 protocol encapsulated in Geneve with VNI 0xb. This will
 match both IPv4 directly encapsulated in Geneve as well as IPv4 contained
 inside an Ethernet frame.
+.IP "\fBvxlan \fI[vni]\fR"
+True if the packet is a VXLAN packet (UDP port 4789). If the optional
+\fIvni\fR is specified, only true if the packet has the specified
+\fIvni\fR.  Note that when the \fBvxlan\fR keyword is encountered in
+an expression, it changes the decoding offsets for the remainder of
+the expression on the assumption that the packet is a VXLAN packet.
+.IP
+For example:
+.in +.5i
+.nf
+\fBvxlan\fP 0x7 \fB&& ip6 \fR
+.fi
+.in -.5i
+filters IPv6 protocol encapsulated in VXLAN with VNI 0x7.
 .IP "\fBiso proto \fIprotocol\fR"
 True if the packet is an OSI packet of protocol type \fIprotocol\fP.
 \fIProtocol\fP can be a number or one of the names

--- a/scanner.l
+++ b/scanner.l
@@ -367,6 +367,7 @@ mpls		return MPLS;
 pppoed		return PPPOED;
 pppoes		return PPPOES;
 geneve		return GENEVE;
+vxlan		return VXLAN;
 
 lane		return LANE;
 llc		return LLC;


### PR DESCRIPTION
This change extends libpcap with support for filtering VXLAN ("Virtual eXtensible LAN") packets. The implementation is based on the existing support for Geneve.