### PR TITLE
The time stamp in pcap packet headers has two unsigned 32-bit values.

### DIFF
--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -844,10 +844,10 @@ pcap_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 		return;
 	/*
 	 * Better not try writing pcap files after
-	 * 2038-01-19 03:14:07 UTC; switch to pcapng.
+	 * 2106-02-07 06:28:15 UTC; switch to pcapng.
 	 */
-	sf_hdr.ts.tv_sec  = (bpf_int32)h->ts.tv_sec;
-	sf_hdr.ts.tv_usec = (bpf_int32)h->ts.tv_usec;
+	sf_hdr.ts.tv_sec  = (bpf_u_int32)h->ts.tv_sec;
+	sf_hdr.ts.tv_usec = (bpf_u_int32)h->ts.tv_usec;
 	sf_hdr.caplen     = h->caplen;
 	sf_hdr.len        = h->len;
 	/*


### PR DESCRIPTION
When writing a pcap packet record, cast the seconds and microseconds values to bpf_u_int32, as that's the type of the values in the record header.  Update the sell-by date of pcap files; making them unsigned means pcap files don't have a Y2.038K problem, but it does have a Y2.106K problem.