### PR TITLE
Check return value of `opendir` in `pcap_findalldevs_ex` to avoid a null pointer deref

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -4829,18 +4829,19 @@ pcap_findalldevs_ex(const char *source, struct pcap_rmtauth *auth _USED_FOR_REMO
 		if (unixdir == NULL) {
 			DIAG_OFF_FORMAT_TRUNCATION
 			snprintf(errbuf, PCAP_ERRBUF_SIZE,
-			    "Error when listing files: does folder '%s' exist?", path);
+			    "Error when listing files in '%s': %s", path, pcap_strerror(errno));
 			DIAG_ON_FORMAT_TRUNCATION
 			return (PCAP_ERROR);
 		}
 
 		/* get the first file into it */
+		errno = 0;
 		filedata= readdir(unixdir);
 
 		if (filedata == NULL) {
 			DIAG_OFF_FORMAT_TRUNCATION
 			snprintf(errbuf, PCAP_ERRBUF_SIZE,
-			    "Error when listing files: does folder '%s' contain files?", path);
+			    "Error when listing files in '%s': %s", path, pcap_strerror(errno));
 			DIAG_ON_FORMAT_TRUNCATION
 			closedir(unixdir);
 			return (PCAP_ERROR);

--- a/pcap.c
+++ b/pcap.c
@@ -4826,6 +4826,13 @@ pcap_findalldevs_ex(const char *source, struct pcap_rmtauth *auth _USED_FOR_REMO
 #else
 		/* opening the folder */
 		unixdir= opendir(path);
+		if (unixdir == NULL) {
+			DIAG_OFF_FORMAT_TRUNCATION
+			snprintf(errbuf, PCAP_ERRBUF_SIZE,
+			    "Error when listing files: does folder '%s' exist?", path);
+			DIAG_ON_FORMAT_TRUNCATION
+			return (PCAP_ERROR);
+		}
 
 		/* get the first file into it */
 		filedata= readdir(unixdir);
@@ -4833,7 +4840,7 @@ pcap_findalldevs_ex(const char *source, struct pcap_rmtauth *auth _USED_FOR_REMO
 		if (filedata == NULL) {
 			DIAG_OFF_FORMAT_TRUNCATION
 			snprintf(errbuf, PCAP_ERRBUF_SIZE,
-			    "Error when listing files: does folder '%s' exist?", path);
+			    "Error when listing files: does folder '%s' contain files?", path);
 			DIAG_ON_FORMAT_TRUNCATION
 			closedir(unixdir);
 			return (PCAP_ERROR);


### PR DESCRIPTION
These commits fix an issue first reported to security@tcpdump.org. 

Since there were no check on the return value of `opendir`  in [`pcap_findalldevs_ex`](https://github.com/the-tcpdump-group/libpcap/blob/269f6104efcc53d0e009c94e0221658b0a4572ab/pcap.c#L4828), the next call to `readdir` could trigger a null pointer dereference resulting in a SegFault. 

PoC:
```C
char  errbuf[PCAP_ERRBUF_SIZE] = { 0 };
pcap_if_t *allDevs;
int ret = pcap_findalldevs_ex("file://non_existing_file", NULL, &allDevs, errbuf);
```
Thanks for the great library and all the hours spent graciously working on it!

Found by @tregua87 