### PR TITLE
bt-linux, bt-monitor-linux: use PCAP_ERROR_ codes.

### DIFF
--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -85,7 +85,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 			return 0;
 		pcapint_fmt_errmsg_for_errno(err_str, PCAP_ERRBUF_SIZE,
 		    errno, "Can't open raw Bluetooth socket");
-		return -1;
+		return PCAP_ERROR;
 	}
 
 	dev_list = malloc(HCI_MAX_DEV * sizeof(*dev_req) + sizeof(*dev_list));
@@ -93,7 +93,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 	{
 		snprintf(err_str, PCAP_ERRBUF_SIZE, "Can't allocate %zu bytes for Bluetooth device list",
 			HCI_MAX_DEV * sizeof(*dev_req) + sizeof(*dev_list));
-		ret = -1;
+		ret = PCAP_ERROR;
 		goto done;
 	}
 
@@ -111,7 +111,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 	{
 		pcapint_fmt_errmsg_for_errno(err_str, PCAP_ERRBUF_SIZE,
 		    errno, "Can't get Bluetooth device list via ioctl");
-		ret = -1;
+		ret = PCAP_ERROR;
 		goto free;
 	}
 
@@ -132,7 +132,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 		 */
 		if (pcapint_add_dev(devlistp, dev_name, PCAP_IF_WIRELESS, dev_descr, err_str)  == NULL)
 		{
-			ret = -1;
+			ret = PCAP_ERROR;
 			break;
 		}
 	}
@@ -342,7 +342,7 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 		if (handle->break_loop)
 		{
 			handle->break_loop = 0;
-			return -2;
+			return PCAP_ERROR_BREAK;
 		}
 		ret = recvmsg(handle->fd, &msg, 0);
 	} while ((ret == -1) && (errno == EINTR));
@@ -354,7 +354,7 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 		}
 		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "Can't receive packet");
-		return -1;
+		return PCAP_ERROR;
 	}
 
 	pkth.caplen = (bpf_u_int32)ret;

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -83,7 +83,7 @@ bt_monitor_findalldevs(pcap_if_list_t *devlistp, char *err_str)
                 PCAP_IF_WIRELESS|PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
                 "Bluetooth Linux Monitor", err_str) == NULL)
     {
-        ret = -1;
+        ret = PCAP_ERROR;
     }
 
     return ret;
@@ -120,7 +120,7 @@ bt_monitor_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_ch
         if (handle->break_loop)
         {
             handle->break_loop = 0;
-            return -2;
+            return PCAP_ERROR_BREAK;
         }
         ret = recvmsg(handle->fd, &msg, 0);
     } while ((ret == -1) && (errno == EINTR));
@@ -132,7 +132,7 @@ bt_monitor_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_ch
         }
         pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
             errno, "Can't receive packet");
-        return -1;
+        return PCAP_ERROR;
     }
 
     pkth.caplen = (bpf_u_int32)(ret - sizeof(hdr) + sizeof(pcap_bluetooth_linux_monitor_header));
@@ -165,7 +165,7 @@ bt_monitor_inject(pcap_t *handle, const void *buf _U_, int size _U_)
 {
     snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
         "Packet injection is not supported yet on Bluetooth monitor devices");
-    return -1;
+    return PCAP_ERROR;
 }
 
 static int


### PR DESCRIPTION
Use them rather than numerical values.