### PR TITLE
Autoconf: Fix an E_EMPTY_TRANSLATION_UNIT error

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1912,13 +1912,14 @@ return 0;
 		ADDITIONAL_LIBS_STATIC="$ADDITIONAL_LIBS_STATIC $OPENSSL_LIBS_STATIC"
 		LIBS_PRIVATE="$LIBS_PRIVATE $OPENSSL_LIBS_PRIVATE"
 		REQUIRES_PRIVATE="$REQUIRES_PRIVATE $OPENSSL_REQUIRES_PRIVATE"
+		REMOTE_C_SRC="$REMOTE_C_SRC sslutils.c"
 	else
 		AC_MSG_NOTICE(OpenSSL not found)
 	fi
 
 	AC_DEFINE(ENABLE_REMOTE, 1,
 	    [Define to 1 if remote packet capture is to be supported])
-	REMOTE_C_SRC="$REMOTE_C_SRC pcap-rpcap.c rpcap-protocol.c sockutils.c sslutils.c"
+	REMOTE_C_SRC="$REMOTE_C_SRC pcap-rpcap.c rpcap-protocol.c sockutils.c"
 	BUILD_RPCAPD=build-rpcapd
 	INSTALL_RPCAPD=install-rpcapd
 	;;

--- a/rpcapd/Makefile.in
+++ b/rpcapd/Makefile.in
@@ -85,7 +85,7 @@ SRC =	daemon.c \
 	log.c \
 	rpcapd.c
 
-OBJ =	$(SRC:.c=.o) ../rpcap-protocol.o ../sockutils.o ../fmtutils.o ../sslutils.o
+OBJ =	$(SRC:.c=.o)
 PUBHDR =
 
 HDR = $(PUBHDR) log.h


### PR DESCRIPTION
```
Build sslutils.c only if HAVE_OPENSSL is set.

Remark: rpcap-protocol.o, sockutils.o, fmtutils.o and eventually
sslutils.o are prerequisite of libpcap.a thus also for rpcapd.

Fix the following error:

===== SETUP 2: CC=/opt/solarisstudio12.3/bin/suncc CMAKE=no IPV6=no REMOTE=yes =====
[...]
$ make -s CFLAGS=-errwarn=%all -errtags=yes
"sslutils.c", line 34: empty translation unit (E_EMPTY_TRANSLATION_UNIT)
cc: acomp failed for sslutils.c

(It reproduces on OpenCSW unstable10x and Studio 12.3/12.4)
```