### PR TITLE
dlpi: fix open_dlpi_device() to handle Solaris/HP-UX logical interfaces.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -197,6 +197,8 @@ Friday, August 30, 2024 / The Tcpdump Group
       Allow attaching to links owned by a non-global zone.  (Based on
         pull request #1202.)
       Fix AF_LINK handling on illumos.
+      Fix not to ignore logical interfaces in fad-gifc.c and
+        fad-glifc.c.
     macOS:
       Redid the availability macros to be closer to what Apple's doing
         in recent SDKs, including tagging pcap-namedb.h routines.

--- a/pcap-dlpi.c
+++ b/pcap-dlpi.c
@@ -320,7 +320,7 @@ open_dlpi_device(const char *name, u_int *ppa, char *errbuf)
 {
 	int status;
 	char dname[100];
-	char *cp;
+	char *cp, *cq;
 	int fd;
 #ifdef HAVE_DEV_DLPI
 	u_int unit;
@@ -337,6 +337,32 @@ open_dlpi_device(const char *name, u_int *ppa, char *errbuf)
 		pcapint_strlcpy(dname, name, sizeof(dname));
 	else
 		pcapint_strlcpy(dname, cp + 1, sizeof(dname));
+
+	/*
+	 * If this name has a colon followed by a number at
+	 * the end, it's a logical interface.  Those are just
+	 * the way you assign multiple IP addresses to a real
+	 * interface, so an entry for a logical interface should
+	 * be treated like the entry for the real interface;
+	 * we do that by stripping off the ":" and the number.
+	 */
+	cp = strchr(dname, ':');
+	if (cp != NULL) {
+		/*
+		 * We have a ":"; is it followed by a number?
+		 */
+		cq = cp + 1;
+		while (PCAP_ISDIGIT(*cq))
+			cq++;
+		if (*cq == '\0') {
+			/*
+			 * All digits after the ":" until the end.
+			 * Strip off the ":" and everything after
+			 * it.
+			 */
+			*cp = '\0';
+		}
+	}
 
 	/*
 	 * Split the device name into a device type name and a unit number;
@@ -398,6 +424,32 @@ open_dlpi_device(const char *name, u_int *ppa, char *errbuf)
 	else
 		snprintf(dname, sizeof(dname), "%s/%s", PCAP_DEV_PREFIX,
 		    name);
+
+	/*
+	 * If this name has a colon followed by a number at
+	 * the end, it's a logical interface.  Those are just
+	 * the way you assign multiple IP addresses to a real
+	 * interface, so an entry for a logical interface should
+	 * be treated like the entry for the real interface;
+	 * we do that by stripping off the ":" and the number.
+	 */
+	cp = strchr(dname, ':');
+	if (cp != NULL) {
+		/*
+		 * We have a ":"; is it followed by a number?
+		 */
+		cq = cp + 1;
+		while (PCAP_ISDIGIT(*cq))
+			cq++;
+		if (*cq == '\0') {
+			/*
+			 * All digits after the ":" until the end.
+			 * Strip off the ":" and everything after
+			 * it.
+			 */
+			*cp = '\0';
+		}
+	}
 
 	/*
 	 * Get the unit number, and a pointer to the end of the device


### PR DESCRIPTION
If handed the name of a logical interface, strip off the logical interface number.  This means that in pcap_findalldevs() we won't skip the logical interfaces and will get the network addresses and netmasks they have.

(It also mean that if you try to capture on a logical interface, it'll capture on the physical interface, but that might be the right thing to do.)

We can't do it earlier in fad-gifc.c and fad-glifc.c, because we have to use the logical interface name when fetching the netmask, etc..