### PR TITLE
thread-local: Add a workaround for building with TinyCC

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -29,6 +29,11 @@ print_cc_version
 # later warnings in the same matrix subset trigger an error.
 # shellcheck disable=SC2221,SC2222
 case `cc_id`/`os_id` in
+tcc-*/*)
+    # At least one warning is expected because TCC does not implement
+    # thread-local storage.
+    LIBPCAP_TAINTED=yes
+    ;;
 *)
     ;;
 esac

--- a/build_common.sh
+++ b/build_common.sh
@@ -63,7 +63,7 @@ print_sysinfo() {
 cc_version_nocache() {
     : "${CC:?}"
     case `basename "$CC"` in
-    gcc*|egcc*|clang*)
+    gcc*|egcc*|clang*|tcc*)
         # GCC and Clang recognize --version, print to stdout and exit with 0.
         "$CC" --version
         ;;
@@ -151,6 +151,17 @@ cc_id_nocache() {
         return
     fi
 
+    # Examples of installed packages:
+    # "tcc version 0.9.27 (x86_64 Linux)"
+    # "tcc version 0.9.27 2023-07-05 mob@5b28165 (x86_64 OpenBSD)"
+    # Example of a development version:
+    # "tcc version 0.9.28rc 2024-04-28 mob@0aca8611 (x86_64 Linux)"
+    cc_id_guessed=`echo "$cc_id_firstline" | sed 's/^.*tcc version \([0-9\.rc]*\).*$/tcc-\1/'`
+    if [ "$cc_id_firstline" != "$cc_id_guessed" ]; then
+        echo "$cc_id_guessed"
+        return
+    fi
+
     # OpenBSD default GCC:
     # "gcc (GCC) 4.2.1 20070719"
     # RedHat GCC:
@@ -187,7 +198,7 @@ discard_cc_cache() {
 # warnings as errors.
 cc_werr_cflags() {
     case `cc_id` in
-    gcc-*|clang-*)
+    gcc-*|clang-*|tcc-*)
         echo '-Werror'
         ;;
     xlc-*)

--- a/thread-local.h
+++ b/thread-local.h
@@ -50,6 +50,9 @@
 #ifndef thread_local
   #if __STDC_VERSION__ >= 201112 && !defined __STDC_NO_THREADS__
     #define thread_local _Thread_local
+  #elif defined __TINYC__
+    #define thread_local
+    #warning "Some libpcap calls will not be thread-safe."
   #elif defined _WIN32 && ( \
          defined _MSC_VER || \
          defined __ICL || \


### PR DESCRIPTION
Some libpcap calls will not be thread-safe. Print a warning.

TinyCC (aka TCC) can be found at https://bellard.org/tcc/,
https://repo.or.cz/r/tinycc.git or as package on some distros.