### PR TITLE
CMake: handle Windows architectures as we do for tcpdump.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,15 +29,19 @@ environment:
   matrix:
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
-      SDK: WpdPack
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017 Win64"
+      PLATFORM: Win32
       SDK: WpdPack
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
+      PLATFORM: x64
+      SDK: WpdPack
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      GENERATOR: "Visual Studio 15 2017"
+      PLATFORM: Win32
       SDK: npcap-sdk
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
-      GENERATOR: "Visual Studio 15 2017 Win64"
+      GENERATOR: "Visual Studio 15 2017"
+      PLATFORM: x64
       SDK: npcap-sdk
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
@@ -159,6 +163,5 @@ build_script:
   - md build
   - cd build
   - cmake --version
-  - if NOT DEFINED PLATFORM cmake %REMOTE% %OPENSSL_ROOT_DIR% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -G"%GENERATOR%" ..
-  - if DEFINED PLATFORM cmake %REMOTE% %OPENSSL_ROOT_DIR% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -G"%GENERATOR%" -A %PLATFORM% ..
+  - cmake %REMOTE% %OPENSSL_ROOT_DIR% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -G"%GENERATOR%" -A %PLATFORM% ..
   - msbuild /m /nologo /p:Configuration=Release pcap.sln

--- a/cmake/Modules/FindPacket.cmake
+++ b/cmake/Modules/FindPacket.cmake
@@ -47,42 +47,27 @@
 # (e.g cmake -DPacket_ROOT=C:\path\to\packet [...])
 #
 
-# The 64-bit Packet.lib is located under /x64
-if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+if(CMAKE_GENERATOR_PLATFORM STREQUAL "Win32")
+  #
+  # 32-bit x86; no need to look in subdirectories of the SDK's
+  # Lib directory for the libraries, as the libraries are in
+  # the Lib directory
+  #
+else()
+  #
+  # Platform other than 32-bit x86.
   #
   # For the WinPcap and Npcap SDKs, the Lib subdirectory of the top-level
-  # directory contains 32-bit libraries; the 64-bit libraries are in the
-  # Lib/x64 directory.
+  # directory contains 32-bit x86 libraries; the libraries for other
+  # platforms are in subdirectories of the Lib directory whose names
+  # are the names of the supported platforms.
   #
-  # The only way to *FORCE* CMake to look in the Lib/x64 directory
-  # without searching in the Lib directory first appears to be to set
-  # CMAKE_LIBRARY_ARCHITECTURE to "x64".
+  # The only way to *FORCE* CMake to look in the appropriate
+  # subdirectory of Lib for libraries without searching in the
+  # Lib directory first appears to be to set
+  # CMAKE_LIBRARY_ARCHITECTURE to the name of the subdirectory.
   #
-  # In newer versions of CMake, CMAKE_LIBRARY_ARCHITECTURE is set according to
-  # the language, e.g., CMAKE_<LANG>_LIBRARY_ARCHITECTURE. So, set the new
-  # variable, CMAKE_C_LIBRARY_ARCHITECTURE, so that CMAKE_LIBRARY_ARCHITECTURE
-  # inherits the correct value.
-  #
-  set(archdetect_c_code "
-  #ifndef _M_ARM64
-  #error Not ARM64
-  #endif
-  int main() { return 0; }
-  ")
-
-  file(WRITE "${CMAKE_BINARY_DIR}/archdetect.c" "${archdetect_c_code}")
-  try_compile(
-	  IsArm64
-	  "${CMAKE_BINARY_DIR}/archdetect"
-	  "${CMAKE_BINARY_DIR}/archdetect.c"
-	  )
-  if(IsArm64)
-	  set(CMAKE_C_LIBRARY_ARCHITECTURE "ARM64")
-	  set(CMAKE_LIBRARY_ARCHITECTURE "ARM64")
-  else()
-	  set(CMAKE_C_LIBRARY_ARCHITECTURE "x64")
-	  set(CMAKE_LIBRARY_ARCHITECTURE "x64")
-  endif()
+  set(CMAKE_LIBRARY_ARCHITECTURE "${CMAKE_GENERATOR_PLATFORM}")
 endif()
 
 # Find the header


### PR DESCRIPTION
Just use CMAKE_GENERATOR_PLATFORM to determine for which architecture we're building, and use that to set the subdirectory of the SDK's Lib directory in which to look for libraries.

Use the -A flag for all generators; according to the CMake documentation, they're supported for all generators in CMake 3.1 and later and, on Windows, we require CMake 3.12 or later.  That ensures that CMAKE_GENERATOR_PLATFORM will be set, so that we can use it to determine the right directory in which to look for pcap libraries.