### PR TITLE
Appveyor: Download WpdPack_4_1_2.zip archive from our repository

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,6 +13,8 @@ install:
   - choco install winflexbison
   - win_flex --version
   - win_bison --version
+  - appveyor DownloadFile https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+  - 7z x .\WpdPack_4_1_2.zip -oc:\projects\libpcap\Win32
   - appveyor DownloadFile https://npcap.com/dist/npcap-sdk-1.13.zip
   - 7z x .\npcap-sdk-1.13.zip -oc:\projects\libpcap\Win32\npcap-sdk
   - appveyor DownloadFile https://support.riverbed.com/bin/support/download?sid=l3vk3eu649usgu3rj60uncjqqu -FileName AirPcap_Devpack.zip
@@ -28,11 +30,22 @@ environment:
   #
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      GENERATOR: "Visual Studio 14 2015 Win64"
+      SDK: WpdPack
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: "Visual Studio 14 2015"
       SDK: npcap-sdk
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
       GENERATOR: "Visual Studio 14 2015 Win64"
       SDK: npcap-sdk
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: "Visual Studio 15 2017"
+      SDK: WpdPack
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: "Visual Studio 15 2017 Win64"
+      SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
@@ -46,6 +59,18 @@ environment:
       GENERATOR: "Visual Studio 15 2017 Win64"
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: "Visual Studio 16 2019"
+      PLATFORM: Win32
+      SDK: WpdPack
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
+      GENERATOR: "Visual Studio 16 2019"
+      PLATFORM: x64
+      SDK: WpdPack
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=NO
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: Win32

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ install:
   - choco install winflexbison
   - win_flex --version
   - win_bison --version
-  - appveyor DownloadFile https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
+  - appveyor DownloadFile https://github.com/the-tcpdump-group/WinPcap_Dev_Pack_mirror/raw/master/WpdPack_4_1_2.zip
   - 7z x .\WpdPack_4_1_2.zip -oc:\projects\libpcap\Win32
   - appveyor DownloadFile https://npcap.com/dist/npcap-sdk-1.13.zip
   - 7z x .\npcap-sdk-1.13.zip -oc:\projects\libpcap\Win32\npcap-sdk


### PR DESCRIPTION
The goal is to avoid this type of error with AppVeyor builds:
appveyor DownloadFile https://www.winpcap.org/install/bin/WpdPack_4_1_2.zip
Error downloading remote file: One or more errors occurred.
Inner Exception: The request was aborted: Could not create SSL/TLS
  secure channel.
Command exited with code 2