### PR TITLE
assorted refactoring and all-zero tetras

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -5236,6 +5236,12 @@ gen_host6(compiler_state_t *cstate, struct in6_addr *addr,
 	case Q_DEFAULT:
 	case Q_IPV6:
 		b0 = gen_linktype(cstate, ETHERTYPE_IPV6);
+		// Same as the Q_IP case in gen_host().
+		if (
+			! memcmp(mask, &in6addr_any, sizeof(struct in6_addr)) &&
+			! memcmp(addr, &in6addr_any, sizeof(struct in6_addr))
+		)
+			return b0;
 		b1 = gen_hostop6(cstate, addr, mask, dir, 8, 24);
 		gen_and(b0, b1);
 		return b1;

--- a/gencode.c
+++ b/gencode.c
@@ -5172,16 +5172,16 @@ gen_mpls_linktype(compiler_state_t *cstate, bpf_u_int32 ll_proto)
 	case ETHERTYPE_IPV6:
 		/* match the bottom-of-stack bit */
 		b0 = gen_mcmp(cstate, OR_LINKPL, (u_int)-2, BPF_B, 0x01, 0x01);
-		/* match the IPv4 version number */
+		/* match the IPv6 version number */
 		b1 = gen_mcmp(cstate, OR_LINKPL, 0, BPF_B, 0x60, 0xf0);
 		gen_and(b0, b1);
 		return b1;
 
- default:
-	 /* FIXME add other L3 proto IDs */
-	 bpf_error(cstate, "unsupported protocol over mpls");
-	 /*NOTREACHED*/
- }
+	default:
+		/* FIXME add other L3 proto IDs */
+		bpf_error(cstate, "unsupported protocol over mpls");
+		/*NOTREACHED*/
+	}
 }
 
 static struct block *

