### PR TITLE
Autoconf: Update autogen.sh to fix run on Solaris

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -28,7 +28,7 @@ echo "$AUTORECONF identification: $AUTORECONFVERSION"
 # is Y2038-safe.
 if [ "`uname -s`" = Linux ]; then
 	if [ "$maj" -gt 2 ] || { [ "$maj" -eq 2 ] && [ "$min" -ge 72 ]; }; then
-		GLIBC_VERSION=$(ldd --version|head -1|grep GLIBC|sed 's/.* //')
+		GLIBC_VERSION=`ldd --version|head -1|grep GLIBC|sed 's/.* //'`
 		maj_glibc=`echo "$GLIBC_VERSION" | cut -d. -f1`
 		min_glibc=`echo "$GLIBC_VERSION" | cut -d. -f2`
 		if [ "$maj_glibc" -gt 2 ] || { [ "$maj_glibc" -eq 2 ] && \


### PR DESCRIPTION
Solaris /bin/sh before 11 does not support the $() command substitution syntax.

The error was:
./autogen.sh: syntax error at line 31: `GLIBC_VERSION=$' unexpected