### PR TITLE
Include <config.h> unconditionally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -576,8 +576,6 @@ set(PACKAGE_STRING "${LIBRARY_NAME} ${PACKAGE_VERSION}")
 # Project settings
 ######################################
 
-add_definitions(-DHAVE_CONFIG_H)
-
 include_directories(
     ${CMAKE_CURRENT_BINARY_DIR}
     ${pcap_SOURCE_DIR}

--- a/bpf_dump.c
+++ b/bpf_dump.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap.h>
 #include <stdio.h>

--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -38,9 +38,7 @@
  *	@(#)bpf.c	7.5 (Berkeley) 7/15/91
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap/pcap-inttypes.h>
 #include "pcap-types.h"

--- a/bpf_image.c
+++ b/bpf_image.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 

--- a/dlpisubs.c
+++ b/dlpisubs.c
@@ -11,9 +11,7 @@
  * by pcap-[dlpi,libdlpi].c.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifndef DL_IPATM
 #define DL_IPATM	0x12	/* ATM Classical IP interface */

--- a/etherent.c
+++ b/etherent.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 

--- a/fad-getad.c
+++ b/fad-getad.c
@@ -32,9 +32,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 #include <sys/socket.h>

--- a/fad-gifc.c
+++ b/fad-gifc.c
@@ -32,9 +32,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/param.h>
 #include <sys/ioctl.h>

--- a/fad-glifc.c
+++ b/fad-glifc.c
@@ -32,9 +32,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/param.h>
 #include <sys/file.h>

--- a/fmtutils.c
+++ b/fmtutils.c
@@ -35,9 +35,7 @@
  * Utilities for message formatting used both by libpcap and rpcapd.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "ftmacros.h"
 

--- a/gencode.c
+++ b/gencode.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifdef _WIN32
   #include <ws2tcpip.h>

--- a/grammar.y.in
+++ b/grammar.y.in
@@ -67,9 +67,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /*
  * grammar.h requires gencode.h and sometimes breaks in a polluted namespace

--- a/missing/strlcat.c
+++ b/missing/strlcat.c
@@ -16,9 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stddef.h>
 #include <string.h>

--- a/missing/strlcpy.c
+++ b/missing/strlcpy.c
@@ -16,9 +16,7 @@
  * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stddef.h>
 #include <string.h>

--- a/missing/strtok_r.c
+++ b/missing/strtok_r.c
@@ -34,9 +34,7 @@
  * From: @(#)strtok.c	8.1 (Berkeley) 6/4/93
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "portability.h"
 

--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -22,9 +22,7 @@
  * These functions are not time critical.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifdef _WIN32
   #include <winsock2.h>

--- a/optimize.c
+++ b/optimize.c
@@ -21,9 +21,7 @@
  *  Optimization module for BPF code intermediate representation.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 

--- a/pcap-airpcap.c
+++ b/pcap-airpcap.c
@@ -31,9 +31,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "pcap-int.h"
 

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/param.h>			/* optionally get BSD define */
 #include <sys/socket.h>

--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -32,9 +32,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "pcap-int.h"
 #include "pcap-bt-linux.h"

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -29,9 +29,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <errno.h>
 #include <stdint.h>

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -21,9 +21,7 @@
  * pcap-common.c - common code for pcap and pcapng files
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -7,9 +7,7 @@
  *                Stephen Donnelly <stephen.donnelly@endace.com>
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/param.h>			/* optionally get BSD define */
 

--- a/pcap-dbus.c
+++ b/pcap-dbus.c
@@ -28,9 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <string.h>
 

--- a/pcap-dlpi.c
+++ b/pcap-dlpi.c
@@ -65,9 +65,7 @@
  *      DL_HP_RAWDLS?
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 #include <sys/time.h>

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -75,9 +75,7 @@ For example, the testprogs/capturetest could be launched by:
 env DPDK_CFG="--log-level=debug -l0 -dlibrte_pmd_e1000.so -dlibrte_pmd_ixgbe.so -dlibrte_mempool_ring.so" ./capturetest -i dpdk:0
 */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <errno.h>
 #include <netdb.h>

--- a/pcap-hurd.c
+++ b/pcap-hurd.c
@@ -3,9 +3,7 @@
 /* XXX Hack not to include the Mach BPF interface */
 #define _DEVICE_BPF_H_
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <fcntl.h>
 #include <hurd.h>

--- a/pcap-libdlpi.c
+++ b/pcap-libdlpi.c
@@ -24,9 +24,7 @@
  * Packet capture routines for DLPI using libdlpi under SunOS 5.11.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 #include <sys/time.h>

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -70,9 +70,7 @@
 
 #define _GNU_SOURCE
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <errno.h>
 #include <stdio.h>

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -28,9 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "pcap-int.h"
 #include "diag-control.h"

--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -24,9 +24,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <poll.h>
 #include <errno.h>

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -31,9 +31,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <errno.h>
 #include <limits.h> /* for INT_MAX */

--- a/pcap-null.c
+++ b/pcap-null.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <string.h>
 

--- a/pcap-options.c
+++ b/pcap-options.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/types.h>
 

--- a/pcap-rdmasniff.c
+++ b/pcap-rdmasniff.c
@@ -28,9 +28,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "pcap-int.h"
 #include "pcap-rdmasniff.h"

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -31,9 +31,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "ftmacros.h"
 #include "diag-control.h"

--- a/pcap-septel.c
+++ b/pcap-septel.c
@@ -5,9 +5,7 @@
  * (+961 3 485243)
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <sys/param.h>
 

--- a/pcap-sita.c
+++ b/pcap-sita.c
@@ -24,9 +24,7 @@
  *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdio.h>
 #include <string.h>

--- a/pcap-snf.c
+++ b/pcap-snf.c
@@ -1,6 +1,4 @@
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifndef _WIN32
 #include <sys/param.h>

--- a/pcap-tc.c
+++ b/pcap-tc.c
@@ -29,9 +29,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap.h>
 #include <pcap-int.h>

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -33,9 +33,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "pcap/usb.h"
 #include "pcap-int.h"

--- a/pcap-util.c
+++ b/pcap-util.c
@@ -21,9 +21,7 @@
  * pcap-util.c - common code for various files
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 

--- a/pcap.c
+++ b/pcap.c
@@ -31,9 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /*
  * Include this before including any system header files, as it

--- a/rpcap-protocol.c
+++ b/rpcap-protocol.c
@@ -31,9 +31,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <string.h>		/* for strlen(), ... */
 #include <stdlib.h>		/* for malloc(), free(), ... */

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -29,9 +29,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "ftmacros.h"
 #include "varattrs.h"

--- a/rpcapd/daemon.h
+++ b/rpcapd/daemon.h
@@ -33,9 +33,7 @@
 #ifndef __DAEMON_H__
 #define __DAEMON_H__
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "sslutils.h"
 

--- a/rpcapd/fileconf.c
+++ b/rpcapd/fileconf.c
@@ -31,9 +31,7 @@
  * SUCH DAMAGE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "ftmacros.h"
 

--- a/rpcapd/log.c
+++ b/rpcapd/log.c
@@ -19,9 +19,7 @@
  * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdio.h>
 #include <stdarg.h>

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -30,9 +30,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include "ftmacros.h"
 #include "diag-control.h"

--- a/savefile.c
+++ b/savefile.c
@@ -28,9 +28,7 @@
  * dependent values so we can print the dump file on any architecture.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 #ifdef _WIN32

--- a/scanner.l
+++ b/scanner.l
@@ -1,8 +1,6 @@
 %top {
 /* Must come first for _LARGE_FILE_API on AIX. */
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /*
  * Must come first to avoid warnings on Windows.

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -28,9 +28,7 @@
  * dependent values so we can print the dump file on any architecture.
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap-types.h>
 #ifdef _WIN32

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -21,9 +21,7 @@
  * sf-pcapng.c - pcapng-file-format-specific code from savefile.c
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap/pcap-inttypes.h>
 

--- a/sockutils.c
+++ b/sockutils.c
@@ -30,9 +30,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 /*
  * \file sockutils.c

--- a/sslutils.c
+++ b/sslutils.c
@@ -30,9 +30,7 @@
  *
  */
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #ifdef HAVE_OPENSSL
 #include <stdlib.h>

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -27,9 +27,7 @@ static const char copyright[] _U_ =
 The Regents of the University of California.  All rights reserved.\n";
 #endif
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <pcap.h>
 #include <stdio.h>

--- a/testprogs/findalldevstest-perf.c
+++ b/testprogs/findalldevstest-perf.c
@@ -1,6 +1,4 @@
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/testprogs/findalldevstest.c
+++ b/testprogs/findalldevstest.c
@@ -1,6 +1,4 @@
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdlib.h>
 #include <string.h>

--- a/testprogs/valgrindtest.c
+++ b/testprogs/valgrindtest.c
@@ -51,9 +51,7 @@ static const char copyright[] _U_ =
 The Regents of the University of California.  All rights reserved.\n";
 #endif
 
-#ifdef HAVE_CONFIG_H
 #include <config.h>
-#endif
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Builds using Autotools or CMake generate config.h, thus remove the '#ifdef HAVE_CONFIG_H'/'#endif'.

Remove also the 'add_definitions(-DHAVE_CONFIG_H)' in CMakeLists.txt.