### PR TITLE
Account for rx_dropped packets in linux ifdropped

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -771,9 +771,10 @@ linux_get_stat(const char * if_name, const char * stat) {
 static long long int
 linux_if_drops(const char * if_name)
 {
+	long long int dropped = linux_get_stat(if_name, "rx_dropped");
 	long long int missed = linux_get_stat(if_name, "rx_missed_errors");
 	long long int fifo = linux_get_stat(if_name, "rx_fifo_errors");
-	return missed + fifo;
+	return dropped + missed + fifo;
 }
 
 


### PR DESCRIPTION
Many Linux drivers are not reporting anything into `rx_missed_errors` or `rx_fifo_errors`. They, instead, report dropped packets into `rx_dropped`.

Without including `rx_dropped` into `ps_ifdrop`, we can get a wildly optimistic view of performance.

This particularly affects vmxnet3, enic, ena, cxgb, and cxgb4 drivers.

Issue described in: #1328