### PR TITLE
cmake: treat building for another ISA as a cross-compile.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -636,6 +636,28 @@ else (USE_STATIC_RT)
     message(STATUS "Use DYNAMIC runtime")
 endif(USE_STATIC_RT)
 
+#
+# CMake's definition of "cross-compiling" appears to be "compiling
+# for an *operating system* other than the one on which the build
+# is being done*.
+#
+# This is an inadequate definition, as people build for the same
+# operating system but a different instruciton set, e.g. building
+# on an IA-32 or x86-64 Linux box for an Arm embedded Linux box,
+# or building Arm code on an IA-32 or x86-64 Windows box.
+#
+# At least for the Windows case, people may do those builds by
+# setting the target with th -A flag to CMake; that causes
+# CMAKE_GENERATOR_PLATFORM to be set to the target.  If
+# CMAKE_GENERATOR_PLATFORM is set, compare it with
+# CMAKE_HOST_SYSTEM_PROCESSOR and, if they're not equal, set
+# CMAKE_CROSSCOMPILING to TRUE.
+#
+if (CMAKE_GENERATOR_PLATFORM AND
+    NOT CMAKE_GENERATOR_PLATFORM STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
+    set(CMAKE_CROSSCOMPILING TRUE)
+endif()
+
 ###################################################################
 #   Detect available platform features
 ###################################################################


### PR DESCRIPTION
CMake appears to have the notion that a build is only a cross-compile if the targt *operating system* is different.  This is an incorrect notion, as even if the target is the *same* OS but a different instruction set, you may not be able to do tests that involve compiling and running a program.

Check whether CMAKE_GENERATOR_PLATFORM is set and has a value different from that of CMAKE_HOST_SYSTEM_PROCESSOR and, if that's the case, set CMAKE_CROSSCOMPILING to TRUE.

This should fix issue #1352.

(A different strategy may be necessary for cross-builds with UNIX toolchains.)