### PR TITLE
DAG: Add experimental packet transmit support.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -89,6 +89,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Remove FCS quirks specific to 4.2S and 4.23S.
       Fix packet filtering with low snaplen.
       Fix ps_drop for stream drop counters.
+      Add experimental packet transmit support.
     SNF:
       Fix packet filtering with low snaplen.
       Require SNF_VERSION_API >= 0x0003.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,7 @@ endif(APPLE)
 option(DISABLE_RDMA "Disable RDMA sniffing support" OFF)
 
 option(DISABLE_DAG "Disable Endace DAG card support" OFF)
+option(ENABLE_DAG_TX "Enable Endace DAG transmit support" OFF)
 
 option(DISABLE_SEPTEL "Disable Septel card support" OFF)
 set(SEPTEL_ROOT "${CMAKE_CURRENT_SOURCE_DIR}/../septel" CACHE PATH "Path to directory with include and lib subdirectories for Septel API")
@@ -2625,6 +2626,11 @@ if(NOT DISABLE_DAG)
             set(LIBS_STATIC "${LIBS_STATIC} ${CMAKE_THREAD_LIBS_INIT}")
             set(LIBS_PRIVATE "${LIBS_PRIVATE} ${CMAKE_THREAD_LIBS_INIT}")
         endif()
+
+        if(ENABLE_DAG_TX)
+            set(ENABLE_DAG_TX TRUE)
+        endif()
+        message(STATUS "Endace DAG transmit support (EXPERIMENTAL): ${ENABLE_DAG_TX}")
     endif()
 endif()
 

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -30,6 +30,9 @@
 /* define if you have vdag_set_device_info() */
 #cmakedefine HAVE_DAG_VDAG 1
 
+/* Define to 1 if DAG transmit support is enabled */
+#cmakedefine ENABLE_DAG_TX 1
+
 /* Define to 1 if you have the declaration of `ether_hostton' */
 #cmakedefine HAVE_DECL_ETHER_HOSTTON 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -1418,6 +1418,17 @@ if test "$want_dag" != no; then
 		AC_MSG_NOTICE([using Endace DAG API headers from $dag_include_dir])
 		AC_MSG_NOTICE([using Endace DAG API libraries from $dag_lib_dir])
 		AC_DEFINE(HAVE_DAG_API, 1, [define if you have the DAG API])
+
+		AC_MSG_CHECKING([whether to enable Endace DAG transmit support (EXPERIMENTAL)])
+		AC_ARG_ENABLE(dag-tx,
+			AS_HELP_STRING([--enable-dag-tx],
+				[enable Endace DAG transmit support (EXPERIMENTAL) @<:@default=no@:>@]
+			)
+		)
+		if test "$enable_dag_tx" = "yes"; then
+			AC_DEFINE(ENABLE_DAG_TX, 1, [Define to 1 if DAG transmit support is enabled])
+		fi
+		AC_MSG_RESULT(${enable_dag_tx-no})
 	else
 		if test "$V_PCAP" = dag; then
 			# User requested "dag" capture type but we couldn't

--- a/doc/README.dag.md
+++ b/doc/README.dag.md
@@ -88,7 +88,31 @@ buffer size is user configurable outside libpcap, typically 16-512MB.
 `pcap_get_selectable_fd()` is not supported, as DAG cards do not support
 `poll()`/`select()` methods.
 
-`pcap_inject()` and `pcap_sendpacket()` are not supported.
+`pcap_inject()` and `pcap_sendpacket()` are supported under certain conditions.
+Endace DAG transmit support in libpcap is an experimental feature, it has been
+tested for Ethernet only and is disabled by default.  To enable it, add
+`--enable-dag-tx` to the `configure` script arguments or `-DENABLE_DAG_TX=yes`
+to `cmake` arguments.
+
+The transmit support will work as expected if:
+* the packets are Ethernet frames w/o FCS (the usual in libpcap), and
+* the card's transmitting port is adding 32-bit FCS to outgoing Ethernet
+  frames (usually the default configuration).
+
+The DAG device may be configured to expect FCS in the packets supplied for
+sending and to strip it before adding a new FCS (usually the default
+configuration) or to expect the packets to have no FCS.  `pcap_activate()`
+automatically detects this configuration and subsequently `pcap_inject()`
+composes the Ethernet frame to match what the card is expecting.  If the card
+configuration changes after the call to `pcap_activate()`, things will break.
+
+To transmit packets from an interface (a port on the DAG card) other than the
+default 0 (port A), set the `ERF_TX_INTERFACE` environment variable to the
+number of the required interface before calling `pcap_activate()`.  For
+example, `ERF_TX_INTERFACE=1` uses port B.
+
+This feature has been tested on DAG 7.5G2 and DAG 9.2X2, other models may or
+may not work.
 
 ## Other considerations
 


### PR DESCRIPTION
Here is the first version after clean-ups. It works if used correctly, but still has a few rough edges. Also it makes it easier to see where the current libpcap API is not a perfect fit for a mix of Rx-only and Tx-only devices.

It is not clear if it would be better to reuse the Rx FCS environment variables for Tx, or to query the card for the current parameters to minimise user intervention, or maybe to justify introducing C functions into the API to query/set FCS settings on a `pcap_t`.

Likewise, in this revision libpcap returns an error rather late: from `pcap_read()` when trying to capture from a Tx-only stream and from `pcap_inject()` when trying to transmit into an Rx-only stream.  It would be better to have feedback right from `pcap_activate()` (something such as `PCAP_ERROR_SENDING_NOTSUP`), which would in this case depend on the user declaring the mode of use before the activation by calling a new function such as `pcap_set_device_mode()`, which would change the default "capture and inject" to "capture only" or "inject only".  Alternatively, there could be a function to query the device capabilities.  This certainly requires more thought before implementing anything.

DAG API may be a convenient use case for testing new functions for multiple-packet transmission (Guy [refers](https://npcap.com/guide/npcap-api.html) to Npcap `pcap_sendqueue_*()` functions as a potential model).