### PR TITLE
Require a proof of suitable snprintf(3) implementation.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -30,11 +30,6 @@ environment:
   #
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "MinGW Makefiles"
-      SDK: WpdPack
-      AIRPCAP: -DDISABLE_AIRPCAP=YES
-      MINGW_ROOT: C:\mingw-w64\x86_64-8.1.0-posix-seh-rt_v6-rev0
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: "Visual Studio 14 2015 Win64"
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
@@ -102,15 +97,6 @@ build_script:
   - type NUL >.devel
   - md build
   - cd build
-  # Remove the default MinGW path
-  - if "%GENERATOR%"=="MinGW Makefiles" set PATH=%PATH:C:\MinGW\bin;=%
-  # Add the specified MinGW path
-  - if "%GENERATOR%"=="MinGW Makefiles" set PATH=%MINGW_ROOT%\mingw64\bin;%PATH%
-  # Remove the path to Git, so that we don't pick up its sh.exe, as
-  # that breaks MinGW builds - CMake checks for that and fails in the
-  # configuration stage
-  - if "%GENERATOR%"=="MinGW Makefiles" set PATH=%PATH:C:\Program Files\Git\usr\bin;=%
   - if NOT DEFINED PLATFORM cmake %AIRPCAP% %REMOTE% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DAirPcap_ROOT=c:\projects\libpcap\Win32\Airpcap_Devpack -G"%GENERATOR%" ..
   - if DEFINED PLATFORM cmake %AIRPCAP% %REMOTE% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DAirPcap_ROOT=c:\projects\libpcap\Win32\Airpcap_Devpack -G"%GENERATOR%" -A %PLATFORM% ..
-  - if NOT "%GENERATOR%"=="MinGW Makefiles" msbuild /m /nologo /p:Configuration=Release pcap.sln
-  - if "%GENERATOR%"=="MinGW Makefiles" mingw32-make
+  - msbuild /m /nologo /p:Configuration=Release pcap.sln

--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Print MAC addresses in findalldevstest.
       When necessary, trust the OS to implement ffs().
       Fix HCI_CHANNEL_MONITOR detection with musl libc.
+      At build time require a proof of suitable snprintf(3) implementation in
+        libc (and document Solaris 9 and MinGW as unsupported because of that).
     Hurd:
       Support network capture devices too.
       Fix a few device activation bugs.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -736,18 +736,55 @@ else(HAVE_STRERROR_R)
 endif(HAVE_STRERROR_R)
 
 #
-# Make sure we have vsnprintf() and snprintf(); we require them.
-# We use check_symbol_exists(), as they aren't necessarily external
-# functions - in Visual Studio, for example, they're inline functions
-# calling a common external function.
+# Require a proof of suitable snprintf(3), same as in Autoconf.
 #
