### PR TITLE
Deprecate bpf_filter().

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -47,6 +47,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Initialize the scratch memory store to 0.
       Require "[wlan] dir" integer value to be within range.
       Fix the != comparison for ATM and MTP field values.
+      Deprecate bpf_filter().
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -263,6 +263,7 @@ struct bpf_insn {
 #define BPF_JUMP(code, k, jt, jf) { (u_short)(code), jt, jf, k }
 
 PCAP_AVAILABLE_0_4
+PCAP_DEPRECATED("use pcap_offline_filter()")
 PCAP_API u_int	bpf_filter(const struct bpf_insn *, const u_char *, u_int, u_int);
 
 PCAP_AVAILABLE_0_6


### PR DESCRIPTION
It takes the on-the-network length, followed by the captured length, as arguments; apparently, some people (or LLMs?) think, perhaps based on other code that takes the captured length first, that it's the other way around, and their fuzz-testing finds that bug in their code.  See issue #1442.