### PR TITLE
CMake: Remove unnecessary header checks.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -655,13 +655,10 @@ include(CheckTypeSize)
 #
 # Header files.
 #
-check_include_file(inttypes.h HAVE_INTTYPES_H)
-check_include_file(stdint.h HAVE_STDINT_H)
 check_include_file(unistd.h HAVE_UNISTD_H)
 if(NOT HAVE_UNISTD_H)
     add_definitions(-DYY_NO_UNISTD_H)
 endif(NOT HAVE_UNISTD_H)
-check_include_file(bitypes.h HAVE_SYS_BITYPES_H)
 if(NOT WIN32)
     check_include_file(sys/ioccom.h HAVE_SYS_IOCCOM_H)
     check_include_file(sys/sockio.h HAVE_SYS_SOCKIO_H)

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -66,9 +66,6 @@
 /* Define to 1 if you have the <hurd.h> header file. */
 #cmakedefine HAVE_HURD_H 1
 
-/* Define to 1 if you have the <inttypes.h> header file. */
-#cmakedefine HAVE_INTTYPES_H 1
-
 /* if libdlpi exists */
 #cmakedefine HAVE_LIBDLPI 1
 
@@ -147,17 +144,8 @@
 /* define if we have the Solaris getprotobyname_r() */
 #cmakedefine HAVE_SOLARIS_GETPROTOBYNAME_R 1
 
-/* Define to 1 if you have the <stdint.h> header file. */
-#cmakedefine HAVE_STDINT_H 1
-
-/* Define to 1 if you have the <stdlib.h> header file. */
-#cmakedefine HAVE_STDLIB_H 1
-
 /* Define to 1 if you have the <strings.h> header file. */
 #cmakedefine HAVE_STRINGS_H 1
-
-/* Define to 1 if you have the <string.h> header file. */
-#cmakedefine HAVE_STRING_H 1
 
 /* Define to 1 if you have the `strlcat' function. */
 #cmakedefine HAVE_STRLCAT 1


### PR DESCRIPTION
This is expected to pass the CI.