### PR TITLE
Require a live capture for all Linux BPF extensions.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -89,6 +89,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       CI: Implement "make check".
       Fix autotools and CMake issues with snprintf test and sanitizers.
         Fixes issue #1396.
+      filtertest: Add "-l" flag to use Linux BPF extensions.
     Hurd:
       Support network capture devices too.
       Fix a few device activation bugs.

--- a/CHANGES
+++ b/CHANGES
@@ -64,6 +64,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Add a README.snf.md file.
       pcap-filter(7): Clarify Ethernet, IPv4 and IPv6.
       pcap_lib_version(3PCAP): Add details and examples.
+      Discuss Linux BPF extensions in the man pages.
     Building and testing:
       Apply GNU Hurd support patch from the Debian package.
       CI: Introduce and use LIBPCAP_CMAKE_TAINTED.

--- a/CHANGES
+++ b/CHANGES
@@ -48,6 +48,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Require "[wlan] dir" integer value to be within range.
       Fix the != comparison for ATM and MTP field values.
       Deprecate bpf_filter().
+      Require a live capture for all Linux BPF extensions.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -368,6 +368,12 @@ struct pcap {
  * BPF code generation flags.
  */
 #define BPF_SPECIAL_VLAN_HANDLING	0x00000001	/* special VLAN handling for Linux */
+/*
+ * Special handling of packet type and ifindex, which are some of the auxiliary
+ * data items available in Linux >= 2.6.27.  Disregard protocol and netlink
+ * attributes for now.
+ */
+#define BPF_SPECIAL_BASIC_HANDLING	0x00000002
 
 /*
  * User data structure for the one-shot callback used for pcap_next()

--- a/pcap_compile.3pcap.in
+++ b/pcap_compile.3pcap.in
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_COMPILE 3PCAP "25 November 2024"
+.TH PCAP_COMPILE 3PCAP "24 January 2025"
 .SH NAME
 pcap_compile \- compile a filter expression
 .SH SYNOPSIS
@@ -56,6 +56,39 @@ than one network, a value of
 can be supplied; tests
 for IPv4 broadcast addresses will fail to compile, but all other tests in
 the filter program will be OK.
+.PP
+On Linux, if the
+.B pcap_t
+handle corresponds to a live packet capture, the resulting filter program
+may use Linux BPF extensions.  This works transparently if the filter
+program is used to filter packets on the same
+.B pcap_t
+handle, which should be done when possible.  In other use cases trying to
+use a filter program with BPF extensions in
+.BR \%pcap_offline_filter (3PCAP)
+or for filtering an input savefile would reject more packets than expected
+because the extensions depend on auxiliary packet data, which would not be
+available.  The workaround is to compile the filter without the extensions
+by using a
+.B pcap_t
+handle from
+.BR \%pcap_open_dead (3PCAP)
+or
+.BR \%pcap_open_offline (3PCAP)
+rather than a handle from
+.BR \%pcap_create (3PCAP)
+or
+.BR \%pcap_open_live (3PCAP).
+.PP
+If BPF extensions are disabled as described above or the OS is not Linux,
+.BR pcap_compile ()
+may start rejecting some filter expressions for some link-layer header types,
+this is the expected behaviour.  For example, the
+.B ifindex
+keyword is valid for any live capture on Linux, but when reading packets
+from a savefile, regardless of the OS it is valid for
+.B DLT_LINUX_SLL2
+only.
 .SH RETURN VALUE
 .BR pcap_compile ()
 returns

--- a/pcap_offline_filter.3pcap
+++ b/pcap_offline_filter.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_OFFLINE_FILTER 3PCAP "7 April 2014"
+.TH PCAP_OFFLINE_FILTER 3PCAP "24 January 2025"
 .SH NAME
 pcap_offline_filter \- check whether a filter matches a packet
 .SH SYNOPSIS
@@ -45,6 +45,12 @@ points to the
 structure for the packet, and
 .I pkt
 points to the data in the packet.
+.PP
+The filter program must have been compiled for a link-layer header type
+that matches the packet data; also on Linux the filter must not use
+BPF extensions, see
+.BR \%pcap_compile ()
+for more information.
 .SH RETURN VALUE
 .BR pcap_offline_filter ()
 returns the return value of the filter program.  This will be zero if

--- a/pcap_setfilter.3pcap
+++ b/pcap_setfilter.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_SETFILTER 3PCAP "5 March 2022"
+.TH PCAP_SETFILTER 3PCAP "24 January 2025"
 .SH NAME
 pcap_setfilter \- set the filter
 .SH SYNOPSIS
@@ -38,6 +38,20 @@ is a pointer to a
 .I bpf_program
 struct, usually the result of a call to
 .BR \%pcap_compile (3PCAP).
+.PP
+If the calls to
+.BR \%pcap_compile ()
+and
+.BR \%pcap_setfilter ()
+use the same
+.B pcap_t
+handle, packet filtering should either work correctly or fail correctly
+without additional efforts.  Otherwise the filter program must have been
+compiled for the same link-layer header type as the one used by the
+.B pcap_t
+handle; also on Linux the filter must not use BPF extensions, see
+.BR pcap_compile ()
+for more information.
 .SH RETURN VALUE
 .BR pcap_setfilter ()
 returns

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -112,6 +112,8 @@ sub is_not_linux {
 #   "unopt" separately)
 # * skip (optional, string): if defined and is not equal to an empty string,
 #   causes the test to skip using the string as the reason
+# * linuxext (optional, int): if defined and is equal to 1, use Linux BPF
+#   extensions.
 #
 # At least one of "opt" and "unopt" must be defined in each accept test block.
 
@@ -1921,6 +1923,70 @@ my %accept_blocks = (
 			(008) ret      #0
 			EOF
 	}, # vlan_netanalyzer_unary
+	vlan_eth_linuxext_nullary => {
+		skip => is_not_linux(),
+		DLT => 'EN10MB',
+		linuxext => 1,
+		expr => 'vlan',
+		opt => <<~'EOF',
+			(000) ldb      [vlanp]
+			(001) jeq      #0x1             jt 6	jf 2
+			(002) ldh      [12]
+			(003) jeq      #0x8100          jt 6	jf 4
+			(004) jeq      #0x88a8          jt 6	jf 5
+			(005) jeq      #0x9100          jt 6	jf 7
+			(006) ret      #262144
+			(007) ret      #0
+			EOF
+	}, # vlan_eth_linuxext_nullary
+	vlan_eth_linuxext_unary => {
+		skip => is_not_linux(),
+		DLT => 'EN10MB',
+		linuxext => 1,
+		expr => 'vlan 10',
+		opt => <<~'EOF',
+			(000) ldb      [vlanp]
+			(001) jeq      #0x1             jt 6	jf 2
+			(002) ldh      [12]
+			(003) jeq      #0x8100          jt 6	jf 4
+			(004) jeq      #0x88a8          jt 6	jf 5
+			(005) jeq      #0x9100          jt 6	jf 14
+			(006) ldb      [vlanp]
+			(007) jeq      #0x1             jt 8	jf 10
+			(008) ldh      [vlan_tci]
+			(009) ja       11
+			(010) ldh      [14]
+			(011) and      #0xfff
+			(012) jeq      #0xa             jt 13	jf 14
+			(013) ret      #262144
+			(014) ret      #0
+			EOF
+	}, # vlan_eth_linuxext_unary
+	vlan_and_vlan_eth_linuxext => {
+		skip => is_not_linux(),
+		DLT => 'EN10MB',
+		linuxext => 1,
+		expr => 'vlan and vlan',
+		opt => <<~'EOF',
+			(000) ld       #0x0
+			(001) st       M[1]
+			(002) ldb      [vlanp]
+			(003) jeq      #0x1             jt 10	jf 4
+			(004) ld       #0x4
+			(005) st       M[1]
+			(006) ldh      [12]
+			(007) jeq      #0x8100          jt 10	jf 8
+			(008) jeq      #0x88a8          jt 10	jf 9
+			(009) jeq      #0x9100          jt 10	jf 16
+			(010) ldx      M[1]
+			(011) ldh      [x + 12]
+			(012) jeq      #0x8100          jt 15	jf 13
+			(013) jeq      #0x88a8          jt 15	jf 14
+			(014) jeq      #0x9100          jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			EOF
+	}, # vlan_and_vlan_eth_linuxext
 
 	mpls_eth_nullary => {
 		DLT => 'EN10MB',
@@ -5859,6 +5925,7 @@ sub run_accept_test {
 	push @args, $filtertest;
 	push @args, ('-s', $test{snaplen}) if defined $test{snaplen};
 	push @args, '-O' unless $test{optimize};
+	push @args, '-l' if $test{linuxext};
 	# Write the filter expression to a file because the version of
 	# system() that takes a list does not support redirecting stdout,
 	# and the version of system() that takes a string does not escape
@@ -6003,6 +6070,7 @@ foreach my $testname (sort keys %accept_blocks) {
 				func => \&run_accept_test,
 				snaplen => defined $test->{snaplen} ? $test->{snaplen} : undef,
 				optimize => int ($optunopt eq 'opt'),
+				linuxext => defined $test->{linuxext} && $test->{linuxext} == 1,
 				expected => $test->{$optunopt},
 			};
 			$main->{$_} = $test->{$_} foreach ('DLT', 'expr');
@@ -6013,7 +6081,7 @@ foreach my $testname (sort keys %accept_blocks) {
 						label => valid_alias_label ($label, $i),
 						expr => $test->{aliases}[$i],
 					};
-					$alias->{$_} = $main->{$_} foreach ('DLT', 'func', 'optimize', 'expected', 'snaplen');
+					$alias->{$_} = $main->{$_} foreach ('DLT', 'func', 'optimize', 'expected', 'snaplen', 'linuxext');
 					push @ready_to_run, $alias;
 				}
 			}

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -490,12 +490,9 @@ my %accept_blocks = (
 			(004) ret      #0
 			EOF
 	}, # juniper_mfr_outbound
-	# The two tests below represent the current Linux-specific implementation,
-	# which is not consistent in which function -- pcap_compile() or
-	# pcap_setfilter() -- and under which conditions patches the bytecode for
-	# specific keywords.  So this behaviour may change in future.
-	linux_skf_ad_inbound => {
+	inbound_linuxext => {
 		skip => is_not_linux(),
+		linuxext => 1,
 		DLT => 'EN10MB',
 		expr => 'inbound',
 		unopt => <<~'EOF',
@@ -504,9 +501,10 @@ my %accept_blocks = (
 			(002) ret      #0
 			(003) ret      #262144
 			EOF
-	}, # linux_skf_ad_inbound
-	linux_skf_ad_outbound => {
+	}, # inbound_linuxext
+	outbound_linuxext => {
 		skip => is_not_linux(),
+		linuxext => 1,
 		DLT => 'EN10MB',
 		expr => 'outbound',
 		unopt => <<~'EOF',
@@ -515,7 +513,19 @@ my %accept_blocks = (
 			(002) ret      #262144
 			(003) ret      #0
 			EOF
-	}, # linux_skf_ad_inbound
+	}, # outbound_linuxext
+	ifindex_linuxext => {
+		skip => is_not_linux(),
+		linuxext => 1,
+		DLT => 'EN10MB',
+		expr => 'ifindex 10',
+		unopt => <<~'EOF',
+			(000) ld       [ifidx]
+			(001) jeq      #0xa             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			EOF
+	}, # ifindex_linuxext
 
 	mtp2_fisu => {
 		DLT => 'MTP2',
@@ -5776,17 +5786,41 @@ my %reject_tests = (
 		expr => 'mpls 1048576',
 		errstr => 'greater than maximum',
 	},
-	inbound_not_supported => {
+	inbound_not_supported_linux => {
+		skip => is_not_linux(),
+		DLT => 'EN10MB',
+		expr => 'inbound',
+		errstr => 'not a live capture',
+	},
+	outbound_not_supported_linux => {
+		skip => is_not_linux(),
+		DLT => 'EN10MB',
+		expr => 'outbound',
+		errstr => 'not a live capture',
+	},
+	ifindex_not_supported_linux => {
+		skip => is_not_linux(),
+		DLT => 'LINUX_SLL',
+		expr => 'ifindex 1',
+		errstr => 'not a live capture',
+	},
+	inbound_not_supported_other => {
 		skip => is_linux(),
 		DLT => 'EN10MB',
 		expr => 'inbound',
-		errstr => 'inbound/outbound not supported',
+		errstr => 'not supported',
 	},
-	outbound_not_supported => {
+	outbound_not_supported_other => {
 		skip => is_linux(),
 		DLT => 'EN10MB',
 		expr => 'outbound',
-		errstr => 'inbound/outbound not supported',
+		errstr => 'not supported',
+	},
+	ifindex_not_supported_other => {
+		skip => is_linux(),
+		DLT => 'EN10MB',
+		expr => 'ifindex 1',
+		errstr => 'not supported',
 	},
 );
 

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -362,6 +362,7 @@ main(int argc, char **argv)
 #ifdef LINUX_BPF_EXT
 	if (lflag) {
 		pd->bpf_codegen_flags |= BPF_SPECIAL_VLAN_HANDLING;
+		pd->bpf_codegen_flags |= BPF_SPECIAL_BASIC_HANDLING;
 	}
 #endif
 


### PR DESCRIPTION
Please proof-read, this looks correct to me, but the changes concern all live captures on Linux, so it is desirable not to break things.

This is one of the related imperfections discussed in #1430.