### PR TITLE
CI: Remove VS 2015 build, add VS 2022 build.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -27,18 +27,6 @@ environment:
   # For now, we disable the remote capture build there.
   #
   matrix:
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015"
-      SDK: WpdPack
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015 Win64"
-      SDK: WpdPack
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015"
-      SDK: npcap-sdk
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
-      GENERATOR: "Visual Studio 14 2015 Win64"
-      SDK: npcap-sdk
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
       SDK: WpdPack
@@ -71,6 +59,46 @@ environment:
       PLATFORM: x64
       SDK: npcap-sdk
       REMOTE: -DENABLE_REMOTE=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: Win32
+      SDK: WpdPack
+      REMOTE: -DENABLE_REMOTE=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: Win32
+      SDK: WpdPack
+      REMOTE: -DENABLE_REMOTE=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: WpdPack
+      REMOTE: -DENABLE_REMOTE=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: WpdPack
+      REMOTE: -DENABLE_REMOTE=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: Win32
+      SDK: npcap-sdk
+      REMOTE: -DENABLE_REMOTE=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: Win32
+      SDK: npcap-sdk
+      REMOTE: -DENABLE_REMOTE=YES
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: npcap-sdk
+      REMOTE: -DENABLE_REMOTE=NO
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: x64
+      SDK: npcap-sdk
+      REMOTE: -DENABLE_REMOTE=YES
 
 build_script:
   #

--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -27,31 +27,6 @@
 #ifdef _WIN32
   #include <winsock2.h>
   #include <ws2tcpip.h>
-
-  #ifdef INET6
-    /*
-     * To quote the MSDN page for getaddrinfo() at
-     *
-     *    https://msdn.microsoft.com/en-us/library/windows/desktop/ms738520(v=vs.85).aspx
-     *
-     * "Support for getaddrinfo on Windows 2000 and older versions
-     * The getaddrinfo function was added to the Ws2_32.dll on Windows XP and
-     * later. To execute an application that uses this function on earlier
-     * versions of Windows, then you need to include the Ws2tcpip.h and
-     * Wspiapi.h files. When the Wspiapi.h include file is added, the
-     * getaddrinfo function is defined to the WspiapiGetAddrInfo inline
-     * function in the Wspiapi.h file. At runtime, the WspiapiGetAddrInfo
-     * function is implemented in such a way that if the Ws2_32.dll or the
-     * Wship6.dll (the file containing getaddrinfo in the IPv6 Technology
-     * Preview for Windows 2000) does not include getaddrinfo, then a
-     * version of getaddrinfo is implemented inline based on code in the
-     * Wspiapi.h header file. This inline code will be used on older Windows
-     * platforms that do not natively support the getaddrinfo function."
-     *
-     * We use getaddrinfo(), so we include Wspiapi.h here.
-     */
-    #include <wspiapi.h>
-  #endif /* INET6 */
 #else /* _WIN32 */
   #include <sys/param.h>
   #include <sys/types.h>

--- a/scanner.l
+++ b/scanner.l
@@ -126,28 +126,6 @@ void pcap_set_column(int, yyscan_t);
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
-/*
- * To quote the MSDN page for getaddrinfo() at
- *
- *    https://msdn.microsoft.com/en-us/library/windows/desktop/ms738520(v=vs.85).aspx
- *
- * "Support for getaddrinfo on Windows 2000 and older versions
- * The getaddrinfo function was added to the Ws2_32.dll on Windows XP and
- * later. To execute an application that uses this function on earlier
- * versions of Windows, then you need to include the Ws2tcpip.h and
- * Wspiapi.h files. When the Wspiapi.h include file is added, the
- * getaddrinfo function is defined to the WspiapiGetAddrInfo inline
- * function in the Wspiapi.h file. At runtime, the WspiapiGetAddrInfo
- * function is implemented in such a way that if the Ws2_32.dll or the
- * Wship6.dll (the file containing getaddrinfo in the IPv6 Technology
- * Preview for Windows 2000) does not include getaddrinfo, then a
- * version of getaddrinfo is implemented inline based on code in the
- * Wspiapi.h header file. This inline code will be used on older Windows
- * platforms that do not natively support the getaddrinfo function."
- *
- * We use getaddrinfo(), so we include Wspiapi.h here.
- */
-#include <wspiapi.h>
 #else /* _WIN32 */
 #include <sys/socket.h>	/* for "struct sockaddr" in "struct addrinfo" */
 #include <netdb.h>	/* for "struct addrinfo" */

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -224,7 +224,6 @@ main(int argc, char **argv)
 	WSADATA wsaData;
 	if (0 != WSAStartup(MAKEWORD(2, 2), &wsaData))
 		return 1;
-	atexit ((void(*)(void))WSACleanup);
 #endif /* _WIN32 */
 
 	dflag = 1;
@@ -358,6 +357,9 @@ main(int argc, char **argv)
 	free(cmdbuf);
 	pcap_freecode (&fcode);
 	pcap_close(pd);
+#ifdef _WIN32
+	WSACleanup();
+#endif
 	exit(0);
 }
 


### PR DESCRIPTION
VS 2015 is approximately 10 years old; get tid of the VS 2015 builds.

Add VS 2022 builds; try doing them with and without external capture support.

Remove include of <wspiapi.h>; it's only needed for IPv6 support on Windows 2000, which is almost 25 years old, and it has code that provokes warnings in VS2022 builds.

In filtertest, don't arrange to call WSACleanup() via atexit(), as that causes a pointer casting warning in VS 2022 builds.

(AppVeyor-only, so...)

[skip ci]