### PR TITLE
Use correct size for VLAN tag load instruction

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -9273,7 +9273,7 @@ gen_vlan_patch_vid_test(compiler_state_t *cstate, struct block *b_vid)
 	sjeq->s.jf = b_vid->stmts;
 	sappend(s, sjeq);
 
-	s2 = new_stmt(cstate, BPF_LD|BPF_B|BPF_ABS);
+	s2 = new_stmt(cstate, BPF_LD|BPF_H|BPF_ABS);
 	s2->s.k = SKF_AD_OFF + SKF_AD_VLAN_TAG;
 	sappend(s, s2);
 	sjeq->s.jt = s2;


### PR DESCRIPTION
Not a true bug, since Linux kernel (net/core/filter.c) forces any load from SKF_AD_VLAN_TAG to a BPF_H width. However, this change makes libpcap code easier to understand.