### PR TITLE
modify call recvmsg function after check break_loop, with bt-linux and bt-monitor-linux.

### DIFF
--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -339,12 +339,12 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 
 	/* ignore interrupt system call error */
 	do {
-		ret = recvmsg(handle->fd, &msg, 0);
 		if (handle->break_loop)
 		{
 			handle->break_loop = 0;
 			return -2;
 		}
+		ret = recvmsg(handle->fd, &msg, 0);
 	} while ((ret == -1) && (errno == EINTR));
 
 	if (ret < 0) {

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -117,12 +117,12 @@ bt_monitor_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_ch
     msg.msg_controllen = BT_CONTROL_SIZE;
 
     do {
-        ret = recvmsg(handle->fd, &msg, 0);
         if (handle->break_loop)
         {
             handle->break_loop = 0;
             return -2;
         }
+        ret = recvmsg(handle->fd, &msg, 0);
     } while ((ret == -1) && (errno == EINTR));
 
     if (ret < 0) {


### PR DESCRIPTION
it may be block with recvmsg function, after call pcap_breakloop function.