### PR TITLE
more pcap_findalldevs() fixes

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -52,6 +52,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Fix a few device activation bugs.
       Count and timestamp packets better.
       Add kernel filtering, fix userland filtering.
+    Solaris:
+      Fix AF_LINK handling on illumos.
 
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 1.10.5 libpcap release (so far!)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1065,7 +1065,6 @@ if(WIN32)
 else(WIN32)
     set(CMAKE_EXTRA_INCLUDE_FILES unistd.h sys/socket.h)
 endif(WIN32)
-check_type_size("struct sockaddr_storage" STRUCT_SOCKADDR_STORAGE)
 check_type_size("socklen_t" SOCKLEN_T)
 cmake_pop_check_state()
 

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -192,9 +192,6 @@
 /* Define to 1 if `sa_len' is a member of `struct sockaddr'. */
 #cmakedefine HAVE_STRUCT_SOCKADDR_SA_LEN 1
 
-/* Define to 1 if the system has the type `struct sockaddr_storage'. */
-#cmakedefine HAVE_STRUCT_SOCKADDR_STORAGE 1
-
 /* Define to 1 if `tp_vlan_tci' is a member of `struct tpacket_auxdata'. */
 #cmakedefine HAVE_STRUCT_TPACKET_AUXDATA_TP_VLAN_TCI 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -2401,15 +2401,6 @@ AC_CHECK_MEMBERS([struct sockaddr.sa_len],,,
     ])
 
 #
-# Check to see if there's a sockaddr_storage structure.
-#
-AC_CHECK_TYPES(struct sockaddr_storage,,,
-    [
-	#include <sys/types.h>
-	#include <sys/socket.h>
-    ])
-
-#
 # Check to see if the dl_hp_ppa_info_t struct has the HP-UX 11.00
 # dl_module_id_1 member.
 #

--- a/fad-getad.c
+++ b/fad-getad.c
@@ -104,7 +104,6 @@
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
 #define SA_LEN(addr)	((addr)->sa_len)
 #else /* HAVE_STRUCT_SOCKADDR_SA_LEN */
-#ifdef HAVE_STRUCT_SOCKADDR_STORAGE
 static size_t
 get_sa_len(struct sockaddr *addr)
 {
@@ -130,9 +129,6 @@ get_sa_len(struct sockaddr *addr)
 	}
 }
 #define SA_LEN(addr)	(get_sa_len(addr))
-#else /* HAVE_STRUCT_SOCKADDR_STORAGE */
-#define SA_LEN(addr)	(sizeof (struct sockaddr))
-#endif /* HAVE_STRUCT_SOCKADDR_STORAGE */
 #endif /* HAVE_STRUCT_SOCKADDR_SA_LEN */
 #endif /* SA_LEN */
 

--- a/fad-getad.c
+++ b/fad-getad.c
@@ -99,6 +99,17 @@
  * but not in the final version).  On the latter systems, we explicitly
  * check the AF_ type to determine the length; we assume that on
  * all those systems we have "struct sockaddr_storage".
+ *
+ * OSes that use this file are:
+ * - FreeBSD (HAVE_STRUCT_SOCKADDR_SA_LEN is defined)
+ * - Haiku (HAVE_STRUCT_SOCKADDR_SA_LEN is defined)
+ * - Hurd (HAVE_STRUCT_SOCKADDR_SA_LEN is defined)
+ * - illumos (HAVE_STRUCT_SOCKADDR_SA_LEN is not defined)
+ * - Linux (HAVE_STRUCT_SOCKADDR_SA_LEN is not defined)
+ * - macOS (HAVE_STRUCT_SOCKADDR_SA_LEN is defined)
+ * - NetBSD (HAVE_STRUCT_SOCKADDR_SA_LEN is defined)
+ * - OpenBSD (SA_LEN() is defined)
+ * - Solaris 11 (HAVE_STRUCT_SOCKADDR_SA_LEN is not defined)
  */
 #ifndef SA_LEN
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN
@@ -122,6 +133,11 @@ get_sa_len(struct sockaddr *addr)
 #if (defined(linux) || defined(__Lynx__)) && defined(AF_PACKET)
 	case AF_PACKET:
 		return (sizeof (struct sockaddr_ll));
+#endif
+
+#ifdef AF_LINK
+	case AF_LINK:
+		return (sizeof (struct sockaddr_dl));
 #endif
 
 	default:

--- a/fad-gifc.c
+++ b/fad-gifc.c
@@ -87,6 +87,10 @@ struct rtentry;		/* declarations in <net/if.h> */
  * We assume that a UNIX that doesn't have "getifaddrs()" and doesn't have
  * SIOCGLIFCONF, but has SIOCGIFCONF, uses "struct sockaddr" for the
  * address in an entry returned by SIOCGIFCONF.
+ *
+ * OSes that use this file are:
+ * - AIX 7 (SA_LEN() is not defined, HAVE_STRUCT_SOCKADDR_SA_LEN is defined)
+ * - HP-UX 11 (HAVE_STRUCT_SOCKADDR_SA_LEN is not defined)
  */
 #ifndef SA_LEN
 #ifdef HAVE_STRUCT_SOCKADDR_SA_LEN

--- a/fad-glifc.c
+++ b/fad-glifc.c
@@ -40,10 +40,7 @@
 #include <sys/file.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
-#ifdef HAVE_SYS_SOCKIO_H
 #include <sys/sockio.h>
-#endif
-#include <sys/time.h>				/* concession to AIX */
 
 struct mbuf;		/* Squelch compiler warnings on some platforms for */
 struct rtentry;		/* declarations in <net/if.h> */
@@ -87,9 +84,7 @@ pcapint_findalldevs_interfaces(pcap_if_list_t *devlistp, char *errbuf,
 	struct lifconf ifc;
 	char *buf = NULL;
 	unsigned buf_size;
-#ifdef HAVE_SOLARIS
 	char *p, *q;
-#endif
 	struct lifreq ifrflags, ifrnetmask, ifrbroadaddr, ifrdstaddr;
 	struct sockaddr *netmask, *broadaddr, *dstaddr;
 	int ret = 0;
@@ -299,7 +294,6 @@ pcapint_findalldevs_interfaces(pcap_if_list_t *devlistp, char *errbuf,
 		} else
 			dstaddr = NULL;
 
-#ifdef HAVE_SOLARIS
 		/*
 		 * If this entry has a colon followed by a number at
 		 * the end, it's a logical interface.  Those are just
@@ -325,7 +319,6 @@ pcapint_findalldevs_interfaces(pcap_if_list_t *devlistp, char *errbuf,
 				*p = '\0';
 			}
 		}
-#endif
 
 		/*
 		 * Add information for this address to the list.

--- a/fad-glifc.c
+++ b/fad-glifc.c
@@ -64,6 +64,10 @@ struct rtentry;		/* declarations in <net/if.h> */
 #endif
 
 /*
+ * Only Solaris 10 uses this file.
+ */
+
+/*
  * Get a list of all interfaces that are up and that we can open.
  * Returns -1 on error, 0 otherwise.
  * The list, as returned through "alldevsp", may be null if no interfaces


### PR DESCRIPTION
This improves SNR a bit and fixes a bug. It still looks a bit off that `get_sa_len()` defaults to `sizeof (struct sockaddr)` instead of `sizeof (struct sockaddr_storage)`, but I cannot quickly prove that change to work correctly in all cases, so I am not making it right now. Unless someone sees an issue with these changes, they will be merged soon.