### PR TITLE
dbus: fix message leak

### DIFF
--- a/pcap-dbus.c
+++ b/pcap-dbus.c
@@ -80,6 +80,7 @@ dbus_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char *us
 
 	if (dbus_message_is_signal(message, DBUS_INTERFACE_LOCAL, "Disconnected")) {
 		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE, "Disconnected");
+		dbus_message_unref(message);
 		return -1;
 	}
 
@@ -97,6 +98,9 @@ dbus_read(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char *us
 
 		dbus_free(raw_msg);
 	}
+
+	dbus_message_unref(message);
+
 	return count;
 }
 


### PR DESCRIPTION
`dbus_connection_pop_message()` transfers a reference to the caller. For the message to be properly disposed of, the caller must drop this transferred reference after it has finished using the returned message object.

Previously this was not done, resulting in every single D-Bus message (including file descriptors) being leaked. Fix that by simply calling `dbus_message_unref()` at the appropriate places.