### PR TITLE
assorted fixups for the "byte" primitive

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -57,6 +57,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Use the correct IS-IS PDU type offset for DLT_C_HDLC.
       Use the correct bit mask for IS-IS PDU type value.
       Fix the "|" and "&" operators of the "byte" primitive.
+      Require "byte" argument value to be within range.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/CHANGES
+++ b/CHANGES
@@ -56,6 +56,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Require "(iso|isis) proto" values to be within valid ranges.
       Use the correct IS-IS PDU type offset for DLT_C_HDLC.
       Use the correct bit mask for IS-IS PDU type value.
+      Fix the "|" and "&" operators of the "byte" primitive.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/gencode.c
+++ b/gencode.c
@@ -8123,6 +8123,8 @@ gen_byteop(compiler_state_t *cstate, int op, int idx, bpf_u_int32 val)
 	if (setjmp(cstate->top_ctx))
 		return (NULL);
 
+	assert_maxval(cstate, "byte argument", val, UINT8_MAX);
+
 	switch (op) {
 	default:
 		abort();

--- a/gencode.c
+++ b/gencode.c
@@ -8147,8 +8147,11 @@ gen_byteop(compiler_state_t *cstate, int op, int idx, bpf_u_int32 val)
 		break;
 	}
 	s->s.k = val;
+	// Load the required byte first.
+	struct slist *s0 = gen_load_a(cstate, OR_LINKHDR, idx, BPF_B);
+	sappend(s0, s);
 	b = new_block(cstate, JMP(BPF_JEQ));
-	b->stmts = s;
+	b->stmts = s0;
 	gen_not(b);
 
 	return b;

--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -18,7 +18,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP-FILTER @MAN_MISC_INFO@ "25 March 2025"
+.TH PCAP-FILTER @MAN_MISC_INFO@ "27 March 2025"
 .SH NAME
 pcap-filter \- packet filter syntax
 .br
@@ -1331,6 +1331,36 @@ are equivalent to
 Note that this address syntax clashes with the parameter expansion syntax
 in POSIX-compatible shells and elsewhere, so depending on the use case the
 filter string may require the use of single quotes or a backslash.
+.IP "\fBbyte \fIidx op val\fR"
+True if the value of the link layer byte number
+.I idx
+satisfies a condition with regard to
+.IR val ,
+which can be a number only.  The condition is one of: "equals to" (if
+.I op
+is
+.BR = ),
+"less than" (if
+.I op
+is
+.BR < ),
+"greater than" (if
+.I op
+is
+.BR > ),
+"the result of bitwise AND is not zero" (if
+.I op
+is
+.BR & ),
+"the result of bitwise OR is not zero" (if
+.I op
+is
+.BR | ).
+.IP
+The arithmetic expressions and packet data accessors below implement all of
+these and many other things much better, so this primitive will be removed in
+a future release and should not be used in applications that require forward
+compatibility.
 .SH ARITHMETIC EXPRESSIONS
 Arithmetic expressions are the operands of a relational operator in a
 relation of the following form:

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -12223,6 +12223,36 @@ my @reject_tests = (
 		expr => 'byte 1 >> 2',
 		errstr => 'syntax error',
 	},
