### PR TITLE
CMake: don't build with sslutils.c if you don't have a TLS library.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2676,7 +2676,10 @@ if(ENABLE_REMOTE)
     check_struct_has_member("struct msghdr" msg_flags "ftmacros.h;sys/socket.h" HAVE_STRUCT_MSGHDR_MSG_FLAGS)
     cmake_pop_check_state()
     set(PROJECT_SOURCE_LIST_C ${PROJECT_SOURCE_LIST_C}
-        pcap-rpcap.c rpcap-protocol.c sockutils.c sslutils.c)
+        pcap-rpcap.c rpcap-protocol.c sockutils.c)
+    if(OPENSSL_FOUND)
+        set(PROJECT_SOURCE_LIST_C ${PROJECT_SOURCE_LIST_C} sslutils.c)
+    endif()
 endif(ENABLE_REMOTE)
 
 ###################################################################

--- a/rpcapd/CMakeLists.txt
+++ b/rpcapd/CMakeLists.txt
@@ -48,26 +48,30 @@ if(WIN32 OR ((CMAKE_USE_PTHREADS_INIT OR PTHREADS_FOUND) AND HAVE_CRYPT))
     endif(NOT STDLIBS_HAVE_GETADDRINFO)
   endif(UNIX)
 
-  if(WIN32)
-    set(RPCAPD_EXTRA_SOURCES
-        win32-svc.c
-        ${pcap_SOURCE_DIR}/charconv.c
-        ${pcap_SOURCE_DIR}/missing/getopt.c
-        rpcapd.rc)
-    include_directories(${pcap_SOURCE_DIR}/rpcapd ${pcap_SOURCE_DIR}/missing)
-  endif(WIN32)
-
-  add_executable(rpcapd
+  set(RPCAPD_SOURCES
     daemon.c
     fileconf.c
     log.c
     rpcapd.c
     ${pcap_SOURCE_DIR}/rpcap-protocol.c
     ${pcap_SOURCE_DIR}/sockutils.c
-    ${pcap_SOURCE_DIR}/sslutils.c
     ${pcap_SOURCE_DIR}/fmtutils.c
-    ${RPCAPD_EXTRA_SOURCES}
   )
+  if(OPENSSL_FOUND)
+    set(RPCAPD_SOURCES ${RPCAPD_SOURCES}
+      ${pcap_SOURCE_DIR}/sslutils.c)
+  endif(OPENSSL_FOUND)
+  if(WIN32)
+    set(RPCAPD_SOURCES ${RPCAPD_SOURCES}
+      win32-svc.c
+      ${pcap_SOURCE_DIR}/charconv.c
+      ${pcap_SOURCE_DIR}/missing/getopt.c
+      rpcapd.rc
+    )
+    include_directories(${pcap_SOURCE_DIR}/rpcapd ${pcap_SOURCE_DIR}/missing)
+  endif(WIN32)
+
+  add_executable(rpcapd ${RPCAPD_SOURCES})
 
   if(NOT C_ADDITIONAL_FLAGS STREQUAL "")
     set_target_properties(rpcapd PROPERTIES COMPILE_FLAGS ${C_ADDITIONAL_FLAGS})


### PR DESCRIPTION
Some versions of Visual Studio's C compiler report a warning when compiling an empty translation unit, which is what sslutils.c is if we're building without a TLS library.