### PR TITLE
Filter Linux SocketCAN frames in userland if necessary.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -50,6 +50,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Deprecate bpf_filter().
       Require a live capture for all Linux BPF extensions.
       Have "outbound" mean Tx only for DLT_SLIP.
+      Filter Linux SocketCAN frames in userland if necessary.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -353,7 +353,6 @@ static int	iface_get_ts_types(const char *device, pcap_t *handle,
 static int	iface_get_offload(pcap_t *handle);
 
 static int	fix_program(pcap_t *handle, struct sock_fprog *fcode);
-static int	fix_offset(pcap_t *handle, struct bpf_insn *p);
 static int	set_kernel_filter(pcap_t *handle, struct sock_fprog *fcode);
 static int	reset_kernel_filter(pcap_t *handle);
 
@@ -5872,12 +5871,119 @@ fix_dlt_can_socketcan(const u_int len, struct bpf_insn insn[])
 }
 
 static int
+fix_cooked(const u_int len, struct bpf_insn insn[], int(*fixfunc)(struct bpf_insn *))
+{
+	for (u_int i = 0; i < len; ++i) {
+		/*
+		 * If this is a load instruction that loads from the packet,
+		 * fix it if possible, otherwise request userland filtering.
+		 */
+		switch (BPF_CLASS(insn[i].code) | BPF_MODE(insn[i].code)) {
+		case BPF_LD|BPF_ABS:
+		case BPF_LD|BPF_IND:
+		case BPF_LDX|BPF_MSH:
+			/*
+			 * Existing references to auxiliary data shouldn't be adjusted.
+			 *
+			 * Note that SKF_AD_OFF is negative, but p->k is unsigned, so
+			 * we use >= and cast SKF_AD_OFF to unsigned.
+			 */
+			if (insn[i].k >= (bpf_u_int32)SKF_AD_OFF)
+				break;
+
+			if (fixfunc(insn + i) < 0)
+				return 0; // Userland filtering only.
+			// Fixed now.
+			break;
+		}
+	}
+	return 1;
+}
+
+static int
+fix_offset_sll(struct bpf_insn *p)
+{
+	/*
+	 * What's the offset?
+	 */
+	if (p->k >= SLL_HDR_LEN) {
+		/*
+		 * It's within the link-layer payload; that starts
+		 * at an offset of 0, as far as the kernel packet
+		 * filter is concerned, so subtract the length of
+		 * the link-layer header.
+		 */
+		p->k -= SLL_HDR_LEN;
+	} else if (p->k == 0) {
+		/*
+		 * It's the packet type field; map it to the
+		 * special magic kernel offset for that field.
+		 */
+		p->k = SKF_AD_OFF + SKF_AD_PKTTYPE;
+	} else if (p->k == 14) {
+		/*
+		 * It's the protocol field; map it to the
+		 * special magic kernel offset for that field.
+		 */
+		p->k = SKF_AD_OFF + SKF_AD_PROTOCOL;
+	} else if ((bpf_int32)(p->k) > 0) {
+		/*
+		 * It's within the header, but it's not one of
+		 * those fields; we can't do that in the kernel,
+		 * so punt to userland.
+		 */
+		return -1;
+	}
+	return 0;
+}
+
+static int
+fix_offset_sll2(struct bpf_insn *p)
+{
+	/*
+	 * What's the offset?
+	 */
+	if (p->k >= SLL2_HDR_LEN) {
+		/*
+		 * It's within the link-layer payload; that starts
+		 * at an offset of 0, as far as the kernel packet
+		 * filter is concerned, so subtract the length of
+		 * the link-layer header.
+		 */
+		p->k -= SLL2_HDR_LEN;
+	} else if (p->k == 0) {
+		/*
+		 * It's the protocol field; map it to the
+		 * special magic kernel offset for that field.
+		 */
+		p->k = SKF_AD_OFF + SKF_AD_PROTOCOL;
+	} else if (p->k == 4) {
+		/*
+		 * It's the ifindex field; map it to the
+		 * special magic kernel offset for that field.
+		 */
+		p->k = SKF_AD_OFF + SKF_AD_IFINDEX;
+	} else if (p->k == 10) {
+		/*
+		 * It's the packet type field; map it to the
+		 * special magic kernel offset for that field.
+		 */
+		p->k = SKF_AD_OFF + SKF_AD_PKTTYPE;
+	} else if ((bpf_int32)(p->k) > 0) {
+		/*
+		 * It's within the header, but it's not one of
+		 * those fields; we can't do that in the kernel,
+		 * so punt to userland.
+		 */
+		return -1;
+	}
+	return 0;
+}
+
+static int
 fix_program(pcap_t *handle, struct sock_fprog *fcode)
 {
-	struct pcap_linux *handlep = handle->priv;
 	size_t prog_size;
-	register int i;
-	register struct bpf_insn *p;
 	struct bpf_insn *f;
 	int len;
 
@@ -5906,134 +6012,13 @@ fix_program(pcap_t *handle, struct sock_fprog *fcode)
 		 * DLT_LINUX_SLL2.
 		 */
 		return fix_dlt_can_socketcan(len, f);
+	case DLT_LINUX_SLL:
+		return fix_cooked(len, f, fix_offset_sll);
+	case DLT_LINUX_SLL2:
+		return fix_cooked(len, f, fix_offset_sll2);
 	}
 
