### PR TITLE
Call WSAStartup and WSACleanup for each use. Fixes #1333

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -726,9 +726,6 @@ int
 pcap_compile(pcap_t *p, struct bpf_program *program,
 	     const char *buf, int optimize, bpf_u_int32 mask)
 {
-#ifdef _WIN32
-	static int done = 0;
-#endif
 	compiler_state_t cstate;
 	const char * volatile xbuf = buf;
 	yyscan_t scanner = NULL;
@@ -746,12 +743,9 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 		return (PCAP_ERROR);
 	}
 
-#ifdef _WIN32
-	if (!done) {
-		pcap_wsockinit();
-		done = 1;
+	if(0 != pcapint_sockinit()) {
+		return (PCAP_ERROR);
 	}
-#endif
 
 #ifdef ENABLE_REMOTE
 	/*
@@ -874,6 +868,8 @@ quit:
 	 * Clean up our own allocated memory.
 	 */
 	freechunks(&cstate);
+
+	pcapint_sockcleanup();
 
 	return (rc);
 }

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -1080,9 +1080,6 @@ pcap_activate_npf(pcap_t *p)
 		}
 	}
 
-	/* Init Winsock if it hasn't already been initialized */
-	pcap_wsockinit();
-
 	pw->adapter = PacketOpenAdapter(p->opt.device);
 
 	if (pw->adapter == NULL)

--- a/pcap.3pcap.in
+++ b/pcap.3pcap.in
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP 3PCAP "4 March 2024"
+.TH PCAP 3PCAP "18 September 2024"
 .SH NAME
 pcap \- Packet Capture library
 .SH SYNOPSIS
@@ -72,15 +72,7 @@ makes an attempt to check whether the string passed as an argument is a
 UTF-16LE string - note that this attempt is unsafe, as it may run past
 the end of the string - to handle
 .BR pcap_lookupdev ()
-returning a UTF-16LE string. Programs that don't call
-.BR pcap_init ()
-should, on Windows, call
-.BR pcap_wsockinit ()
-to initialize Winsock; this is not necessary if
-.BR pcap_init ()
-is called, as
-.BR pcap_init ()
-will initialize Winsock itself on Windows.
+returning a UTF-16LE string.
 .TP
 .B Routines
 .RS

--- a/pcap_init.3pcap
+++ b/pcap_init.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_INIT 3PCAP "30 November 2023"
+.TH PCAP_INIT 3PCAP "18 September 2024"
 .SH NAME
 pcap_init \- initialize the library
 .SH SYNOPSIS
@@ -76,15 +76,7 @@ makes an attempt to check whether the string passed as an argument is a
 UTF-16LE string - note that this attempt is unsafe, as it may run past
 the end of the string - to handle
 .BR pcap_lookupdev ()
-returning a UTF-16LE string. Programs that don't call
-.BR pcap_init ()
-should, on Windows, call
-.BR pcap_wsockinit ()
-to initialize Winsock; this is not necessary if
-.BR pcap_init ()
-is called, as
-.BR pcap_init ()
-will initialize Winsock itself on Windows.
+returning a UTF-16LE string.
 .SH RETURN VALUE
 .BR pcap_init ()
 returns

--- a/portability.h
+++ b/portability.h
@@ -157,7 +157,25 @@ extern int pcapint_vasprintf(char **, PCAP_FORMAT_STRING(const char *), va_list 
   #if !defined(__cplusplus)
     #define inline __inline
   #endif
+#include <winsock2.h>
 #endif /* _WIN32 */
+
+static inline int pcapint_sockinit(void)
+{
+#ifdef _WIN32
+  WSADATA wsaData;
+  return WSAStartup(MAKEWORD(2,2), &wsaData);
+#else
+  return 0;
+#endif /* _WIN32 */
+}
+
+static inline void pcapint_sockcleanup(void)
+{
+#ifdef _WIN32
+  WSACleanup();
+#endif /* _WIN32 */
+}
 
 #ifdef __cplusplus
 }

--- a/rpcapd/log.c
+++ b/rpcapd/log.c
@@ -26,6 +26,9 @@
 #include <stdlib.h>
 
 #ifdef _WIN32
+/* Prevent inclusion of winsock.h, which causes redefinition errors when
+ * winsock2.h is included later */
+#define WIN32_LEAN_AND_MEAN
 #include <windows.h>
 #else
 #include <syslog.h>

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -221,8 +221,10 @@ main(int argc, char **argv)
 	struct bpf_program fcode;
 
 #ifdef _WIN32
-	if (pcap_wsockinit() != 0)
+	WSADATA wsaData;
+	if (0 != WSAStartup(MAKEWORD(2, 2), &wsaData))
 		return 1;
+	atexit ((void(*)(void))WSACleanup);
 #endif /* _WIN32 */
 
 	dflag = 1;


### PR DESCRIPTION
`WSACleanup` cannot be called from `atexit()` because that's run in `DllMain` context. Instead, start and cleanup at each use, using existing reference counting functions from `sockutils.c`.

Performance impact ought to be small because these are not frequently-called functions in the lifetime of a capture handle, and because `WSAStartup`/`WSACleanup` are essentially just reference increment/decrement in the common case of an application that has already called `WSAStartup`.

I believe this commit covers all likely situations, with one unlikely exception: the functions in `nametoaddr.c` are exported by the library, though they are not documented in the manpages. They are only called internally from functions within `gencode.c` which should be handled by the startup/cleanup calls in `pcap_compile()`, and I have not found any applications on Github that call them directly. If any application had previously called them directly, relying on `pcap_init()` to call `WSAStartup()`, then that code would need to be changed to call `WSAStartup()` itself. I couldn't just add startup/cleanup within each function in `nametoaddr.c` because several of them return static buffers allocated by Winsock functions, which I assume could be invalidated by calling `WSACleanup()`.