-check_symbol_exists(vsnprintf "stdio.h" HAVE_VSNPRINTF)
-if(NOT HAVE_VSNPRINTF)
-    message(FATAL_ERROR "vsnprintf() is required but wasn't found")
-endif(NOT HAVE_VSNPRINTF)
-check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
-if(NOT HAVE_SNPRINTF)
-    message(FATAL_ERROR "snprintf() is required but wasn't found")
+include(CheckCSourceRuns)
+check_c_source_runs("
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <sys/types.h>
+
+int main()
+{
+  char buf[100];
+  uint64_t t = (uint64_t)1 << 32;
+
+  snprintf(buf, sizeof(buf), \"%zu\", sizeof(buf));
+  if (strncmp(buf, \"100\", sizeof(buf)))
+    return 1;
+
+  snprintf(buf, sizeof(buf), \"%zd\", -sizeof(buf));
+  if (strncmp(buf, \"-100\", sizeof(buf)))
+    return 2;
+
+  snprintf(buf, sizeof(buf), \"%\" PRId64, -t);
+  if (strncmp(buf, \"-4294967296\", sizeof(buf)))
+    return 3;
+
+  snprintf(buf, sizeof(buf), \"0o%\" PRIo64, t);
+  if (strncmp(buf, \"0o40000000000\", sizeof(buf)))
+    return 4;
+
+  snprintf(buf, sizeof(buf), \"0x%\" PRIx64, t);
+  if (strncmp(buf, \"0x100000000\", sizeof(buf)))
+    return 5;
+
+  snprintf(buf, sizeof(buf), \"%\" PRIu64, t);
+  if (strncmp(buf, \"4294967296\", sizeof(buf)))
+    return 6;
+
+  return 0;
+}
+
+"
+    SUITABLE_SNPRINTF
+)
+if(NOT SUITABLE_SNPRINTF)
+    message(FATAL_ERROR
+"The snprintf(3) implementation in this libc is not suitable,
+libpcap would not work correctly even if it managed to compile."
+    )
 endif()
 
 check_function_exists(strlcpy HAVE_STRLCPY)

--- a/configure.ac
+++ b/configure.ac
@@ -208,12 +208,63 @@ main(void)
 AC_CHECK_FUNCS(vsyslog)
 
 #
-# Make sure we have vsnprintf() and snprintf(); we require them.
+# Require a proof of suitable snprintf(3), same as in tcpdump.
 #
-AC_CHECK_FUNC(vsnprintf,,
-    AC_MSG_ERROR([vsnprintf() is required but wasn't found]))
-AC_CHECK_FUNC(snprintf,,
-    AC_MSG_ERROR([snprintf() is required but wasn't found]))
+AC_MSG_CHECKING([whether snprintf is suitable])
+AC_RUN_IFELSE(
+    [
+        AC_LANG_SOURCE([[
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <sys/types.h>
+
+int main()
+{
+  char buf[100];
+  uint64_t t = (uint64_t)1 << 32;
+
+  snprintf(buf, sizeof(buf), "%zu", sizeof(buf));
+  if (strncmp(buf, "100", sizeof(buf)))
+    return 1;
+
+  snprintf(buf, sizeof(buf), "%zd", -sizeof(buf));
+  if (strncmp(buf, "-100", sizeof(buf)))
+    return 2;
+
+  snprintf(buf, sizeof(buf), "%" PRId64, -t);
+  if (strncmp(buf, "-4294967296", sizeof(buf)))
+    return 3;
+
+  snprintf(buf, sizeof(buf), "0o%" PRIo64, t);
+  if (strncmp(buf, "0o40000000000", sizeof(buf)))
+    return 4;
+
+  snprintf(buf, sizeof(buf), "0x%" PRIx64, t);
+  if (strncmp(buf, "0x100000000", sizeof(buf)))
+    return 5;
+
+  snprintf(buf, sizeof(buf), "%" PRIu64, t);
+  if (strncmp(buf, "4294967296", sizeof(buf)))
+    return 6;
+
+  return 0;
+}
+        ]])
+    ],
+    [
+        AC_MSG_RESULT(yes)
+    ],
+    [
+        AC_MSG_RESULT(no)
+        AC_MSG_ERROR(
+[The snprintf(3) implementation in this libc is not suitable,
+libpcap would not work correctly even if it managed to compile.])
+    ],
+    [
+        AC_MSG_RESULT(not while cross-compiling)
+    ]
+)
 
 needasprintf=no
 AC_CHECK_FUNCS(vasprintf asprintf,,

--- a/doc/README.solaris.md
+++ b/doc/README.solaris.md
@@ -82,8 +82,7 @@ ENDOFTEXT
 * CMake 3.14.3 works.
 * Sun C 5.13 works, GCC 5.5.0 works.
 
-## Solaris 9/SPARC
+## Solaris 9
 
-* flex 2.5.35 and GNU Bison 3.0.2 work.
-* CMake 2.8.9 does not work.
-* Neither Sun C 5.8 nor Sun C 5.9 work, GCC 4.6.4 works.
+This version of this OS is not supported because the snprintf(3) implementation
+in its libc is not suitable.

--- a/doc/README.windows.md
+++ b/doc/README.windows.md
@@ -239,4 +239,4 @@ where `{configuration}` can be "Release", "Debug", or "RelWithDebInfo".
 Building with MinGW
 -------------------
 
-(XXX - this should be added)
+MinGW is not supported because its snprintf(3) implementation is not suitable.


### PR DESCRIPTION
libpcap was not working correctly on Solaris 9 already, the test makes it obvious.