### PR TITLE
CMakeLists.txt: Add a "make check" target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3585,3 +3585,19 @@ configure_file(
 
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+#
+# libpcap tests
+# We try to find the Perl interpreter and, if we do, we have the check
+# rule run testprogs/TESTrun with it, because just trying to run the TESTrun
+# script as a command won't work on Windows.
+#
+find_program(PERL perl)
+if(PERL)
+    message(STATUS "Found perl at ${PERL}")
+    add_custom_target(check
+        COMMAND ${PERL} ${CMAKE_SOURCE_DIR}/testprogs/TESTrun
+        DEPENDS testprogs)
+else()
+    message(STATUS "Didn't find perl")
+endif()

--- a/Makefile.in
+++ b/Makefile.in
@@ -837,6 +837,8 @@ releasecheck: releasetar
 	./configure --enable-remote --quiet --prefix="$$INSTALL_DIR" && \
 	echo '[$@] $$ $(MAKE) -s all testprogs' && \
 	$(MAKE) -s all testprogs && \
+	echo '[$@] $$ $(MAKE) -s check' && \
+	$(MAKE) -s check >/dev/null && \
 	echo '[$@] $$ $(MAKE) -s install' && \
 	$(MAKE) -s install && \
 	cd .. && \
@@ -857,6 +859,8 @@ releasecheck: releasetar
 	    .. && \
 	echo '[$@] $$ $(MAKE) -s all testprogs' && \
 	$(MAKE) -s all testprogs && \
+	echo '[$@] $$ $(MAKE) -s check' && \
+	$(MAKE) -s check >/dev/null && \
 	echo '[$@] $$ $(MAKE) -s install' && \
 	$(MAKE) -s install && \
 	cd ../.. && \

--- a/build.sh
+++ b/build.sh
@@ -98,13 +98,13 @@ run_after_echo "$PREFIX/bin/pcap-config" --additional-libs --static-pcap-only
 if [ "$CMAKE" = no ]; then
     FILTERTEST_BIN="$VALGRIND_CMD testprogs/filtertest"
     export FILTERTEST_BIN
-    run_after_echo testprogs/TESTrun
+    run_after_echo "$MAKE_BIN" -s check
     run_after_echo $VALGRIND_CMD testprogs/findalldevstest
     [ "$TEST_RELEASETAR" = yes ] && run_after_echo "$MAKE_BIN" releasetar
 else
     FILTERTEST_BIN="$VALGRIND_CMD run/filtertest"
     export FILTERTEST_BIN
-    run_after_echo ../testprogs/TESTrun
+    run_after_echo "$MAKE_BIN" -s check
     run_after_echo $VALGRIND_CMD run/findalldevstest
 fi
 handle_matrix_debug


### PR DESCRIPTION
Similar to tcpdump.

build.sh: Replace "testprogs/TESTrun" by "make -s check".

Makefile.in: Add "make -s check" commands in releasecheck target.