### PR TITLE
Autoconf: Use AC_SYS_YEAR2038_RECOMMENDED when possible

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -23,6 +23,27 @@ fi
 
 echo "$AUTORECONF identification: $AUTORECONFVERSION"
 
+# On Linux, if Autoconf version >= 2.72 and GNU C Library version >= 2.34,
+# s/AC_SYS_LARGEFILE/AC_SYS_YEAR2038_RECOMMENDED/ to ensure time_t
+# is Y2038-safe.
+if [ "`uname -s`" = Linux ]; then
+	if [ "$maj" -gt 2 ] || { [ "$maj" -eq 2 ] && [ "$min" -ge 72 ]; }; then
+		GLIBC_VERSION=$(ldd --version|head -1|grep GLIBC|sed 's/.* //')
+		maj_glibc=`echo "$GLIBC_VERSION" | cut -d. -f1`
+		min_glibc=`echo "$GLIBC_VERSION" | cut -d. -f2`
+		if [ "$maj_glibc" -gt 2 ] || { [ "$maj_glibc" -eq 2 ] && \
+		   [ "$min_glibc" -ge 34 ]; }; then
+			CONFIGURE_AC_NEW="configure.ac.new$$"
+			sed 's/^AC_SYS_LARGEFILE/AC_SYS_YEAR2038_RECOMMENDED/' \
+				<configure.ac >"$CONFIGURE_AC_NEW"
+			cmp -s configure.ac "$CONFIGURE_AC_NEW" || \
+			cat "$CONFIGURE_AC_NEW" >configure.ac
+			rm -f "$CONFIGURE_AC_NEW"
+			echo 'Setup to ensure time_t is Y2038-safe.'
+		fi
+	fi
+fi
+
 # configure.ac is an Autoconf 2.69 file, but it works as expected even with
 # Autoconf 2.72.  However, in Autoconf versions 2.70 and later obsolete
 # construct warnings are enabled by default, which adds varying (depending on


### PR DESCRIPTION
On Linux, if Autoconf version >= 2.72 and GNU C Library version >= 2.34, 
s/AC_SYS_LARGEFILE/AC_SYS_YEAR2038_RECOMMENDED/ to ensure time_t is Y2038-safe.