### PR TITLE
CI: on UN*Xes, do a smoke test of the filter compiler.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -96,9 +96,11 @@ run_after_echo "$PREFIX/bin/pcap-config" --additional-libs --static-pcap-only
 # VALGRIND_CMD is meant either to collapse or to expand.
 # shellcheck disable=SC2086
 if [ "$CMAKE" = no ]; then
+    run_after_echo $VALGRIND_CMD testprogs/filtertest EN10MB
     run_after_echo $VALGRIND_CMD testprogs/findalldevstest
     [ "$TEST_RELEASETAR" = yes ] && run_after_echo "$MAKE_BIN" releasetar
 else
+    run_after_echo $VALGRIND_CMD run/filtertest EN10MB
     run_after_echo $VALGRIND_CMD run/findalldevstest
 fi
 handle_matrix_debug


### PR DESCRIPTION
Run "filtertest EN10MB", which makes sure that the filter compiler isn't completely broken, as it was after
df8296449a3ae6db4fd50cd0ecd32f595f14f74c; that wasn't detected by the buildbots until it was committed to the repository and tested in tcpdump builds triggered by the libpcap commit.