### PR TITLE
Remove some apparently-unneeded includes.

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -24,14 +24,7 @@
 #ifdef _WIN32
   #include <ws2tcpip.h>
 #else
-  #include <sys/socket.h>
-
-  #ifdef __NetBSD__
-    #include <sys/param.h>
-  #endif
-
   #include <netinet/in.h>
-  #include <arpa/inet.h>
 #endif /* _WIN32 */
 
 #include <stdlib.h>

--- a/grammar.y.in
+++ b/grammar.y.in
@@ -78,19 +78,6 @@
 
 #include <stdlib.h>
 
-#ifndef _WIN32
-#include <sys/types.h>
-#include <sys/socket.h>
-
-#if __STDC__
-struct mbuf;
-struct rtentry;
-#endif
-
-#include <netinet/in.h>
-#include <arpa/inet.h>
-#endif /* _WIN32 */
-
 #include <stdio.h>
 
 #include "diag-control.h"

--- a/pflog.h
+++ b/pflog.h
@@ -31,6 +31,10 @@
  * SUCH DAMAGE.
  */
 
+#ifndef _WIN32
+  #include <netinet/in.h>
+#endif
+
 /*
  * pflog headers, at least as they exist now.
  */


### PR DESCRIPTION
Include <netinet/in.h> in pflog.h, as a case of include-what-you-use (it needs address structures).

(cherry picked from commit c6ea3652f55b9d1ab1c0c94f5f8ba0c0bca64a9d)