### PR TITLE
CMake: check whether check_c_source_runs() works.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -648,16 +648,23 @@ endif(USE_STATIC_RT)
 # on an IA-32 or x86-64 Linux box for an Arm embedded Linux box,
 # or building Arm code on an IA-32 or x86-64 Windows box.
 #
-# At least for the Windows case, people may do those builds by
-# setting the target with th -A flag to CMake; that causes
-# CMAKE_GENERATOR_PLATFORM to be set to the target.  If
-# CMAKE_GENERATOR_PLATFORM is set, compare it with
-# CMAKE_HOST_SYSTEM_PROCESSOR and, if they're not equal, set
-# CMAKE_CROSSCOMPILING to TRUE.
+# So just test whether check_c_source_runs() on a trivial program
+# works; if not, it's probably because the generated code won't
+# run on the platform on which we're running.
 #
-if (CMAKE_GENERATOR_PLATFORM AND
-    NOT CMAKE_GENERATOR_PLATFORM STREQUAL CMAKE_HOST_SYSTEM_PROCESSOR)
-    set(CMAKE_CROSSCOMPILING TRUE)
+include(CheckCSourceRuns)
+if (NOT CMAKE_CROSSCOMPILING)
+    check_c_source_runs("
+    int main()
+    {
+        return 0;
+    }
+    "
+        CHECK_C_SOURCE_RUNS_WORKS
+    )
+    if (NOT CHECK_C_SOURCE_RUNS_WORKS)
+        set(CMAKE_CROSSCOMPILING TRUE)
+    endif()
 endif()
 
 ###################################################################
@@ -763,7 +770,6 @@ if (NOT CMAKE_CROSSCOMPILING)
     #
     # Require a proof of suitable snprintf(3), same as in Autoconf.
     #
-    include(CheckCSourceRuns)
     check_c_source_runs("
     #include <stdio.h>
     #include <string.h>


### PR DESCRIPTION
That's the simplest way to check whether we can use check_c_source_runs() to test for a suitable snprintf; it's easier than trying to find out the target instruction set architecture and comparing it with the host instruction set architecture, as CMake doesn't provide any mechanism to provide the target instruction set architecture, on all platforms, in a form that can be compared with the host instruction set architecture, and even if the target is different, we may be able to run code for that instruction set architecture if, for example, it's a 32-bit version of the instruction set architecture on which the build is being done, or if there's a binary emulator.