--- a/gencode.c
+++ b/gencode.c
@@ -5136,18 +5136,33 @@ gen_host(compiler_state_t *cstate, bpf_u_int32 addr, bpf_u_int32 mask,
 
 	case Q_IP:
 		b0 = gen_linktype(cstate, ETHERTYPE_IP);
+		/*
+		 * Belt and braces: if other code works correctly, any host
+		 * bits are clear and mask == 0 means addr == 0.  In this case
+		 * the call to gen_hostop() would produce an "always true"
+		 * instruction block and ANDing it with the link type check
+		 * would be a no-op.
+		 */
+		if (mask == 0 && addr == 0)
+			return b0;
 		b1 = gen_hostop(cstate, addr, mask, dir, 12, 16);
 		gen_and(b0, b1);
 		return b1;
 
 	case Q_RARP:
 		b0 = gen_linktype(cstate, ETHERTYPE_REVARP);
+		// Same as for Q_IP above.
+		if (mask == 0 && addr == 0)
+			return b0;
 		b1 = gen_hostop(cstate, addr, mask, dir, 14, 24);
 		gen_and(b0, b1);
 		return b1;
 
 	case Q_ARP:
 		b0 = gen_linktype(cstate, ETHERTYPE_ARP);
+		// Same as for Q_IP above.
+		if (mask == 0 && addr == 0)
+			return b0;
 		b1 = gen_hostop(cstate, addr, mask, dir, 14, 24);
 		gen_and(b0, b1);
 		return b1;

--- a/gencode.c
+++ b/gencode.c
@@ -729,6 +729,8 @@ static struct block *gen_atmfield_code_internal(compiler_state_t *, int,
 static struct block *gen_atmtype_llc(compiler_state_t *);
 static struct block *gen_msg_abbrev(compiler_state_t *, const uint8_t);
 static struct block *gen_atm_prototype(compiler_state_t *, const uint8_t);
+static struct block *gen_atm_vpi(compiler_state_t *, const uint8_t);
+static struct block *gen_atm_vci(compiler_state_t *, const uint16_t);
 
 static void
 initchunks(compiler_state_t *cstate)
@@ -9742,12 +9744,24 @@ gen_atmfield_code_internal(compiler_state_t *cstate, int atmfield,
 }
 
 static struct block *
+gen_atm_vpi(compiler_state_t *cstate, const uint8_t v)
+{
+	return gen_atmfield_code_internal(cstate, A_VPI, v, BPF_JEQ, 0);
+}
+
+static struct block *
+gen_atm_vci(compiler_state_t *cstate, const uint16_t v)
+{
+	return gen_atmfield_code_internal(cstate, A_VCI, v, BPF_JEQ, 0);
+}
+
+static struct block *
 gen_atmtype_metac(compiler_state_t *cstate)
 {
 	struct block *b0, *b1;
 
-	b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
-	b1 = gen_atmfield_code_internal(cstate, A_VCI, 1, BPF_JEQ, 0);
+	b0 = gen_atm_vpi(cstate, 0);
+	b1 = gen_atm_vci(cstate, 1);
 	gen_and(b0, b1);
 	return b1;
 }
@@ -9757,8 +9771,8 @@ gen_atmtype_sc(compiler_state_t *cstate)
 {
 	struct block *b0, *b1;
 
-	b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
-	b1 = gen_atmfield_code_internal(cstate, A_VCI, 5, BPF_JEQ, 0);
+	b0 = gen_atm_vpi(cstate, 0);
+	b1 = gen_atm_vci(cstate, 5);
 	gen_and(b0, b1);
 	return b1;
 }
@@ -9817,22 +9831,22 @@ gen_atmtype_abbrev(compiler_state_t *cstate, int type)
 
 	case A_BCC:
 		/* Get all packets in Broadcast Circuit*/
-		b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
-		b1 = gen_atmfield_code_internal(cstate, A_VCI, 2, BPF_JEQ, 0);
+		b0 = gen_atm_vpi(cstate, 0);
+		b1 = gen_atm_vci(cstate, 2);
 		gen_and(b0, b1);
 		break;
 
 	case A_OAMF4SC:
 		/* Get all cells in Segment OAM F4 circuit*/
-		b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
-		b1 = gen_atmfield_code_internal(cstate, A_VCI, 3, BPF_JEQ, 0);
+		b0 = gen_atm_vpi(cstate, 0);
+		b1 = gen_atm_vci(cstate, 3);
 		gen_and(b0, b1);
 		break;
 
 	case A_OAMF4EC:
 		/* Get all cells in End-to-End OAM F4 Circuit*/
-		b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
-		b1 = gen_atmfield_code_internal(cstate, A_VCI, 4, BPF_JEQ, 0);
+		b0 = gen_atm_vpi(cstate, 0);
+		b1 = gen_atm_vci(cstate, 4);
 		gen_and(b0, b1);
 		break;
 
@@ -9843,8 +9857,8 @@ gen_atmtype_abbrev(compiler_state_t *cstate, int type)
 
 	case A_ILMIC:
 		/* Get all packets in ILMI Circuit */
-		b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
-		b1 = gen_atmfield_code_internal(cstate, A_VCI, 16, BPF_JEQ, 0);
+		b0 = gen_atm_vpi(cstate, 0);
+		b1 = gen_atm_vci(cstate, 16);
 		gen_and(b0, b1);
 		break;
 
@@ -10097,19 +10111,19 @@ gen_atmmulti_abbrev(compiler_state_t *cstate, int type)
 
 	case A_OAM:
 		/* OAM F4 type */
-		b0 = gen_atmfield_code_internal(cstate, A_VCI, 3, BPF_JEQ, 0);
-		b1 = gen_atmfield_code_internal(cstate, A_VCI, 4, BPF_JEQ, 0);
+		b0 = gen_atm_vci(cstate, 3);
+		b1 = gen_atm_vci(cstate, 4);
 		gen_or(b0, b1);
-		b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
+		b0 = gen_atm_vpi(cstate, 0);
 		gen_and(b0, b1);
 		break;
 
 	case A_OAMF4:
 		/* OAM F4 type */
-		b0 = gen_atmfield_code_internal(cstate, A_VCI, 3, BPF_JEQ, 0);
-		b1 = gen_atmfield_code_internal(cstate, A_VCI, 4, BPF_JEQ, 0);
+		b0 = gen_atm_vci(cstate, 3);
+		b1 = gen_atm_vci(cstate, 4);
 		gen_or(b0, b1);
-		b0 = gen_atmfield_code_internal(cstate, A_VPI, 0, BPF_JEQ, 0);
+		b0 = gen_atm_vpi(cstate, 0);
 		gen_and(b0, b1);
 		break;
 

--- a/gencode.c
+++ b/gencode.c
@@ -9756,28 +9756,6 @@ gen_atm_vci(compiler_state_t *cstate, const uint16_t v)
 }
 
 static struct block *
-gen_atmtype_metac(compiler_state_t *cstate)
-{
-	struct block *b0, *b1;
-
-	b0 = gen_atm_vpi(cstate, 0);
-	b1 = gen_atm_vci(cstate, 1);
-	gen_and(b0, b1);
-	return b1;
-}
-
-static struct block *
-gen_atmtype_sc(compiler_state_t *cstate)
-{
-	struct block *b0, *b1;
-
-	b0 = gen_atm_vpi(cstate, 0);
-	b1 = gen_atm_vci(cstate, 5);
-	gen_and(b0, b1);
-	return b1;
-}
-
-static struct block *
 gen_atm_prototype(compiler_state_t *cstate, const uint8_t v)
 {
 	return gen_mcmp(cstate, OR_LINKHDR, cstate->off_proto, BPF_B, v, 0x0fU);
@@ -9826,7 +9804,9 @@ gen_atmtype_abbrev(compiler_state_t *cstate, int type)
 
 	case A_METAC:
 		/* Get all packets in Meta signalling Circuit */
-		b1 = gen_atmtype_metac(cstate);
+		b0 = gen_atm_vpi(cstate, 0);
+		b1 = gen_atm_vci(cstate, 1);
+		gen_and(b0, b1);
 		break;
 
 	case A_BCC:
@@ -9852,7 +9832,9 @@ gen_atmtype_abbrev(compiler_state_t *cstate, int type)
 
 	case A_SC:
 		/*  Get all packets in connection Signalling Circuit */
-		b1 = gen_atmtype_sc(cstate);
+		b0 = gen_atm_vpi(cstate, 0);
+		b1 = gen_atm_vci(cstate, 5);
+		gen_and(b0, b1);
 		break;
 
 	case A_ILMIC:
@@ -10143,7 +10125,7 @@ gen_atmmulti_abbrev(compiler_state_t *cstate, int type)
 		gen_or(b0, b1);
 		b0 = gen_msg_abbrev(cstate, RELEASE_DONE);
 		gen_or(b0, b1);
-		b0 = gen_atmtype_sc(cstate);
+		b0 = gen_atmtype_abbrev(cstate, A_SC);
 		gen_and(b0, b1);
 		break;
 
@@ -10157,7 +10139,7 @@ gen_atmmulti_abbrev(compiler_state_t *cstate, int type)
 		gen_or(b0, b1);
 		b0 = gen_msg_abbrev(cstate, RELEASE_DONE);
 		gen_or(b0, b1);
-		b0 = gen_atmtype_metac(cstate);
+		b0 = gen_atmtype_abbrev(cstate, A_METAC);
 		gen_and(b0, b1);
 		break;
 

--- a/gencode.h
+++ b/gencode.h
@@ -161,19 +161,9 @@
 #define A_OAMF4		29	/* OAM F4 cells: Segment + End-to-end */
 #define A_LANE		30	/* LANE traffic */
 
-/* Based on Q.2931 signalling protocol */
-#define A_SETUP		41	/* Setup message */
-#define A_CALLPROCEED	42	/* Call proceeding message */
-#define A_CONNECT	43	/* Connect message */
-#define A_CONNECTACK	44	/* Connect Ack message */
-#define A_RELEASE	45	/* Release message */
-#define A_RELEASE_DONE	46	/* Release message */
-
 /* ATM field types */
 #define A_VPI		51
 #define A_VCI		52
-#define A_PROTOTYPE	53
-#define A_MSGTYPE	54
 
 #define A_CONNECTMSG	70	/* returns Q.2931 signalling messages for
 				   establishing and destroying switched

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -9177,7 +9177,30 @@ my @accept_blocks = (
 			',
 	}, # ip_src_net_NAME
 	{
-		name => 'ip_dst_net_addr',
+		name => 'ip_dst_net_addr_0',
+		DLT => 'RAW',
+		snaplen => 2000,
+		aliases => ['ip dst net 0.0.0.0/0'],
+		opt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x40            jt 3	jf 4
+			(003) ret      #2000
+			(004) ret      #0
+			',
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x40            jt 3	jf 7
+			(003) ld       [16]
+			(004) and      #0x0
+			(005) jeq      #0x0             jt 6	jf 7
+			(006) ret      #2000
+			(007) ret      #0
+			',
+	}, # ip_dst_net_addr_0
+	{
+		name => 'ip_dst_net_addr_8',
 		DLT => 'RAW',
 		snaplen => 2000,
 		aliases => [
@@ -9201,7 +9224,7 @@ my @accept_blocks = (
 			(006) ret      #2000
 			(007) ret      #0
 			',
-	}, # ip_dst_net_addr
+	}, # ip_dst_net_addr_8
 	{
 		name => 'ip_dst_net_name',
 		skip => skip_no_networks(),
@@ -11257,6 +11280,16 @@ my @accept_blocks = (
 			'host ::1',
 			'src or dst host ::1',
 			'src or dst ::1',
+			'ip6 net ::1/128',
+			'ip6 src or dst net ::1/128',
+			'net ::1/128',
+			'src or dst net ::1/128',
+			# "...so in this primitive IPv6 "network" matches are really always
+			# host matches"
+			'ip6 net ::1',
+			'ip6 src or dst net ::1',
+			'net ::1',
+			'src or dst net ::1',
 			# This syntax is not documented and seems to be an unintended edge case
 			# in the invocation of gen_mcode6() from the grammar.  It may become
 			# invalid syntax later, in which case the aliases below will need to be
@@ -11588,13 +11621,42 @@ my @accept_blocks = (
 			',
 	}, # ip6_src_net
 	{
-		name => 'ip6_dst_net',
+		name => 'ip6_dst_net_0',
 		skip => skip_config_undef ('INET6'),
 		DLT => 'RAW',
-		aliases => [
-			'ip6 dst net ff00::/8',
-			'dst net ff00::/8',
-		],
+		aliases => ['ip6 dst net ::/0'],
+		opt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 16
+			(003) ld       [24]
+			(004) and      #0x0
+			(005) jeq      #0x0             jt 6	jf 16
+			(006) ld       [28]
+			(007) and      #0x0
+			(008) jeq      #0x0             jt 9	jf 16
+			(009) ld       [32]
+			(010) and      #0x0
+			(011) jeq      #0x0             jt 12	jf 16
+			(012) ld       [36]
+			(013) and      #0x0
+			(014) jeq      #0x0             jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			',
+	}, # ip6_dst_net_0
+	{
+		name => 'ip6_dst_net_8',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'RAW',
+		aliases => ['ip6 dst net ff00::/8'],
 		opt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
@@ -11605,7 +11667,121 @@ my @accept_blocks = (
 			(006) ret      #262144
 			(007) ret      #0
 			',
-	}, # ip6_net
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 16
+			(003) ld       [24]
+			(004) and      #0xff000000
+			(005) jeq      #0xff000000      jt 6	jf 16
+			(006) ld       [28]
+			(007) and      #0x0
+			(008) jeq      #0x0             jt 9	jf 16
+			(009) ld       [32]
+			(010) and      #0x0
+			(011) jeq      #0x0             jt 12	jf 16
+			(012) ld       [36]
+			(013) and      #0x0
+			(014) jeq      #0x0             jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			',
+	}, # ip6_dst_net_8
+	{
+		name => 'ip6_dst_net_40',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'RAW',
+		aliases => ['ip6 dst net ff11:2233:4400::/40'],
+		opt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 9
+			(003) ld       [24]
+			(004) jeq      #0xff112233      jt 5	jf 9
+			(005) ld       [28]
+			(006) and      #0xff000000
+			(007) jeq      #0x44000000      jt 8	jf 9
+			(008) ret      #262144
+			(009) ret      #0
+			',
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 15
+			(003) ld       [24]
+			(004) jeq      #0xff112233      jt 5	jf 15
+			(005) ld       [28]
+			(006) and      #0xff000000
+			(007) jeq      #0x44000000      jt 8	jf 15
+			(008) ld       [32]
+			(009) and      #0x0
+			(010) jeq      #0x0             jt 11	jf 15
+			(011) ld       [36]
+			(012) and      #0x0
+			(013) jeq      #0x0             jt 14	jf 15
+			(014) ret      #262144
+			(015) ret      #0
+			',
+	}, # ip6_dst_net_40
+	{
+		name => 'ip6_dst_net_80',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'RAW',
+		aliases => ['ip6 dst net ff11:2233:4455:6677:8899::/80'],
+		opt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 11
+			(003) ld       [24]
+			(004) jeq      #0xff112233      jt 5	jf 11
+			(005) ld       [28]
+			(006) jeq      #0x44556677      jt 7	jf 11
+			(007) ld       [32]
+			(008) and      #0xffff0000
+			(009) jeq      #0x88990000      jt 10	jf 11
+			(010) ret      #262144
+			(011) ret      #0
+			',
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 14
+			(003) ld       [24]
+			(004) jeq      #0xff112233      jt 5	jf 14
+			(005) ld       [28]
+			(006) jeq      #0x44556677      jt 7	jf 14
+			(007) ld       [32]
+			(008) and      #0xffff0000
+			(009) jeq      #0x88990000      jt 10	jf 14
+			(010) ld       [36]
+			(011) and      #0x0
+			(012) jeq      #0x0             jt 13	jf 14
+			(013) ret      #262144
+			(014) ret      #0
+			',
+	}, # ip6_dst_net_80
+	{
+		name => 'ip6_dst_net_120',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'RAW',
+		aliases => ['ip6 dst net ff11:2233:4455:6677:8899:aabb:ccdd:ee00/120'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 13
+			(003) ld       [24]
+			(004) jeq      #0xff112233      jt 5	jf 13
+			(005) ld       [28]
+			(006) jeq      #0x44556677      jt 7	jf 13
+			(007) ld       [32]
+			(008) jeq      #0x8899aabb      jt 9	jf 13
+			(009) ld       [36]
+			(010) and      #0xffffff00
+			(011) jeq      #0xccddee00      jt 12	jf 13
+			(012) ret      #262144
+			(013) ret      #0
+			',
+	}, # ip6_dst_net_120
 	{
 		name => 'ip6_multicast',
 		DLT => 'IPV6',

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -9191,12 +9191,11 @@ my @accept_blocks = (
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
-			(002) jeq      #0x40            jt 3	jf 7
-			(003) ld       [16]
-			(004) and      #0x0
-			(005) jeq      #0x0             jt 6	jf 7
-			(006) ret      #2000
-			(007) ret      #0
+			(002) jeq      #0x40            jt 3	jf 6
+			(003) ld       #0x0
+			(004) jeq      #0x0             jt 5	jf 6
+			(005) ret      #2000
+			(006) ret      #0
 			',
 	}, # ip_dst_net_addr_0
 	{
@@ -11635,21 +11634,17 @@ my @accept_blocks = (
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 16
-			(003) ld       [24]
-			(004) and      #0x0
-			(005) jeq      #0x0             jt 6	jf 16
-			(006) ld       [28]
-			(007) and      #0x0
-			(008) jeq      #0x0             jt 9	jf 16
-			(009) ld       [32]
-			(010) and      #0x0
-			(011) jeq      #0x0             jt 12	jf 16
-			(012) ld       [36]
-			(013) and      #0x0
-			(014) jeq      #0x0             jt 15	jf 16
-			(015) ret      #262144
-			(016) ret      #0
+			(002) jeq      #0x60            jt 3	jf 12
+			(003) ld       #0x0
+			(004) jeq      #0x0             jt 5	jf 12
+			(005) ld       #0x0
+			(006) jeq      #0x0             jt 7	jf 12
+			(007) ld       #0x0
+			(008) jeq      #0x0             jt 9	jf 12
+			(009) ld       #0x0
+			(010) jeq      #0x0             jt 11	jf 12
+			(011) ret      #262144
+			(012) ret      #0
 			',
 	}, # ip6_dst_net_0
 	{
@@ -11670,21 +11665,18 @@ my @accept_blocks = (
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 16
+			(002) jeq      #0x60            jt 3	jf 13
 			(003) ld       [24]
 			(004) and      #0xff000000
-			(005) jeq      #0xff000000      jt 6	jf 16
-			(006) ld       [28]
-			(007) and      #0x0
-			(008) jeq      #0x0             jt 9	jf 16
-			(009) ld       [32]
-			(010) and      #0x0
-			(011) jeq      #0x0             jt 12	jf 16
-			(012) ld       [36]
-			(013) and      #0x0
-			(014) jeq      #0x0             jt 15	jf 16
-			(015) ret      #262144
-			(016) ret      #0
+			(005) jeq      #0xff000000      jt 6	jf 13
+			(006) ld       #0x0
+			(007) jeq      #0x0             jt 8	jf 13
+			(008) ld       #0x0
+			(009) jeq      #0x0             jt 10	jf 13
+			(010) ld       #0x0
+			(011) jeq      #0x0             jt 12	jf 13
+			(012) ret      #262144
+			(013) ret      #0
 			',
 	}, # ip6_dst_net_8
 	{
@@ -11707,20 +11699,18 @@ my @accept_blocks = (
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 15
+			(002) jeq      #0x60            jt 3	jf 13
 			(003) ld       [24]
-			(004) jeq      #0xff112233      jt 5	jf 15
+			(004) jeq      #0xff112233      jt 5	jf 13
 			(005) ld       [28]
 			(006) and      #0xff000000
-			(007) jeq      #0x44000000      jt 8	jf 15
-			(008) ld       [32]
-			(009) and      #0x0
-			(010) jeq      #0x0             jt 11	jf 15
-			(011) ld       [36]
-			(012) and      #0x0
-			(013) jeq      #0x0             jt 14	jf 15
-			(014) ret      #262144
-			(015) ret      #0
+			(007) jeq      #0x44000000      jt 8	jf 13
+			(008) ld       #0x0
+			(009) jeq      #0x0             jt 10	jf 13
+			(010) ld       #0x0
+			(011) jeq      #0x0             jt 12	jf 13
+			(012) ret      #262144
+			(013) ret      #0
 			',
 	}, # ip6_dst_net_40
 	{
@@ -11745,19 +11735,18 @@ my @accept_blocks = (
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 14
+			(002) jeq      #0x60            jt 3	jf 13
 			(003) ld       [24]
-			(004) jeq      #0xff112233      jt 5	jf 14
+			(004) jeq      #0xff112233      jt 5	jf 13
 			(005) ld       [28]
-			(006) jeq      #0x44556677      jt 7	jf 14
+			(006) jeq      #0x44556677      jt 7	jf 13
 			(007) ld       [32]
 			(008) and      #0xffff0000
-			(009) jeq      #0x88990000      jt 10	jf 14
-			(010) ld       [36]
-			(011) and      #0x0
-			(012) jeq      #0x0             jt 13	jf 14
-			(013) ret      #262144
-			(014) ret      #0
+			(009) jeq      #0x88990000      jt 10	jf 13
+			(010) ld       #0x0
+			(011) jeq      #0x0             jt 12	jf 13
+			(012) ret      #262144
+			(013) ret      #0
 			',
 	}, # ip6_dst_net_80
 	{

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -9181,21 +9181,12 @@ my @accept_blocks = (
 		DLT => 'RAW',
 		snaplen => 2000,
 		aliases => ['ip dst net 0.0.0.0/0'],
-		opt => '
+		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
 			(002) jeq      #0x40            jt 3	jf 4
 			(003) ret      #2000
 			(004) ret      #0
-			',
-		unopt => '
-			(000) ldb      [0]
-			(001) and      #0xf0
-			(002) jeq      #0x40            jt 3	jf 6
-			(003) ld       #0x0
-			(004) jeq      #0x0             jt 5	jf 6
-			(005) ret      #2000
-			(006) ret      #0
 			',
 	}, # ip_dst_net_addr_0
 	{

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -11625,17 +11625,11 @@ my @accept_blocks = (
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 12
+			(002) jeq      #0x60            jt 3	jf 6
 			(003) ld       #0x0
-			(004) jeq      #0x0             jt 5	jf 12
-			(005) ld       #0x0
-			(006) jeq      #0x0             jt 7	jf 12
-			(007) ld       #0x0
-			(008) jeq      #0x0             jt 9	jf 12
-			(009) ld       #0x0
-			(010) jeq      #0x0             jt 11	jf 12
-			(011) ret      #262144
-			(012) ret      #0
+			(004) jeq      #0x0             jt 5	jf 6
+			(005) ret      #262144
+			(006) ret      #0
 			',
 	}, # ip6_dst_net_0
 	{
@@ -11643,7 +11637,7 @@ my @accept_blocks = (
 		skip => skip_config_undef ('INET6'),
 		DLT => 'RAW',
 		aliases => ['ip6 dst net ff00::/8'],
-		opt => '
+		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
 			(002) jeq      #0x60            jt 3	jf 7
@@ -11653,29 +11647,13 @@ my @accept_blocks = (
 			(006) ret      #262144
 			(007) ret      #0
 			',
-		unopt => '
-			(000) ldb      [0]
-			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 13
-			(003) ld       [24]
-			(004) and      #0xff000000
-			(005) jeq      #0xff000000      jt 6	jf 13
-			(006) ld       #0x0
-			(007) jeq      #0x0             jt 8	jf 13
-			(008) ld       #0x0
-			(009) jeq      #0x0             jt 10	jf 13
-			(010) ld       #0x0
-			(011) jeq      #0x0             jt 12	jf 13
-			(012) ret      #262144
-			(013) ret      #0
-			',
 	}, # ip6_dst_net_8
 	{
 		name => 'ip6_dst_net_40',
 		skip => skip_config_undef ('INET6'),
 		DLT => 'RAW',
 		aliases => ['ip6 dst net ff11:2233:4400::/40'],
-		opt => '
+		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
 			(002) jeq      #0x60            jt 3	jf 9
@@ -11687,29 +11665,13 @@ my @accept_blocks = (
 			(008) ret      #262144
 			(009) ret      #0
 			',
-		unopt => '
-			(000) ldb      [0]
-			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 13
-			(003) ld       [24]
-			(004) jeq      #0xff112233      jt 5	jf 13
-			(005) ld       [28]
-			(006) and      #0xff000000
-			(007) jeq      #0x44000000      jt 8	jf 13
-			(008) ld       #0x0
-			(009) jeq      #0x0             jt 10	jf 13
-			(010) ld       #0x0
-			(011) jeq      #0x0             jt 12	jf 13
-			(012) ret      #262144
-			(013) ret      #0
-			',
 	}, # ip6_dst_net_40
 	{
 		name => 'ip6_dst_net_80',
 		skip => skip_config_undef ('INET6'),
 		DLT => 'RAW',
 		aliases => ['ip6 dst net ff11:2233:4455:6677:8899::/80'],
-		opt => '
+		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
 			(002) jeq      #0x60            jt 3	jf 11
@@ -11722,22 +11684,6 @@ my @accept_blocks = (
 			(009) jeq      #0x88990000      jt 10	jf 11
 			(010) ret      #262144
 			(011) ret      #0
-			',
-		unopt => '
-			(000) ldb      [0]
-			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 13
-			(003) ld       [24]
-			(004) jeq      #0xff112233      jt 5	jf 13
-			(005) ld       [28]
-			(006) jeq      #0x44556677      jt 7	jf 13
-			(007) ld       [32]
-			(008) and      #0xffff0000
-			(009) jeq      #0x88990000      jt 10	jf 13
-			(010) ld       #0x0
-			(011) jeq      #0x0             jt 12	jf 13
-			(012) ret      #262144
-			(013) ret      #0
 			',
 	}, # ip6_dst_net_80
 	{

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -11615,21 +11615,12 @@ my @accept_blocks = (
 		skip => skip_config_undef ('INET6'),
 		DLT => 'RAW',
 		aliases => ['ip6 dst net ::/0'],
-		opt => '
+		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
 			(002) jeq      #0x60            jt 3	jf 4
 			(003) ret      #262144
 			(004) ret      #0
-			',
-		unopt => '
-			(000) ldb      [0]
-			(001) and      #0xf0
-			(002) jeq      #0x60            jt 3	jf 6
-			(003) ld       #0x0
-			(004) jeq      #0x0             jt 5	jf 6
-			(005) ret      #262144
-			(006) ret      #0
 			',
 	}, # ip6_dst_net_0
 	{


### PR DESCRIPTION
For some time I've been trying to address a number of imperfections, this is a series of changes that look ready. The first part reorganizes quite a bit of C code in `gencode.c` with the intent to make it easier to follow, but not to change any filter program outputs. The second part does not change much code, but it does reduce the unoptimized filter programs for IPv4 and IPv6 netmasks.

Due to the amount of changes this pull request is going to stay open for at least a week before merging.