+	{
+		name => 'byte_eq_256',
+		DLT => 'IPV4',
+		expr => 'byte 1 = 256',
+		errstr => 'byte argument 256 greater than maximum 255',
+	},
+	{
+		name => 'byte_lt_256',
+		DLT => 'IPV4',
+		expr => 'byte 1 < 256',
+		errstr => 'byte argument 256 greater than maximum 255',
+	},
+	{
+		name => 'byte_gt_256',
+		DLT => 'IPV4',
+		expr => 'byte 1 > 256',
+		errstr => 'byte argument 256 greater than maximum 255',
+	},
+	{
+		name => 'byte_and_256',
+		DLT => 'IPV4',
+		expr => 'byte 1 & 256',
+		errstr => 'byte argument 256 greater than maximum 255',
+	},
+	{
+		name => 'byte_or_256',
+		DLT => 'IPV4',
+		expr => 'byte 1 | 256',
+		errstr => 'byte argument 256 greater than maximum 255',
+	},
 );
 
 push @reject_tests, {

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -10623,6 +10623,64 @@ my @accept_blocks = (
 			(020) ret      #0
 			',
 	}, # dst_portrange
+	{
+		name => 'byte_eq',
+		DLT => 'IPV4',
+		aliases => [
+			'byte 8 = 5',
+			'byte 8 == 5',
+		],
+		unopt => '
+			(000) ldb      [8]
+			(001) jeq      #0x5             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # byte_eq
+	{
+		name => 'byte_lt',
+		DLT => 'IPV4',
+		aliases => ['byte 8 < 5'],
+		unopt => '
+			(000) ldb      [8]
+			(001) jge      #0x5             jt 2	jf 3
+			(002) ret      #0
+			(003) ret      #262144
+			',
+	}, # byte_lt
+	{
+		name => 'byte_gt',
+		DLT => 'IPV4',
+		aliases => ['byte 8 > 5'],
+		unopt => '
+			(000) ldb      [8]
+			(001) jgt      #0x5             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # byte_gt
+	{
+		name => 'byte_or',
+		DLT => 'IPV4',
+		aliases => ['byte 8 | 5'],
+		unopt => '
+			(000) or       #0x5
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #0
+			(003) ret      #262144
+			',
+	}, # byte_or
+	{
+		name => 'byte_and',
+		DLT => 'IPV4',
+		aliases => ['byte 8 & 5'],
+		unopt => '
+			(000) and      #0x5
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #0
+			(003) ret      #262144
+			',
+	}, # byte_and
 );
 
 # In apply_blocks each test block always generates two tests: optimized and
@@ -12126,6 +12184,42 @@ my @reject_tests = (
 		DLT => 'EN10MB',
 		expr => 'isis proto 32',
 		errstr => 'IS-IS PDU type 32 greater than maximum 31',
+	},
+	{
+		name => 'byte_ne',
+		DLT => 'IPV4',
+		expr => 'byte 1 != 2',
+		errstr => 'syntax error',
+	},
+	{
+		name => 'byte_le',
+		DLT => 'IPV4',
+		expr => 'byte 1 <= 2',
+		errstr => 'syntax error',
+	},
+	{
+		name => 'byte_ge',
+		DLT => 'IPV4',
+		expr => 'byte 1 >= 2',
+		errstr => 'syntax error',
+	},
+	{
+		name => 'byte_xor',
+		DLT => 'IPV4',
+		expr => 'byte 1 ^ 2',
+		errstr => 'syntax error',
+	},
+	{
+		name => 'byte_lsh',
+		DLT => 'IPV4',
+		expr => 'byte 1 << 2',
+		errstr => 'syntax error',
+	},
+	{
+		name => 'byte_rsh',
+		DLT => 'IPV4',
+		expr => 'byte 1 >> 2',
+		errstr => 'syntax error',
 	},
 );
 

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -10664,10 +10664,11 @@ my @accept_blocks = (
 		DLT => 'IPV4',
 		aliases => ['byte 8 | 5'],
 		unopt => '
-			(000) or       #0x5
-			(001) jeq      #0x0             jt 2	jf 3
-			(002) ret      #0
-			(003) ret      #262144
+			(000) ldb      [8]
+			(001) or       #0x5
+			(002) jeq      #0x0             jt 3	jf 4
+			(003) ret      #0
+			(004) ret      #262144
 			',
 	}, # byte_or
 	{
@@ -10675,10 +10676,11 @@ my @accept_blocks = (
 		DLT => 'IPV4',
 		aliases => ['byte 8 & 5'],
 		unopt => '
-			(000) and      #0x5
-			(001) jeq      #0x0             jt 2	jf 3
-			(002) ret      #0
-			(003) ret      #262144
+			(000) ldb      [8]
+			(001) and      #0x5
+			(002) jeq      #0x0             jt 3	jf 4
+			(003) ret      #0
+			(004) ret      #262144
 			',
 	}, # byte_and
 );


### PR DESCRIPTION
This makes `byte` deterministic and a strict subset of modern syntax until it is clear when/how to deprecate this primitive.