### PR TITLE
Makefile.in(s): Fix the depend target / mkdep: Exit if a command fails

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -892,7 +892,7 @@ whitespacecheck:
 	fi
 
 depend:	$(GENERATED_C_SRC) $(GENHDR)
-	$(MKDEP) -c "$(CC)" -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(CFLAGS) $(DEFS) $(INCLS) $(SRC)
+	$(MKDEP) -c $(CC) -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(CFLAGS) $(DEFS) $(INCLS) $(SRC)
 	(cd rpcapd; $(MAKE) depend)
 	(cd testprogs; $(MAKE) depend)
 

--- a/mkdep
+++ b/mkdep
@@ -1,4 +1,4 @@
-#!/bin/sh -
+#!/bin/sh -e
 #
 # Copyright (c) 1994, 1996
 #	The Regents of the University of California.  All rights reserved.

--- a/rpcapd/Makefile.in
+++ b/rpcapd/Makefile.in
@@ -139,4 +139,4 @@ tags: $(TAGFILES)
 	ctags -wtd $(TAGFILES)
 
 depend:
-	$(MKDEP) -c "$(CC)" -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(CFLAGS) $(DEFS) $(INCLS) $(SRC)
+	$(MKDEP) -c $(CC) -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(CFLAGS) $(DEFS) $(INCLS) $(SRC)

--- a/testprogs/Makefile.in
+++ b/testprogs/Makefile.in
@@ -177,4 +177,4 @@ tags: $(TAGFILES)
 	ctags -wtd $(TAGFILES)
 
 depend:
-	$(MKDEP) -c "$(CC)" -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(CFLAGS) $(DEFS) $(INCLS) $(SRC)
+	$(MKDEP) -c $(CC) -m "$(DEPENDENCY_CFLAG)" -s "$(srcdir)" $(CFLAGS) $(DEFS) $(INCLS) $(SRC)


### PR DESCRIPTION
```
Fix an error on Solaris 10 like:
./mkdep: /opt/solarisstudio12.3/bin/cc -D_STDC_C99=: not found

When configure get some compiler option like:
checking for /opt/solarisstudio12.3/bin/cc option to accept ISO C99...
-D_STDC_C99=
Makefile will contain:
CC = /opt/solarisstudio12.3/bin/cc -D_STDC_C99=

And if we use '-c "$(CC)"' mkdep will set and try to run:
CC="/opt/solarisstudio12.3/bin/cc -D_STDC_C99=", which is incorrect.

Remove the quotes to allow mkdep to set CC with the compiler name and
set flags with the option.
```