### PR TITLE
Cirrus CI: Update the macOS task image

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,7 +43,7 @@ macos_task:
   name: macos-aarch64
   only_if: $CIRRUS_BRANCH != 'coverity_scan'
   macos_instance:
-    image: ghcr.io/cirruslabs/macos-ventura-xcode:14.1 # macOS 13 with Xcode 14.1
+    image: ghcr.io/cirruslabs/macos-runner:sonoma # last 3 versions of Xcode
   env:
     MAKEFLAGS: '-j 4' # macOS VMs run on 4 cores
   script:


### PR DESCRIPTION
Based on https://cirrus-ci.org/guide/macOS/.

This will avoid the warning:
Only ghcr.io/cirruslabs/macos-runner:sonoma is allowed. Automatically upgraded.