-	for (i = 0; i < len; ++i) {
-		p = &f[i];
-		/*
-		 * What type of instruction is this?
-		 */
-		switch (BPF_CLASS(p->code)) {
-
-		case BPF_LD:
-		case BPF_LDX:
-			/*
-			 * It's a load instruction; is it loading
-			 * from the packet?
-			 */
-			switch (BPF_MODE(p->code)) {
-
-			case BPF_ABS:
-			case BPF_IND:
-			case BPF_MSH:
-				/*
-				 * Yes; are we in cooked mode?
-				 */
-				if (handlep->cooked) {
-					/*
-					 * Yes, so we need to fix this
-					 * instruction.
-					 */
-					if (fix_offset(handle, p) < 0) {
-						/*
-						 * We failed to do so.
-						 * Return 0, so our caller
-						 * knows to punt to userland.
-						 */
-						return 0;
-					}
-				}
-				break;
-			}
-			break;
-		}
-	}
 	return 1;	/* we succeeded */
-}
-
-static int
-fix_offset(pcap_t *handle, struct bpf_insn *p)
-{
-	/*
-	 * Existing references to auxiliary data shouldn't be adjusted.
-	 *
-	 * Note that SKF_AD_OFF is negative, but p->k is unsigned, so
-	 * we use >= and cast SKF_AD_OFF to unsigned.
-	 */
-	if (p->k >= (bpf_u_int32)SKF_AD_OFF)
-		return 0;
-	if (handle->linktype == DLT_LINUX_SLL2) {
-		/*
-		 * What's the offset?
-		 */
-		if (p->k >= SLL2_HDR_LEN) {
-			/*
-			 * It's within the link-layer payload; that starts
-			 * at an offset of 0, as far as the kernel packet
-			 * filter is concerned, so subtract the length of
-			 * the link-layer header.
-			 */
-			p->k -= SLL2_HDR_LEN;
-		} else if (p->k == 0) {
-			/*
-			 * It's the protocol field; map it to the
-			 * special magic kernel offset for that field.
-			 */
-			p->k = SKF_AD_OFF + SKF_AD_PROTOCOL;
-		} else if (p->k == 4) {
-			/*
-			 * It's the ifindex field; map it to the
-			 * special magic kernel offset for that field.
-			 */
-			p->k = SKF_AD_OFF + SKF_AD_IFINDEX;
-		} else if (p->k == 10) {
-			/*
-			 * It's the packet type field; map it to the
-			 * special magic kernel offset for that field.
-			 */
-			p->k = SKF_AD_OFF + SKF_AD_PKTTYPE;
-		} else if ((bpf_int32)(p->k) > 0) {
-			/*
-			 * It's within the header, but it's not one of
-			 * those fields; we can't do that in the kernel,
-			 * so punt to userland.
-			 */
-			return -1;
-		}
-	} else {
-		/*
-		 * What's the offset?
-		 */
-		if (p->k >= SLL_HDR_LEN) {
-			/*
-			 * It's within the link-layer payload; that starts
-			 * at an offset of 0, as far as the kernel packet
-			 * filter is concerned, so subtract the length of
-			 * the link-layer header.
-			 */
-			p->k -= SLL_HDR_LEN;
-		} else if (p->k == 0) {
-			/*
-			 * It's the packet type field; map it to the
-			 * special magic kernel offset for that field.
-			 */
-			p->k = SKF_AD_OFF + SKF_AD_PKTTYPE;
-		} else if (p->k == 14) {
-			/*
-			 * It's the protocol field; map it to the
-			 * special magic kernel offset for that field.
-			 */
-			p->k = SKF_AD_OFF + SKF_AD_PROTOCOL;
-		} else if ((bpf_int32)(p->k) > 0) {
-			/*
-			 * It's within the header, but it's not one of
-			 * those fields; we can't do that in the kernel,
-			 * so punt to userland.
-			 */
-			return -1;
-		}
-	}
-	return 0;
 }
 
 static int

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -5821,6 +5821,56 @@ iface_get_arptype(int fd, const char *device, char *ebuf)
 	return ifr.ifr_hwaddr.sa_family;
 }
 
