### PR TITLE
Don't fail on unsupported DSA tag

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -5482,10 +5482,14 @@ iface_dsa_get_proto_info(const char *device, pcap_t *handle)
 		}
 	}
 
+	/*
+	 * Not an error. We don't know how to decode all DSA tag formats,
+	 * but we shouldn't give up on the packet.
+	 */
 	snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
-		      "unsupported DSA tag: %s", buf);
+		 "unsupported DSA tag: %s", buf);
 
-	return PCAP_ERROR;
+	return 0;
 }
 
 /*


### PR DESCRIPTION
Up until commit 8f1f6fcbe4b4 ("If we can't allocate a DLT_ list, fail."), the iface_dsa_get_proto_info() return code was ignored, but now it isn't.

Many DSA tags are in use which libpcap has no idea about: https://github.com/the-tcpdump-group/libpcap/issues/1367

Let's keep the behavior as before, i.e. don't give up on these packets, even though we don't know what's inside.