### PR TITLE
Changelog and backwards compat notes for VXLAN support

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -28,6 +28,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Add support for Block Ack Req and Block Ack frame types (pull
         request #1039).
       Deprecate pcap_compile_nopcap().
+      Add support for filtering packets encapsulated with VXLAN (pull
+        request #1273).
     Savefiles:
       Reject pcap files where one of the reserved fields in the
         "link-layer type plus other stuff" is non-zero.

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -18,7 +18,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP-FILTER @MAN_MISC_INFO@ "12 February 2024"
+.TH PCAP-FILTER @MAN_MISC_INFO@ "9 July 2024"
 .SH NAME
 pcap-filter \- packet filter syntax
 .br
@@ -1196,6 +1196,10 @@ keyword became available in libpcap 1.8.0.
 The
 .B ifindex
 keyword became available in libpcap 1.10.0.
+.PP
+The
+.B vxlan
+keyword became available in libpcap 1.11.0.
 .SH SEE ALSO
 .BR pcap (3PCAP)
 .SH BUGS


### PR DESCRIPTION
Following up  #1273, this change adds a backwards compatibility note to the `pcap-filter` manual page for the `vxlan` keyword, and adds an entry to the changelog for this feature.