### PR TITLE
Fix "tcpdump -i <n>" for something-only libpcap builds.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,5 +1,11 @@
 DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
   Summary for 1.10.6 libpcap release (so far!)
+    Source code:
+      Fix "tcpdump -i <n>" for something-only libpcap builds.
+      Remove some unneeded includes.
+    Packet filtering:
+      Make the chunk allocator's alignment more general and
+        platform-independent.
     Linux:
       Fix check for mac80211 phydev.
       Don't create monitor-mode interface if we're capturing on one.
@@ -14,6 +20,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Makefile.in: Include instrument-functions.c in the release tarball.
       CMake: Fix libnl usage with pkg-config.
       CMake: Fix build with CMake 3.31.
+      CI: Report CMake version in builds.
 
 Friday, August 30, 2024 / The Tcpdump Group
   Summary for 1.10.5 libpcap release

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -1425,8 +1425,7 @@ pcapint_platform_finddevs(pcap_if_list_t *devlistp _U_, char *errbuf)
 pcap_t *
 pcapint_create_interface(const char *device, char *errbuf)
 {
-	snprintf(errbuf, PCAP_ERRBUF_SIZE,
-	    "This version of libpcap only supports DAG cards");
+	snprintf(errbuf, PCAP_ERRBUF_SIZE, PCAP_ENODEV_MESSAGE, "DAG");
 	return NULL;
 }
 

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -1068,8 +1068,7 @@ pcapint_platform_finddevs(pcap_if_list_t *devlistp _U_, char *errbuf)
 pcap_t *
 pcapint_create_interface(const char *device, char *errbuf)
 {
-	snprintf(errbuf, PCAP_ERRBUF_SIZE,
-	    "This version of libpcap only supports DPDK");
+	snprintf(errbuf, PCAP_ERRBUF_SIZE, PCAP_ENODEV_MESSAGE, "DPDK");
 	return NULL;
 }
 

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -413,6 +413,14 @@ int	pcapint_setnonblock_fd(pcap_t *p, int);
  * by pcap_create routines.
  */
 pcap_t	*pcapint_create_interface(const char *, char *);
+/*
+ * A format string for something-only libpcap builds, which use a stub
+ * implementation of pcapint_create_interface().  It contains the substring
+ * "No such device" (one of the standard descriptions of ENODEV) -- this way
+ * tcpdump can detect a particular error condition even though pcap_create()
+ * returns NULL for all errors.
+ */
+#define PCAP_ENODEV_MESSAGE "No such device (this build of libpcap supports %s devices only)."
 
 /*
  * This wrapper takes an error buffer pointer and a type to use for the

--- a/pcap-septel.c
+++ b/pcap-septel.c
@@ -312,8 +312,7 @@ pcapint_platform_finddevs(pcap_if_list_t *devlistp, char *errbuf)
 pcap_t *
 pcapint_create_interface(const char *device, char *errbuf)
 {
-  snprintf(errbuf, PCAP_ERRBUF_SIZE,
-                "This version of libpcap only supports Septel cards");
+	snprintf(errbuf, PCAP_ERRBUF_SIZE, PCAP_ENODEV_MESSAGE, "Septel");
   return (NULL);
 }
 

--- a/pcap-snf.c
+++ b/pcap-snf.c
@@ -599,8 +599,7 @@ pcapint_platform_finddevs(pcap_if_list_t *devlistp, char *errbuf)
 pcap_t *
 pcapint_create_interface(const char *device, char *errbuf)
 {
-	snprintf(errbuf, PCAP_ERRBUF_SIZE,
-	    "This version of libpcap only supports SNF cards");
+	snprintf(errbuf, PCAP_ERRBUF_SIZE, PCAP_ENODEV_MESSAGE, "SNF");
 	return NULL;
 }
 


### PR DESCRIPTION
pcap_create() returns NULL for all errors, so tcpdump tries to find evidence of ENODEV in the error buffer in order to retry using a different device name.  That does not work when the error string is "This version of libpcap only supports...", so use a format string that works and place it in pcap-int.h.

```
# tcpdump --version
tcpdump version 5.0.0-PRE-GIT
libpcap version 1.11.0-PRE-GIT (DAG-only)

# tcpdump -D
1.dag0 (alias for dag0:0) [none]
2.dag0:0 (Rx stream 0, 64 MiB, DAG 7.5G2 rev A at 0000:01:00.0) [none]
3.dag1 (alias for dag1:0) [none]
4.dag1:0 (Rx stream 0, 64 MiB, DAG 9.2X2 rev D at 0000:02:00.0) [none]
5.dag16 (alias for dag16:0) [none]
6.dag16:0 (Rx stream 0, 64 MiB, vDAG) [none]
```

Before:

```
# tcpdump -ni 1
tcpdump: This version of libpcap only supports DAG cards
```

After:

```
# tcpdump -ni abcde
tcpdump: No such device (this build of libpcap supports DAG devices only).

# tcpdump -ni 1
tcpdump: verbose output suppressed, use -v[v]... for full protocol decode
listening on dag0, link-type EN10MB (Ethernet), snapshot length 262144 bytes
```

(cherry picked from commit 8a5dcc8840bfbdc3256f4d50d9924b3234342fba)

Also, add some changes backported to the 1.10 branch.