### PR TITLE
Indicate no-capture and no-inject devices.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -23,6 +23,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Return more useful strings from pcap_statustostr().
       Rename SWAPSHORT(), SWAPLONG(), SWAPLL() to PCAP_BSWAP_({16,32,64}).
       Replace EXTRACT_SHORT by EXTRACT_BE_U_2, EXTRACT_LONG by EXTRACT_BE_U_4.
+      Indicate no-capture and no-inject devices.
     Link-layer types:
       Add LINKTYPE_DECT_NR_TAP/DLT_DECT_NR_TAP.
     Packet filtering:

--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -131,6 +131,7 @@ bt_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 		 * or PCAP_IF_CONNECTION_STATUS_DISCONNECTED.
 		 */
 		if (pcapint_add_dev(devlistp, dev_name,
+		    PCAP_IF_NO_INJECT |
 		    PCAP_IF_WIRELESS,
 		    dev_descr, err_str)  == NULL)
 		{

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -81,6 +81,7 @@ bt_monitor_findalldevs(pcap_if_list_t *devlistp, char *err_str)
      */
     if (pcapint_add_dev(devlistp, INTERFACE_NAME,
                 PCAP_IF_WIRELESS |
+                PCAP_IF_NO_INJECT |
                 PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
                 "Bluetooth Linux Monitor", err_str) == NULL)
     {

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -1427,6 +1427,22 @@ dag_stream_long_description(char *strbuf, const size_t strbufsize,
 		    inf->bus_id);
 }
 
+static uint32_t
+dag_flags(const int stream)
+{
+	/*
+	 * A DAG card associates a link status with each physical port, but not
+	 * with the data streams.  The number of ports is a matter of hardware,
+	 * the number of streams and how each stream associates with zero or
+	 * more ports is a matter of how the user configures the card.  In this
+	 * context libpcap uses the streams only (i.e. "dag0" is a shorthand
+	 * for "dag0:0"), thus the notion of link status does not apply to the
+	 * resulting libpcap DAG capture devices.
+	 */
+	return PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE |
+	    (RX_ONLY(stream) ? PCAP_IF_NO_INJECT : PCAP_IF_NO_CAPTURE);
+}
+
 /*
  * Add all DAG devices.
  * This excludes vDAG Tx streams, which libpcap cannot use.
@@ -1438,14 +1454,6 @@ dag_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 	int dagfd;
 	char description[256];
 	int stream, rxstreams;
-	// A DAG card associates a link status with each physical port, but not
-	// with the data streams.  The number of ports is a matter of hardware,
-	// the number of streams and how each stream associates with zero or
-	// more ports is a matter of how the user configures the card.  In this
-	// context libpcap uses the streams only (i.e. "dag0" is a shorthand
-	// for "dag0:0"), thus the notion of link status does not apply to the
-	// resulting libpcap DAG capture devices.
-	const bpf_u_int32 flags = PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE;
 	FILE * sysfsinfo = NULL;
 
 	/* Try all the DAGs 0-DAG_MAX_BOARDS */
@@ -1504,6 +1512,7 @@ dag_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 				if (bufsize > 0 &&
 				    (RX_ONLY(stream) || inf->device_code != PCI_DEVICE_ID_VDAG)) {
 					dag_device_description(description, sizeof(description), c);
+					const uint32_t flags = dag_flags(stream);
 					// a conditional shorthand device
 					if (stream == 0 &&
 					    pcapint_add_dev(devlistp, name, flags, description, errbuf) == NULL)
@@ -1548,6 +1557,7 @@ dag_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
 						if (TX_ONLY(stream) && c >= 16 && c <= 31)
 							continue;
 #endif // ENABLE_DAG_TX
+						const uint32_t flags = dag_flags(stream);
 						// a conditional shorthand device
 						dag_device_description(description, sizeof(description), c);
 						if (stream == 0 &&

--- a/pcap-haiku.c
+++ b/pcap-haiku.c
@@ -452,6 +452,8 @@ get_if_flags(const char *name, bpf_u_int32 *flags, char *errbuf)
 	if (validate_ifname(name, errbuf) < 0)
 		return PCAP_ERROR;
 
+	*flags |= PCAP_IF_NO_INJECT;
+
 	if (*flags & PCAP_IF_LOOPBACK ||
 	    ! strncmp(name, "tun", strlen("tun")) ||
 	    ! strncmp(name, "tap", strlen("tap"))) {

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -798,10 +798,12 @@ netfilter_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 	 * XXX - what about "up" and "running"?
 	 */
 	if (pcapint_add_dev(devlistp, NFLOG_IFACE,
+	    PCAP_IF_NO_INJECT |
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 	    "Linux netfilter log (NFLOG) interface", err_str) == NULL)
 		return -1;
 	if (pcapint_add_dev(devlistp, NFQUEUE_IFACE,
+	    PCAP_IF_NO_INJECT |
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 	    "Linux netfilter queue (NFQUEUE) interface", err_str) == NULL)
 		return -1;

--- a/pcap-rdmasniff.c
+++ b/pcap-rdmasniff.c
@@ -741,7 +741,9 @@ rdmasniff_findalldevs(pcap_if_list_t *devlistp, char *err_str)
 		 * XXX - do the notions of "up", "running", or
 		 * "connected" apply here?
 		 */
-		if (!pcapint_add_dev(devlistp, dev_list[i]->name, 0, "RDMA sniffer", err_str)) {
+		if (!pcapint_add_dev(devlistp, dev_list[i]->name,
+		    PCAP_IF_NO_INJECT,
+		    "RDMA sniffer", err_str)) {
 			ret = PCAP_ERROR;
 			break;
 		}

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -152,6 +152,7 @@ usb_dev_add(pcap_if_list_t *devlistp, int n, char *err_str)
 		 * that would apply to a particular USB interface.
 		 */
 		if (pcapint_add_dev(devlistp, dev_name,
+		    PCAP_IF_NO_INJECT |
 		    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 		    "Raw USB traffic, all USB buses", err_str) == NULL)
 			return -1;
@@ -163,7 +164,9 @@ usb_dev_add(pcap_if_list_t *devlistp, int n, char *err_str)
 		 * PCAP_IF_CONNECTION_STATUS_DISCONNECTED?
 		 */
 		snprintf(dev_descr, sizeof(dev_descr), "Raw USB traffic, bus number %d", n);
-		if (pcapint_add_dev(devlistp, dev_name, 0, dev_descr, err_str) == NULL)
+		if (pcapint_add_dev(devlistp, dev_name,
+		    PCAP_IF_NO_INJECT,
+		    dev_descr, err_str) == NULL)
 			return -1;
 	}
 

--- a/pcap.c
+++ b/pcap.c
@@ -1396,6 +1396,7 @@ pcapint_add_any_dev(pcap_if_list_t *devlistp, char *errbuf)
 	return pcapint_add_dev(devlistp, "any",
 	    PCAP_IF_UP |
 	    PCAP_IF_RUNNING |
+	    PCAP_IF_NO_INJECT |
 	    PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE,
 	    any_descr, errbuf);
 }

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -336,6 +336,8 @@ struct pcap_if {
 #define PCAP_IF_CONNECTION_STATUS_CONNECTED		0x00000010	/* connected */
 #define PCAP_IF_CONNECTION_STATUS_DISCONNECTED		0x00000020	/* disconnected */
 #define PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE	0x00000030	/* not applicable */
+#define PCAP_IF_NO_CAPTURE				0x00000040	/* a no-capture device */
+#define PCAP_IF_NO_INJECT				0x00000080	/* a no-inject device */
 
 /*
  * Representation of an interface address.

--- a/pcap_activate.3pcap
+++ b/pcap_activate.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_ACTIVATE 3PCAP "3 June 2024"
+.TH PCAP_ACTIVATE 3PCAP "9 September 2026"
 .SH NAME
 pcap_activate \- activate a capture handle
 .SH SYNOPSIS
@@ -90,7 +90,10 @@ monitor mode.
 The capture source device is not up.
 .TP
 .B PCAP_ERROR_CAPTURE_NOTSUP
-Packet capture is not supported on the capture source.
+Packet capture is not supported on the capture source.  See also the
+.B \%PCAP_IF_NO_CAPTURE
+device flag in
+.BR \%pcap_findalldevs (3PCAP).
 .TP
 .B PCAP_ERROR
 Another error occurred.

--- a/pcap_findalldevs.3pcap
+++ b/pcap_findalldevs.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_FINDALLDEVS 3PCAP "6 September 2026"
+.TH PCAP_FINDALLDEVS 3PCAP "9 September 2026"
 .SH NAME
 pcap_findalldevs, pcap_freealldevs \- get a list of capture devices, and
 free that list
@@ -134,6 +134,16 @@ set if the device is running
 set if the device is a wireless interface; this includes IrDA as well as
 radio-based networks such as IEEE 802.15.4 and IEEE 802.11, so it
 doesn't just mean Wi-Fi
+.TP
+.B PCAP_IF_NO_CAPTURE
+set if the device does not support packet capture in principle, thus any
+attempt to capture on the device will fail with an error; note that this flag
+.B not
+being set does not mean all attempts to capture will succeed: some may fail
+as usual because of the capture parameters, device status, permissions etc.
+.TP
+.B PCAP_IF_NO_INJECT
+same as the above, but with regard to packet injection
 .TP
 .B PCAP_IF_CONNECTION_STATUS
 a bitmask for an indication of whether the adapter is connected or not;
@@ -285,5 +295,11 @@ The
 and
 .B PCAP_IF_CONNECTION_STATUS_NOT_APPLICABLE
 constants became available in libpcap release 1.9.0.
+.PP
+The
+.B PCAP_IF_NO_CAPTURE
+and
+.B PCAP_IF_NO_INJECT
+constants became available in libpcap release 1.11.0.
 .SH SEE ALSO
 .BR pcap (3PCAP)

--- a/pcap_inject.3pcap
+++ b/pcap_inject.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_INJECT 3PCAP "23 November 2024"
+.TH PCAP_INJECT 3PCAP "9 September 2026"
 .SH NAME
 pcap_inject, pcap_sendpacket \- transmit a packet
 .SH SYNOPSIS
@@ -50,7 +50,10 @@ The same limitation applies to
 .BR \%pcap_create (3PCAP)
 and
 .BR \%pcap_activate (3PCAP).
-Note also that some devices might not support sending packets.
+Note also that some devices might not support sending packets.  See also the
+.B \%PCAP_IF_NO_INJECT
+device flag in
+.BR \%pcap_findalldevs (3PCAP).
 .PP
 Note that, on some platforms, the link-layer header of the packet that's
 sent might not be the same as the link-layer header of the packet

--- a/testprogs/findalldevstest.c
+++ b/testprogs/findalldevstest.c
@@ -234,6 +234,14 @@ static int ifprint(pcap_if_t *d)
     printf("%sLOOPBACK", sep);
     sep = ", ";
   }
+  if (d->flags & PCAP_IF_NO_CAPTURE) {
+    printf("%sNO_CAPTURE", sep);
+    sep = ", ";
+  }
+  if (d->flags & PCAP_IF_NO_INJECT) {
+    printf("%sNO_INJECT", sep);
+    sep = ", ";
+  }
   if (d->flags & PCAP_IF_WIRELESS) {
     printf("%sWIRELESS", sep);
     switch (d->flags & PCAP_IF_CONNECTION_STATUS) {


### PR DESCRIPTION
This is a proof of the concept discussed in tcpdump-workers, it may require more work.