### PR TITLE
Don't increment packet buffer pointers past the end of the data.

### DIFF
--- a/pcap-int.h
+++ b/pcap-int.h
@@ -240,7 +240,7 @@ struct pcap {
 	u_int bufsize;
 	u_char *buffer;
 	u_char *bp;
-	int cc;
+	u_int cc;
 
 	sig_atomic_t break_loop; /* flag set to force break from packet-reading loop */
 
@@ -267,7 +267,7 @@ struct pcap {
 	int snapshot;
 	int linktype;		/* Network linktype */
 	int linktype_ext;	/* Extended information stored in the linktype field of a file */
-	int offset;		/* offset for proper alignment */
+	u_int offset;		/* offset for proper alignment */
 	int activated;		/* true if the capture is really started */
 	int oldstyle;		/* if we're opening with pcap_open_live() */
 

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -3658,7 +3658,7 @@ static int rpcap_discard(PCAP_SOCKET sock, SSL *ssl, uint32_t len, char *errbuf)
 static int rpcap_read_packet_msg(struct pcap_rpcap const *rp, pcap_t *p, size_t size)
 {
 	u_char *bp;
-	int cc;
+	u_int cc;
 	int bytes_read;
 
 	bp = p->bp;
@@ -3668,7 +3668,7 @@ static int rpcap_read_packet_msg(struct pcap_rpcap const *rp, pcap_t *p, size_t 
 	 * Loop until we have the amount of data requested or we get
 	 * an error or interrupt.
 	 */
-	while ((size_t)cc < size)
+	while (cc < size)
 	{
 		/*
 		 * We haven't read all of the packet header yet.


### PR DESCRIPTION
For the BPF, Airpcap, and NPF (WinPcap/Npcap) capture mechanisms, each  entry in the buffer read from the capture mechanism is aligned on a word boundary, for some value of "word".  This means that all entries *except for the last of them* has padding at the end.

If we have bp as a pointer to the current entry and ep as a pointer to the end of the buffer, calculated by adding the number of bytes read to a (byte) pointer to the beginning of the buffer, and loop as long as bp < ep, incrementing bp by the length of the entry with padding added, this will put bp *past* the end of the buffer for the last entry, as the last entry lacks padding.

Instead, compute the minimum of the rounded-up length of the entry and the space remaining in the buffer (ep - bp), which means that value will not include padding for the last entry in the buffer, and add that to bp after processing a packet.  That ensures that bp will not go past ep.

This addresses the issue mentioned in pull request #1339.

(That issue is unlikely to be a problem, in practice, in any platform on which we run, but we should fix it anyway.)

We also change the type of the count of bytes in the buffer to a u_int, which also means we change the stored count in a pcap_t and variables to which that's assigned, as well as some other variables, and rewrite some code to reflect that.