+/*
+ * In a DLT_CAN_SOCKETCAN frame the first four bytes are a 32-bit integer
+ * value in host byte order if the filter program is running in the kernel and
+ * in network byte order if in userland.  This applies to both CC, FD and XL
+ * frames, see pcap_handle_packet_mmap() for the rationale.  Return 1 iff the
+ * [possibly modified] filter program can work correctly in the kernel.
+ */
+static int
+fix_dlt_can_socketcan(const u_int len, struct bpf_insn insn[])
+{
+#if __BYTE_ORDER == __LITTLE_ENDIAN
+	for (u_int i = 0; i < len; ++i) {
+		switch (insn[i].code) {
+		case BPF_LD|BPF_B|BPF_ABS: // ldb [k]
+		case BPF_LDX|BPF_MSH|BPF_B: // ldxb 4*([k]&0xf)
+			if (insn[i].k < 4)
+				insn[i].k = 3 - insn[i].k; // Fixed now.
+			break;
+		case BPF_LD|BPF_H|BPF_ABS: // ldh [k]
+		case BPF_LD|BPF_W|BPF_ABS: // ld [k]
+			/*
+			 * A halfword or a word load cannot be fixed by just
+			 * changing k, even if every required byte is within
+			 * the byte-swapped part of the frame, even if the
+			 * load is aligned.  The fix would require either
+			 * rewriting the filter program extensively or
+			 * generating it differently in the first place.
+			 */
+		case BPF_LD|BPF_B|BPF_IND: // ldb [x + k]
+		case BPF_LD|BPF_H|BPF_IND: // ldh [x + k]
+		case BPF_LD|BPF_W|BPF_IND: // ld [x + k]
+			/*
+			 * In addition to the above, a variable offset load
+			 * cannot be fixed because x can have any value, thus
+			 * x + k can have any value, but only the first four
+			 * bytes are swapped.  An easy way to demonstrate it
+			 * is to compile "link[link[4]] == 0", which will use
+			 * "ldb [x + 0]" to access one of the first four bytes
+			 * of the frame iff CAN CC/FD payload length is less
+			 * than 4.
+			 */
+			if (insn[i].k < 4)
+				return 0; // Userland filtering only.
+			break;
+		}
+	}
+#endif // __BYTE_ORDER == __LITTLE_ENDIAN
+	return 1;
+}
+
 static int
 fix_program(pcap_t *handle, struct sock_fprog *fcode)
 {
@@ -5846,6 +5896,17 @@ fix_program(pcap_t *handle, struct sock_fprog *fcode)
 	memcpy(f, handle->fcode.bf_insns, prog_size);
 	fcode->len = len;
 	fcode->filter = (struct sock_filter *) f;
+
+	switch (handle->linktype) {
+	case DLT_CAN_SOCKETCAN:
+		/*
+		 * If a similar fix needs to be done for CAN frames that
+		 * appear on the "any" pseudo-interface, it needs to be done
+		 * differently because that would be within DLT_LINUX_SLL or
+		 * DLT_LINUX_SLL2.
+		 */
+		return fix_dlt_can_socketcan(len, f);
+	}
 
 	for (i = 0; i < len; ++i) {
 		p = &f[i];


### PR DESCRIPTION
To the best of my understanding, this is a correct workaround for #1247. It works in my tests with CAN CC. Tests for this code path do not exist, at least not yet, so please proof-read if you can.