### PR TITLE
WIP/RFC: add support for manual link layer offset changes

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -10712,3 +10712,11 @@ gen_atmmulti_abbrev(compiler_state_t *cstate, int type)
 	}
 	return b1;
 }
+
+struct block *gen_offset_adjustment(compiler_state_t *cstate, int n) {
+    struct block *b = new_block(cstate, BPF_JMP|BPF_JA);
+    b->s.k = 0;  // Jump by 0 bytes, effectively a no-op
+    cstate->off_linkpl.constant_part += n;
+    cstate->off_linktype.constant_part += n;
+    return b;
+}

--- a/gencode.h
+++ b/gencode.h
@@ -378,6 +378,8 @@ struct block *gen_pf_action(compiler_state_t *, int);
 struct block *gen_p80211_type(compiler_state_t *, bpf_u_int32, bpf_u_int32);
 struct block *gen_p80211_fcdir(compiler_state_t *, bpf_u_int32);
 
+struct block *gen_offset_adjustment(compiler_state_t*, int);
+
 /*
  * Representation of a program as a tree of blocks, plus current mark.
  * A block is marked if only if its mark equals the current mark.

--- a/grammar.y.in
+++ b/grammar.y.in
@@ -401,12 +401,14 @@ DIAG_OFF_BISON_BYACC
 %token	RADIO
 %token	FISU LSSU MSU HFISU HLSSU HMSU
 %token	SIO OPC DPC SLS HSIO HOPC HDPC HSLS
+%token  OFFSET OFFSET_PLUS OFFSET_MINUS
 %token	LEX_ERROR
 
 %type	<s> ID EID AID
 %type	<s> HID HID6
 %type	<h> NUM
 %type	<i> action reason type subtype type_subtype dir
+%type   <h> OFFSET_PLUS OFFSET_MINUS
 
 %left OR AND
 %nonassoc  '!'
@@ -689,6 +691,8 @@ other:	  pqual TK_BROADCAST	{ CHECK_PTR_VAL(($$ = gen_broadcast(cstate, $1))); }
 	| GENEVE		{ CHECK_PTR_VAL(($$ = gen_geneve(cstate, 0, 0))); }
 	| VXLAN pnum		{ CHECK_PTR_VAL(($$ = gen_vxlan(cstate, $2, 1))); }
 	| VXLAN			{ CHECK_PTR_VAL(($$ = gen_vxlan(cstate, 0, 0))); }
+	| OFFSET OFFSET_PLUS    { CHECK_PTR_VAL(($$ = gen_offset_adjustment(cstate, $2))); }
+    	| OFFSET OFFSET_MINUS   { CHECK_PTR_VAL(($$ = gen_offset_adjustment(cstate, -$2))); }
 	| pfvar			{ $$ = $1; }
 	| pqual p80211		{ $$ = $2; }
 	| pllc			{ $$ = $1; }
@@ -942,4 +946,5 @@ mtp3fieldvalue: NUM {
 mtp3listvalue: mtp3fieldvalue
 	| mtp3listvalue or mtp3fieldvalue { gen_or($1.b, $3.b); $$ = $3; }
 	;
+
 %%

--- a/scanner.l
+++ b/scanner.l
@@ -471,6 +471,11 @@ tcp-ack			{ yylval->h = 0x10; return NUM; }
 tcp-urg			{ yylval->h = 0x20; return NUM; }
 tcp-ece			{ yylval->h = 0x40; return NUM; }
 tcp-cwr			{ yylval->h = 0x80; return NUM; }
+
+offset		{ return OFFSET; }
+\+[0-9]+        { stou(yytext+1, yylval, yyextra); return OFFSET_PLUS; }
+-[0-9]+         { stou(yytext+1, yylval, yyextra); return OFFSET_MINUS; }
+
 [A-Za-z0-9]([-_.A-Za-z0-9]*[.A-Za-z0-9])? {
 			 yylval->s = sdup(yyextra, (char *)yytext); return ID; }
 "\\"[^ !()\n\t]+	{ yylval->s = sdup(yyextra, (char *)yytext + 1); return ID; }


### PR DESCRIPTION
This is mostly a check to see if there's interest in this kind of feature, if the approach is sane, and what all might need added if this is a feature with interest. If there's a better process for this, please let me know! The contribution guidelines are a little sparse in this area.

----

A few pcap-filter expressions implicitly change the link layer offset. There are other less common headers without their own keywords that might require skipping over some bytes in a link layer adjacent header to get to higher layer network headers. This commit adds an "offset" term that takes a + or - value to adjust the link layer offets in the same way VLAN does. This allows for something like `ethertype 0x8926 and offset +6 and vlan 14 and ip host 192.0.2.14` to skip over a vntag header, process a VLAN header, and look for an IPv4 host.