### PR TITLE
Use always __linux__ for code that uses Linux-specific features

### DIFF
--- a/fad-getad.c
+++ b/fad-getad.c
@@ -58,7 +58,7 @@
  * we end up including both the OS's <net/bpf.h> and our <pcap/bpf.h>,
  * and their definitions of some data structures collide.
  */
-#if (defined(linux) || defined(__Lynx__)) && defined(AF_PACKET)
+#if (defined(__linux__) || defined(__Lynx__)) && defined(AF_PACKET)
 # ifdef HAVE_NETPACKET_PACKET_H
 /* Linux distributions with newer glibc */
 #  include <netpacket/packet.h>
@@ -73,7 +73,7 @@
 #  include <linux/if_packet.h>
 # endif /* __Lynx__ */
 # endif /* HAVE_NETPACKET_PACKET_H */
-#endif /* (defined(linux) || defined(__Lynx__)) && defined(AF_PACKET) */
+#endif /* (defined(__linux__) || defined(__Lynx__)) && defined(AF_PACKET) */
 
 /*
  * This is fun.
@@ -128,7 +128,7 @@ get_sa_len(struct sockaddr *addr)
 		return (sizeof (struct sockaddr_in6));
 #endif
 
-#if (defined(linux) || defined(__Lynx__)) && defined(AF_PACKET)
+#if (defined(__linux__) || defined(__Lynx__)) && defined(AF_PACKET)
 	case AF_PACKET:
 		return (sizeof (struct sockaddr_ll));
 #endif

--- a/gencode.c
+++ b/gencode.c
@@ -61,7 +61,7 @@
 
 #include "scanner.h"
 
-#if defined(linux)
+#if defined(__linux__)
 #include <linux/types.h>
 #include <linux/if_packet.h>
 #include <linux/filter.h>
@@ -8528,7 +8528,7 @@ gen_ifindex(compiler_state_t *cstate, int ifindex)
 		b0 = gen_cmp(cstate, OR_LINKHDR, 4, BPF_W, ifindex);
 		break;
 	default:
-#if defined(linux)
+#if defined(__linux__)
 		/*
 		 * This is Linux; we require PF_PACKET support.
 		 * If this is a *live* capture, we can look at
@@ -8544,11 +8544,11 @@ gen_ifindex(compiler_state_t *cstate, int ifindex)
 		/* match ifindex */
 		b0 = gen_cmp(cstate, OR_LINKHDR, SKF_AD_OFF + SKF_AD_IFINDEX, BPF_W,
 		             ifindex);
-#else /* defined(linux) */
+#else /* defined(__linux__) */
 		bpf_error(cstate, "ifindex not supported on %s",
 		    pcap_datalink_val_to_description_or_dlt(cstate->linktype));
 		/*NOTREACHED*/
-#endif /* defined(linux) */
+#endif /* defined(__linux__) */
 	}
 	return (b0);
 }
@@ -8678,7 +8678,7 @@ gen_inbound(compiler_state_t *cstate, int dir)
 		 * with newer capture APIs, allowing it to be saved
 		 * in pcapng files.
 		 */
-#if defined(linux)
+#if defined(__linux__)
 		/*
 		 * This is Linux; we require PF_PACKET support.
 		 * If this is a *live* capture, we can look at
@@ -8698,11 +8698,11 @@ gen_inbound(compiler_state_t *cstate, int dir)
 			/* to filter on inbound traffic, invert the match */
 			gen_not(b0);
 		}
-#else /* defined(linux) */
+#else /* defined(__linux__) */
 		bpf_error(cstate, "inbound/outbound not supported on %s",
 		    pcap_datalink_val_to_description_or_dlt(cstate->linktype));
 		/*NOTREACHED*/
-#endif /* defined(linux) */
+#endif /* defined(__linux__) */
 	}
 	return (b0);
 }

--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -131,13 +131,13 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 	struct ifreq ifr;
 	int error, fd = d->fd;
 
-#ifdef linux
+#ifdef __linux__
 	fd = socket(AF_INET, SOCK_DGRAM, 0);
 	if (fd < 0) {
 		fprintf(stderr, "Error: cannot get device control socket.\n");
 		return -1;
 	}
-#endif /* linux */
+#endif /* __linux__ */
 	bzero(&ifr, sizeof(ifr));
 	strncpy(ifr.ifr_name, d->req.nr_name, sizeof(ifr.ifr_name));
 	switch (what) {
@@ -192,9 +192,9 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 #endif /* __FreeBSD__ */
 		}
 	}
-#ifdef linux
+#ifdef __linux__
 	close(fd);
-#endif /* linux */
+#endif /* __linux__ */
 	return error ? -1 : 0;
 }
 

--- a/pcap.c
+++ b/pcap.c
@@ -1644,7 +1644,7 @@ pcap_lookupnet(const char *device, bpf_u_int32 *netp, bpf_u_int32 *maskp,
 		return (-1);
 	}
 	memset(&ifr, 0, sizeof(ifr));
-#ifdef linux
+#ifdef __linux__
 	/* XXX Work around Linux kernel bug */
 	ifr.ifr_addr.sa_family = AF_INET;
 #endif
@@ -1675,7 +1675,7 @@ pcap_lookupnet(const char *device, bpf_u_int32 *netp, bpf_u_int32 *maskp,
 	sin4 = (struct sockaddr_in *)&ifr.ifr_addr;
 	*netp = sin4->sin_addr.s_addr;
 	memset(&ifr, 0, sizeof(ifr));
-#ifdef linux
+#ifdef __linux__
 	/* XXX Work around Linux kernel bug */
 	ifr.ifr_addr.sa_family = AF_INET;
 #endif

--- a/testprogs/valgrindtest.c
+++ b/testprogs/valgrindtest.c
@@ -70,7 +70,7 @@ The Regents of the University of California.  All rights reserved.\n";
 #if defined(__APPLE__) || defined(__FreeBSD__) || defined(__NetBSD__) || defined(__OpenBSD__) || defined(__DragonFly__) || defined(_AIX) || defined(sun)
 /* OS with BPF - use BPF */
 #define USE_BPF
-#elif defined(linux)
+#elif defined(__linux__)
 /* Linux - use socket filters */
 #define USE_SOCKET_FILTERS
 #else


### PR DESCRIPTION
See:
https://web.archive.org/web/20231206084513/http://www.faqs.org/docs/Linux-HOWTO/GCC-HOWTO.html#INDEX.25
```
"Use __linux__ for this purpose, not linux. Although the latter is defined, it is not POSIX compliant."

In fact, linux is not always defined:
TinyCC does not define linux, but __linux__.
```