### PR TITLE
Add PCAP_ERROR_CAPTURE_NOTSUP error.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,13 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       At build time require a proof of suitable snprintf(3) implementation in
         libc (and document Solaris 9 and MinGW as unsupported because of that).
       Makefile.in: Update the .c.o build rule (Remove hacks for old SunOS 4).
+    BSD, macOS, AIX, Solaris 11, Linux:
+      Add a new error PCAP_ERROR_CAPTURE_NOTSUP, for use if a capture
+        mechanism is not present, in the hopes that, for example,
+        attempts to capture on Windows Services for Linux 1, in which
+        the NT kernel attempts to simulate Linux system calls but does
+        not support packet sockets, can get an error that better
+        indicates the underlying problem.
     Hurd:
       Support network capture devices too.
       Fix a few device activation bugs.

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -553,13 +553,13 @@ bpf_open(char *errbuf)
 		switch (errno) {
 
 		case ENOENT:
-			fd = PCAP_ERROR;
 			if (n == 1) {
 				/*
 				 * /dev/bpf0 doesn't exist, which
 				 * means we probably have no BPF
 				 * devices.
 				 */
+				fd = PCAP_ERROR_CAPTURE_NOTSUP;
 				snprintf(errbuf, PCAP_ERRBUF_SIZE,
 				    "(there are no BPF devices)");
 			} else {
@@ -569,6 +569,7 @@ bpf_open(char *errbuf)
 				 * devices, but all the ones
 				 * that exist are busy.
 				 */
+				fd = PCAP_ERROR;
 				snprintf(errbuf, PCAP_ERRBUF_SIZE,
 				    "(all BPF devices are busy)");
 			}

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -2359,6 +2359,16 @@ setup_socket(pcap_t *handle, int is_any_device)
 			status = PCAP_ERROR_PERM_DENIED;
 			snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
 			    "Attempt to create packet socket failed - CAP_NET_RAW may be required");
+		} else if (errno == EAFNOSUPPORT) {
+			/*
+			 * PF_PACKET sockets not supported.
+			 * Perhaps we're running on the WSL1 module
+			 * in the Windows NT kernel rather than on
+			 * a real Linux kernel.
+			 */
+			status = PCAP_ERROR_CAPTURE_NOTSUP;
+			snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+			    "PF_PACKET sockets not supported - is this WSL1?");
 		} else {
 			/*
 			 * Other error.

--- a/pcap.c
+++ b/pcap.c
@@ -3737,6 +3737,9 @@ pcap_statustostr(int errnum)
 
 	case PCAP_ERROR_TSTAMP_PRECISION_NOTSUP:
 		return ("That device doesn't support that time stamp precision");
+
+	case PCAP_ERROR_CAPTURE_NOTSUP:
+		return ("Packet capture is not supported on that device");
 	}
 	(void)snprintf(ebuf, sizeof ebuf, "Unknown error: %d", errnum);
 	return(ebuf);

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -369,6 +369,7 @@ typedef void (*pcap_handler)(u_char *, const struct pcap_pkthdr *,
 #define PCAP_ERROR_CANTSET_TSTAMP_TYPE	-10	/* this device doesn't support setting the time stamp type */
 #define PCAP_ERROR_PROMISC_PERM_DENIED	-11	/* you don't have permission to capture in promiscuous mode */
 #define PCAP_ERROR_TSTAMP_PRECISION_NOTSUP -12  /* the requested time stamp precision is not supported */
+#define PCAP_ERROR_CAPTURE_NOTSUP	-13	/* capture mechanism not available */
 
 /*
  * Warning codes for the pcap API.

--- a/pcap_activate.3pcap
+++ b/pcap_activate.3pcap
@@ -89,6 +89,9 @@ monitor mode.
 .B PCAP_ERROR_IFACE_NOT_UP
 The capture source device is not up.
 .TP
+.B PCAP_ERROR_CAPTURE_NOTSUP
+Packet capture is not supported on the capture source.
+.TP
 .B PCAP_ERROR
 Another error occurred.
 .BR pcap_geterr ()
@@ -101,8 +104,9 @@ as an argument to fetch or display a message describing the error.
 If
 .BR PCAP_WARNING_PROMISC_NOTSUP ,
 .BR PCAP_ERROR_NO_SUCH_DEVICE ,
+.BR PCAP_ERROR_PERM_DENIED ,
 or
-.B PCAP_ERROR_PERM_DENIED
+.B PCAP_ERROR_CAPTURE_NOTSUP
 is returned,
 .BR pcap_geterr ()
 or


### PR DESCRIPTION
This means "the platform you're on lacks a capture mechanism that supports that device".

This was inspired by some Stack Overflow questions in which the user was probably trying to run a capture program on Windows Services for Linux 1, in which the NT kernel attempts to simulate Linux system calls but does not support packet sockets.

It can, and does, also handle a system in which the BPF capture mechanism is the native capture mechanism but that has no BPF devices.

The hope is that the error message they get will better indicate the underlying problem.