### PR TITLE
Autoconf: Move AC_SYS_LARGEFILE and AC_FUNC_FSEEKO

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -112,6 +112,12 @@ if test "$ac_cv_prog_cc_c99" = "no"; then
 fi
 
 #
+# Try to arrange for large file support.
+#
+AC_SYS_LARGEFILE
+AC_FUNC_FSEEKO
+
+#
 # Get the size of a void *, to determine whether this is a 32-bit
 # or 64-bit build.
 #
@@ -126,12 +132,6 @@ AC_CHECK_SIZEOF([time_t],,[#include <time.h>])
 AC_LBL_C_INIT(V_CCOPT, V_INCLS)
 AC_LBL_SHLIBS_INIT
 AC_PCAP_C___ATOMICS
-
-#
-# Try to arrange for large file support.
-#
-AC_SYS_LARGEFILE
-AC_FUNC_FSEEKO
 
 dnl
 dnl HAVE_SYS_IOCCOM_H will be required for a few workarounds until all


### PR DESCRIPTION
This change puts them ahead of
"AC_CHECK_SIZEOF([time_t],,[#include <time.h>])"

So, in a future update, AC_SYS_LARGEFILE could be replaced by AC_SYS_YEAR2038_RECOMMENDED for ensuring time_t is Y2038-safe.
(With Autoconf version >= 2.72 and GNU C Library version >= 2.34)