### PR TITLE
CMake: fix to support CMake 3.31.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,14 +13,21 @@ else(WIN32)
     #  on a "long-term support" version # of some OS and that
     #  version supplies an older version of CMake;
     #
-    #  otherwise, require 3.5, so we don't get messages warning
-    #  that support for versions of CMake lower than 3.5 is
+    #  otherwise, if it's a version less than 3.10, require only
+    #  3.10, just in case somebody is configuring with CMake
+    #  on a "long-term support" version # of some OS and that
+    #  version supplies an older version of CMake;
+    #
+    #  otherwise, require 3.10, so we don't get messages warning
+    #  that support for versions of CMake lower than 3.10 is
     #  deprecated.
     #
     if(CMAKE_VERSION VERSION_LESS "3.5")
         cmake_minimum_required(VERSION 2.8.12)
-    else()
+    elseif(CMAKE_VERSION VERSION_LESS "3.10")
         cmake_minimum_required(VERSION 3.5)
+    else()
+        cmake_minimum_required(VERSION 3.10)
     endif()
 endif(WIN32)
 
@@ -2952,7 +2959,6 @@ endif()
 
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/scanner.c ${CMAKE_CURRENT_BINARY_DIR}/scanner.h
-    SOURCE ${pcap_SOURCE_DIR}/scanner.l
     COMMAND ${LEX_EXECUTABLE} -P pcap_ --header-file=scanner.h --nounput -o${CMAKE_CURRENT_BINARY_DIR}/scanner.c ${pcap_SOURCE_DIR}/scanner.l
     DEPENDS ${pcap_SOURCE_DIR}/scanner.l
 )
@@ -3027,7 +3033,6 @@ message(STATUS "Parser generator: ${YACC_EXECUTABLE}")
 #
 add_custom_command(
     OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/grammar.c ${CMAKE_CURRENT_BINARY_DIR}/grammar.h
-    SOURCE ${pcap_BINARY_DIR}/grammar.y
     COMMAND ${YACC_EXECUTABLE} -p pcap_ -o ${CMAKE_CURRENT_BINARY_DIR}/grammar.c -d ${pcap_BINARY_DIR}/grammar.y
     DEPENDS ${pcap_BINARY_DIR}/grammar.y
 )


### PR DESCRIPTION
1) remove SOURCE parameter from add_custom_command().

It was never a valid parameter, but, prior to CMake 3.31, it was silently ignored.  In 3.31 and later, it's treated as an error by default.

See
https://github.com/the-tcpdump-group/libpcap/pull/1380#issuecomment-2471731576
for a case where this breaks something.

2) expand the "still support old versions of CMake, for the benefit of people with older versions, but avoid deprecation warnings/errors" section to handle the deprecation of pre-3.10 versions by 3.31.