### PR TITLE
funcattrs: Update PCAP_NORETURN/PCAP_NORETURN_DEF definitions condition

### DIFF
--- a/pcap/funcattrs.h
+++ b/pcap/funcattrs.h
@@ -260,13 +260,14 @@
     || PCAP_IS_AT_LEAST_GNUC_VERSION(2,5) \
     || PCAP_IS_AT_LEAST_SUNC_VERSION(5,9) \
     || PCAP_IS_AT_LEAST_XL_C_VERSION(7,0) \
-    || PCAP_IS_AT_LEAST_HP_C_VERSION(6,10)
+    || PCAP_IS_AT_LEAST_HP_C_VERSION(6,10) \
+    || __TINYC__
   /*
    * Compiler with support for __attribute((noreturn)), or GCC 2.5 and
    * later, or some compiler asserting compatibility with GCC 2.5 and
    * later, or Solaris Studio 12 (Sun C 5.9) and later, or IBM XL C 7.0
    * and later (do any earlier versions of XL C support this?), or HP aCC
-   * A.06.10 and later.
+   * A.06.10 and later, or current TinyCC.
    */
   #define PCAP_NORETURN __attribute((noreturn))
   #define PCAP_NORETURN_DEF __attribute((noreturn))


### PR DESCRIPTION
Current TinyCC support __attribute((noreturn)).