### PR TITLE
DPDK: don't enable it by default.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -526,12 +526,12 @@ else()
     set(DISABLE_NETMAP ON)
 endif()
 
-if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR
-   CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")
-    option(DISABLE_DPDK "Disable DPDK support" OFF)
-else()
-    set(DISABLE_DPDK ON)
-endif()
+#
+# Require that DPDK support be explicitly enabled, as the code is
+# immensely hard to keep compiling for every random API change
+# the DPDK folks make.
+#
+set(DISABLE_DPDK ON)
 
 #
 # We don't support D-Bus sniffing on macOS; see

--- a/configure.ac
+++ b/configure.ac
@@ -2556,9 +2556,12 @@ AS_HELP_STRING([--with-dpdk@<:@=DIR@:>@],[include DPDK support (located in direc
 		want_dpdk=no
 	else
 		#
-		# Use DPDK API if present, otherwise don't
+		# User didn't explicitly request DPDK; don't give it
+		# to them without their consent, as the code is
+		# immensely hard to keep compiling for every random
+		# API change the DPDK folks make.
 		#
-		want_dpdk=ifpresent
+		want_dpdk=no
 	fi
 ])
 


### PR DESCRIPTION
The code is immensely hard to keep compiling for every random API change the DPDK folks make. If somebody wants DPDK support, it's on them to make it work.