### PR TITLE
CI: add an ARM64 build for AppVeyor.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -110,7 +110,7 @@ environment:
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
       REMOTE: -DENABLE_REMOTE=NO
-      # VS 2022, Npcap, 32-bit and 64-bit, with AirPcap, with remote
+      # VS 2022, Npcap, 32-bit and 64-bit x86, with AirPcap and remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
@@ -121,6 +121,13 @@ environment:
       PLATFORM: x64
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
+      # VS 2022, Npcap, 64-bit ARM, without AirPcap, without remote
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
+      GENERATOR: "Visual Studio 17 2022"
+      PLATFORM: ARM64
+      SDK: npcap-sdk
+      AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=NO
 
 build_script:
   #

--- a/gencode.c
+++ b/gencode.c
@@ -704,12 +704,28 @@ new_stmt(compiler_state_t *cstate, int code)
 }
 
 static struct block *
-gen_retblk(compiler_state_t *cstate, int v)
+gen_retblk_internal(compiler_state_t *cstate, int v)
 {
 	struct block *b = new_block(cstate, BPF_RET|BPF_K);
 
 	b->s.k = v;
 	return b;
+}
+
+static struct block *
+gen_retblk(compiler_state_t *cstate, int v)
+{
+	if (setjmp(cstate->top_ctx)) {
+		/*
+		 * gen_retblk() only fails because a memory
+		 * allocation failed in newchunk(), meaning
+		 * that it can't return a pointer.
+		 *
+		 * Return NULL.
+		 */
+		return NULL;
+	}
+	return gen_retblk(cstate, v);
 }
 
 static inline PCAP_NORETURN_DEF void
@@ -726,9 +742,8 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 	static int done = 0;
 #endif
 	compiler_state_t cstate;
-	const char * volatile xbuf = buf;
 	yyscan_t scanner = NULL;
-	volatile YY_BUFFER_STATE in_buffer = NULL;
+	YY_BUFFER_STATE in_buffer = NULL;
 	u_int len;
 	int rc;
 
@@ -798,7 +813,7 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 		rc = PCAP_ERROR;
 		goto quit;
 	}
-	in_buffer = pcap__scan_string(xbuf ? xbuf : "", scanner);
+	in_buffer = pcap__scan_string(buf ? buf : "", scanner);
 
 	/*
 	 * Associate the compiler state with the lexical analyzer
@@ -822,14 +837,15 @@ pcap_compile(pcap_t *p, struct bpf_program *program,
 	}
 
 	if (cstate.ic.root == NULL) {
+		cstate.ic.root = gen_retblk(&cstate, cstate.snaplen);
+
 		/*
 		 * Catch errors reported by gen_retblk().
 		 */
-		if (setjmp(cstate.top_ctx)) {
+		if (cstate.ic.root== NULL) {
 			rc = PCAP_ERROR;
 			goto quit;
 		}
-		cstate.ic.root = gen_retblk(&cstate, cstate.snaplen);
 	}
 
 	if (optimize && !cstate.no_optimize) {
@@ -998,9 +1014,9 @@ finish_parse(compiler_state_t *cstate, struct block *p)
 	if (ppi_dlt_check != NULL)
 		gen_and(ppi_dlt_check, p);
 
-	backpatch(p, gen_retblk(cstate, cstate->snaplen));
+	backpatch(p, gen_retblk_internal(cstate, cstate->snaplen));
 	p->sense = !p->sense;
-	backpatch(p, gen_retblk(cstate, 0));
+	backpatch(p, gen_retblk_internal(cstate, 0));
 	cstate->ic.root = p->head;
 	return (0);
 }
@@ -9280,19 +9296,11 @@ gen_vlan(compiler_state_t *cstate, bpf_u_int32 vlan_num, int has_vlan_tag)
  * label_num might be clobbered by longjmp - yeah, it might, but *WHO CARES*?
  * It's not *used* after setjmp returns.
  */
-struct block *
-gen_mpls(compiler_state_t *cstate, bpf_u_int32 label_num_arg,
+static struct block *
+gen_mpls_internal(compiler_state_t *cstate, bpf_u_int32 label_num,
     int has_label_num)
 {
-	volatile bpf_u_int32 label_num = label_num_arg;
 	struct	block	*b0, *b1;
-
-	/*
-	 * Catch errors reported by us and routines below us, and return NULL
-	 * on an error.
-	 */
-	if (setjmp(cstate->top_ctx))
-		return (NULL);
 
 	if (cstate->label_stack_depth > 0) {
 		/* just match the bottom-of-stack bit clear */
@@ -9358,6 +9366,19 @@ gen_mpls(compiler_state_t *cstate, bpf_u_int32 label_num_arg,
 	cstate->off_nl += 4;
 	cstate->label_stack_depth++;
 	return (b0);
+}
+
+struct block *
+gen_mpls(compiler_state_t *cstate, bpf_u_int32 label_num, int has_label_num)
+{
+	/*
+	 * Catch errors reported by us and routines below us, and return NULL
+	 * on an error.
+	 */
+	if (setjmp(cstate->top_ctx))
+		return (NULL);
+
+	return gen_mpls_internal(cstate, label_num, has_label_num);
 }
 
 /*
@@ -10032,29 +10053,16 @@ gen_mtp2type_abbrev(compiler_state_t *cstate, int type)
 	return b0;
 }
 
-/*
- * The jvalue_arg dance is to avoid annoying whining by compilers that
- * jvalue might be clobbered by longjmp - yeah, it might, but *WHO CARES*?
- * It's not *used* after setjmp returns.
- */
-struct block *
-gen_mtp3field_code(compiler_state_t *cstate, int mtp3field,
-    bpf_u_int32 jvalue_arg, int jtype, int reverse)
+static struct block *
+gen_mtp3field_code_internal(compiler_state_t *cstate, int mtp3field,
+    bpf_u_int32 jvalue, int jtype, int reverse)
 {
-	volatile bpf_u_int32 jvalue = jvalue_arg;
 	struct block *b0;
 	bpf_u_int32 val1 , val2 , val3;
 	u_int newoff_sio;
 	u_int newoff_opc;
 	u_int newoff_dpc;
 	u_int newoff_sls;
-
-	/*
-	 * Catch errors reported by us and routines below us, and return NULL
-	 * on an error.
-	 */
-	if (setjmp(cstate->top_ctx))
-		return (NULL);
 
 	newoff_sio = cstate->off_sio;
 	newoff_opc = cstate->off_opc;
@@ -10145,6 +10153,21 @@ gen_mtp3field_code(compiler_state_t *cstate, int mtp3field,
 		abort();
 	}
 	return b0;
+}
+
+struct block *
+gen_mtp3field_code(compiler_state_t *cstate, int mtp3field,
+    bpf_u_int32 jvalue, int jtype, int reverse)
+{
+	/*
+	 * Catch errors reported by us and routines below us, and return NULL
+	 * on an error.
+	 */
+	if (setjmp(cstate->top_ctx))
+		return (NULL);
+
+	return gen_mtp3field_code_internal(cstate, mtp3field, jvalue, jtype,
+	    reverse);
 }
 
 static struct block *


### PR DESCRIPTION
Fix volatile access warnings by wrapping routines called within a setjmp() in routines that call setjmp() and returns an error if it's been longjmped to.

(backported from commit df8296449a3ae6db4fd50cd0ecd32f595f14f74c)