### PR TITLE
protocol numbers and ports

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,6 +59,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Fix the "|" and "&" operators of the "byte" primitive.
       Require "byte" argument value to be within range.
       Require "link proto" argument value to be within range.
+      Require "(ip|ip6) proto" value to be within range.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/CHANGES
+++ b/CHANGES
@@ -58,6 +58,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Use the correct bit mask for IS-IS PDU type value.
       Fix the "|" and "&" operators of the "byte" primitive.
       Require "byte" argument value to be within range.
+      Require "link proto" argument value to be within range.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/gencode.c
+++ b/gencode.c
@@ -6423,6 +6423,7 @@ gen_proto(compiler_state_t *cstate, bpf_u_int32 v, int proto)
 		return gen_linktype(cstate, v);
 
 	case Q_IP:
+		assert_maxval(cstate, "protocol number", v, UINT8_MAX);
 		/*
 		 * For FDDI, RFC 1188 says that SNAP encapsulation is used,
 		 * not LLC encapsulation with LLCSAP_IP.
@@ -6460,6 +6461,7 @@ gen_proto(compiler_state_t *cstate, bpf_u_int32 v, int proto)
 		break; // invalid qualifier
 
 	case Q_IPV6:
+		assert_maxval(cstate, "protocol number", v, UINT8_MAX);
 		b0 = gen_linktype(cstate, ETHERTYPE_IPV6);
 		/*
 		 * Also check for a fragment header before the final

--- a/gencode.c
+++ b/gencode.c
@@ -699,22 +699,24 @@ static struct block *gen_gateway(compiler_state_t *, const u_char *,
 static struct block *gen_ip_proto(compiler_state_t *, const uint8_t);
 static struct block *gen_ip6_proto(compiler_state_t *, const uint8_t);
 static struct block *gen_ipfrag(compiler_state_t *);
-static struct block *gen_portatom(compiler_state_t *, int, bpf_u_int32);
-static struct block *gen_portrangeatom(compiler_state_t *, u_int, bpf_u_int32,
-    bpf_u_int32);
-static struct block *gen_portatom6(compiler_state_t *, int, bpf_u_int32);
-static struct block *gen_portrangeatom6(compiler_state_t *, u_int, bpf_u_int32,
-    bpf_u_int32);
-static struct block *gen_portop(compiler_state_t *, u_int, uint8_t, int);
-static struct block *gen_port(compiler_state_t *, u_int, int, int);
-static struct block *gen_portrangeop(compiler_state_t *, u_int, u_int,
+static struct block *gen_portatom(compiler_state_t *, int, uint16_t);
+static struct block *gen_portrangeatom(compiler_state_t *, u_int, uint16_t,
+    uint16_t);
+static struct block *gen_portatom6(compiler_state_t *, int, uint16_t);
+static struct block *gen_portrangeatom6(compiler_state_t *, u_int, uint16_t,
+    uint16_t);
+static struct block *gen_portop(compiler_state_t *, uint16_t, uint8_t, int);
+static struct block *gen_port(compiler_state_t *, uint16_t, int, int);
+static struct block *gen_portrangeop(compiler_state_t *, uint16_t, uint16_t,
     uint8_t, int);
-static struct block *gen_portrange(compiler_state_t *, u_int, u_int, int, int);
-struct block *gen_portop6(compiler_state_t *, u_int, uint8_t, int);
-static struct block *gen_port6(compiler_state_t *, u_int, int, int);
-static struct block *gen_portrangeop6(compiler_state_t *, u_int, u_int,
+static struct block *gen_portrange(compiler_state_t *, uint16_t, uint16_t,
+    int, int);
+static struct block *gen_portop6(compiler_state_t *, uint16_t, uint8_t, int);
+static struct block *gen_port6(compiler_state_t *, uint16_t, int, int);
+static struct block *gen_portrangeop6(compiler_state_t *, uint16_t, uint16_t,
     uint8_t, int);
-static struct block *gen_portrange6(compiler_state_t *, u_int, u_int, int, int);
+static struct block *gen_portrange6(compiler_state_t *, uint16_t, uint16_t,
+    int, int);
 static int lookup_proto(compiler_state_t *, const char *, int);
 #if !defined(NO_PROTOCHAIN)
 static struct block *gen_protochain(compiler_state_t *, bpf_u_int32, int);
@@ -5696,19 +5698,19 @@ gen_ipfrag(compiler_state_t *cstate)
  * headers).
  */
 static struct block *
-gen_portatom(compiler_state_t *cstate, int off, bpf_u_int32 v)
+gen_portatom(compiler_state_t *cstate, int off, uint16_t v)
 {
 	return gen_cmp(cstate, OR_TRAN_IPV4, off, BPF_H, v);
 }
 
 static struct block *
-gen_portatom6(compiler_state_t *cstate, int off, bpf_u_int32 v)
+gen_portatom6(compiler_state_t *cstate, int off, uint16_t v)
 {
 	return gen_cmp(cstate, OR_TRAN_IPV6, off, BPF_H, v);
 }
 
 static struct block *
-gen_portop(compiler_state_t *cstate, u_int port, uint8_t proto, int dir)
+gen_portop(compiler_state_t *cstate, uint16_t port, uint8_t proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
 
@@ -5758,7 +5760,7 @@ gen_portop(compiler_state_t *cstate, u_int port, uint8_t proto, int dir)
 }
 
 static struct block *
-gen_port(compiler_state_t *cstate, u_int port, int proto, int dir)
+gen_port(compiler_state_t *cstate, uint16_t port, int proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
 
@@ -5804,7 +5806,7 @@ gen_port(compiler_state_t *cstate, u_int port, int proto, int dir)
 }
 
 struct block *
-gen_portop6(compiler_state_t *cstate, u_int port, uint8_t proto, int dir)
+gen_portop6(compiler_state_t *cstate, uint16_t port, uint8_t proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
 
@@ -5843,7 +5845,7 @@ gen_portop6(compiler_state_t *cstate, u_int port, uint8_t proto, int dir)
 }
 
 static struct block *
-gen_port6(compiler_state_t *cstate, u_int port, int proto, int dir)
+gen_port6(compiler_state_t *cstate, uint16_t port, int proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
 
@@ -5874,8 +5876,8 @@ gen_port6(compiler_state_t *cstate, u_int port, int proto, int dir)
 
 /* gen_portrange code */
 static struct block *
-gen_portrangeatom(compiler_state_t *cstate, u_int off, bpf_u_int32 v1,
-    bpf_u_int32 v2)
+gen_portrangeatom(compiler_state_t *cstate, u_int off, uint16_t v1,
+    uint16_t v2)
 {
 	if (v1 == v2)
 		return gen_portatom(cstate, off, v1);
@@ -5891,7 +5893,7 @@ gen_portrangeatom(compiler_state_t *cstate, u_int off, bpf_u_int32 v1,
 }
 
 static struct block *
-gen_portrangeop(compiler_state_t *cstate, u_int port1, u_int port2,
+gen_portrangeop(compiler_state_t *cstate, uint16_t port1, uint16_t port2,
     uint8_t proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
@@ -5942,7 +5944,7 @@ gen_portrangeop(compiler_state_t *cstate, u_int port1, u_int port2,
 }
 
 static struct block *
-gen_portrange(compiler_state_t *cstate, u_int port1, u_int port2,
+gen_portrange(compiler_state_t *cstate, uint16_t port1, uint16_t port2,
     int proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
@@ -5974,8 +5976,8 @@ gen_portrange(compiler_state_t *cstate, u_int port1, u_int port2,
 }
 
 static struct block *
-gen_portrangeatom6(compiler_state_t *cstate, u_int off, bpf_u_int32 v1,
-    bpf_u_int32 v2)
+gen_portrangeatom6(compiler_state_t *cstate, u_int off, uint16_t v1,
+    uint16_t v2)
 {
 	if (v1 == v2)
 		return gen_portatom6(cstate, off, v1);
@@ -5991,7 +5993,7 @@ gen_portrangeatom6(compiler_state_t *cstate, u_int off, bpf_u_int32 v1,
 }
 
 static struct block *
-gen_portrangeop6(compiler_state_t *cstate, u_int port1, u_int port2,
+gen_portrangeop6(compiler_state_t *cstate, uint16_t port1, uint16_t port2,
     uint8_t proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
@@ -6031,7 +6033,7 @@ gen_portrangeop6(compiler_state_t *cstate, u_int port1, u_int port2,
 }
 
 static struct block *
-gen_portrange6(compiler_state_t *cstate, u_int port1, u_int port2,
+gen_portrange6(compiler_state_t *cstate, uint16_t port1, uint16_t port2,
     int proto, int dir)
 {
 	struct block *b0, *b1, *tmp;
@@ -7068,8 +7070,8 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 		if (port > 65535)
 			bpf_error(cstate, "illegal port number %d > 65535", port);
 		// real_proto can be PROTO_UNDEF
-		b = gen_port(cstate, port, real_proto, dir);
-		gen_or(gen_port6(cstate, port, real_proto, dir), b);
+		b = gen_port(cstate, (uint16_t)port, real_proto, dir);
+		gen_or(gen_port6(cstate, (uint16_t)port, real_proto, dir), b);
 		return b;
 
 	case Q_PORTRANGE:
@@ -7108,8 +7110,10 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 			bpf_error(cstate, "illegal port number %d > 65535", port2);
 
 		// real_proto can be PROTO_UNDEF
-		b = gen_portrange(cstate, port1, port2, real_proto, dir);
-		gen_or(gen_portrange6(cstate, port1, port2, real_proto, dir), b);
+		b = gen_portrange(cstate, (uint16_t)port1, (uint16_t)port2,
+		    real_proto, dir);
+		gen_or(gen_portrange6(cstate, (uint16_t)port1, (uint16_t)port2,
+		    real_proto, dir), b);
 		return b;
 
 	case Q_GATEWAY:
@@ -7297,8 +7301,8 @@ gen_ncode(compiler_state_t *cstate, const char *s, bpf_u_int32 v, struct qual q)
 		// proto can be PROTO_UNDEF
 	    {
 		struct block *b;
-		b = gen_port(cstate, v, proto, dir);
-		gen_or(gen_port6(cstate, v, proto, dir), b);
+		b = gen_port(cstate, (uint16_t)v, proto, dir);
+		gen_or(gen_port6(cstate, (uint16_t)v, proto, dir), b);
 		return b;
 	    }
 
@@ -7311,8 +7315,10 @@ gen_ncode(compiler_state_t *cstate, const char *s, bpf_u_int32 v, struct qual q)
 		// proto can be PROTO_UNDEF
 	    {
 		struct block *b;
-		b = gen_portrange(cstate, v, v, proto, dir);
-		gen_or(gen_portrange6(cstate, v, v, proto, dir), b);
+		b = gen_portrange(cstate, (uint16_t)v, (uint16_t)v,
+		    proto, dir);
+		gen_or(gen_portrange6(cstate, (uint16_t)v, (uint16_t)v,
+		    proto, dir), b);
 		return b;
 	    }
 
@@ -9303,7 +9309,7 @@ gen_pppoes(compiler_state_t *cstate, bpf_u_int32 sess_num, int has_sess_num)
  * specified. Parameterized to handle both IPv4 and IPv6. */
 static struct block *
 gen_geneve_check(compiler_state_t *cstate,
-    struct block *(*gen_portfn)(compiler_state_t *, u_int, int, int),
+    struct block *(*gen_portfn)(compiler_state_t *, uint16_t, int, int),
     enum e_offrel offrel, bpf_u_int32 vni, int has_vni)
 {
 	struct block *b0, *b1;
@@ -9572,7 +9578,7 @@ gen_geneve(compiler_state_t *cstate, bpf_u_int32 vni, int has_vni)
  * specified. Parameterized to handle both IPv4 and IPv6. */
 static struct block *
 gen_vxlan_check(compiler_state_t *cstate,
-    struct block *(*gen_portfn)(compiler_state_t *, u_int, int, int),
+    struct block *(*gen_portfn)(compiler_state_t *, uint16_t, int, int),
     enum e_offrel offrel, bpf_u_int32 vni, int has_vni)
 {
 	struct block *b0, *b1;

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -14234,6 +14234,70 @@ my @reject_tests = (
 		expr => 'geneve 123456789',
 		errstr => 'Geneve VNI 123456789 greater than maximum 16777215',
 	},
+	# gen_linktype()
+	{
+		name => 'link_proto_65536_C_HDLC',
+		DLT => 'C_HDLC',
+		expr => 'link proto 65536',
+		errstr => 'HDLC protocol 65536 greater than maximum 65535',
+	},
+	{
+		name => 'link_proto_65536_PPP',
+		DLT => 'PPP',
+		expr => 'link proto 65536',
+		errstr => 'PPP protocol 65536 greater than maximum 65535',
+	},
+	{
+		name => 'link_proto_65536_PPP_BSDOS',
+		DLT => 'PPP_BSDOS',
+		expr => 'link proto 65536',
+		errstr => 'PPP protocol 65536 greater than maximum 65535',
+	},
+	{
+		name => 'link_proto_65536_APPLE_IP_OVER_IEEE1394',
+		DLT => 'APPLE_IP_OVER_IEEE1394', # the default case
+		expr => 'link proto 65536',
+		errstr => 'EtherType 65536 greater than maximum 65535',
+	},
+	# gen_ether_linktype()
+	{
+		name => 'link_proto_65536_EN10MB',
+		DLT => 'EN10MB',
+		expr => 'link proto 65536',
+		errstr => 'EtherType 65536 greater than maximum 65535',
+	},
+	{
+		name => 'link_proto_1500_EN10MB',
+		DLT => 'EN10MB',
+		expr => 'link proto 1500',
+		errstr => 'LLC DSAP 1500 greater than maximum 255',
+	},
+	# gen_llc_linktype
+	{
+		name => 'link_proto_65536_IP_OVER_FC',
+		DLT => 'IP_OVER_FC',
+		expr => 'link proto 65536',
+		errstr => 'EtherType 65536 greater than maximum 65535',
+	},
+	{
+		name => 'link_proto_1500_IP_OVER_FC',
+		DLT => 'IP_OVER_FC',
+		expr => 'link proto 1500',
+		errstr => 'LLC DSAP 1500 greater than maximum 255',
+	},
+	# gen_linux_sll_linktype
+	{
+		name => 'link_proto_65536_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		expr => 'link proto 65536',
+		errstr => 'EtherType 65536 greater than maximum 65535',
+	},
+	{
+		name => 'link_proto_1500_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		expr => 'link proto 1500',
+		errstr => 'LLC DSAP 1500 greater than maximum 255',
+	},
 );
 
 push @reject_tests, {

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -11760,6 +11760,30 @@ my @accept_blocks = (
 			(018) ret      #262144
 			(019) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x6             jt 4	jf 8
+			(004) ldh      [54]
+			(005) jeq      #0x19            jt 20	jf 6
+			(006) ldh      [56]
+			(007) jeq      #0x19            jt 20	jf 8
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x6             jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 14]
+			(016) jeq      #0x19            jt 20	jf 17
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 16]
+			(019) jeq      #0x19            jt 20	jf 21
+			(020) ret      #262144
+			(021) ret      #0
+			',
 	}, # tcp_port
 	{
 		name => 'tcp_src_port',
@@ -11792,6 +11816,25 @@ my @accept_blocks = (
 			(014) ret      #262144
 			(015) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 6
+			(002) ldb      [20]
+			(003) jeq      #0x6             jt 4	jf 6
+			(004) ldh      [54]
+			(005) jeq      #0x19            jt 15	jf 6
+			(006) ldh      [12]
+			(007) jeq      #0x800           jt 8	jf 16
+			(008) ldb      [23]
+			(009) jeq      #0x6             jt 10	jf 16
+			(010) ldh      [20]
+			(011) jset     #0x1fff          jt 16	jf 12
+			(012) ldxb     4*([14]&0xf)
+			(013) ldh      [x + 14]
+			(014) jeq      #0x19            jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			',
 	}, # tcp_src_port
 	{
 		name => 'tcp_dst_port',
@@ -11823,6 +11866,25 @@ my @accept_blocks = (
 			(013) jeq      #0x19            jt 14	jf 15
 			(014) ret      #262144
 			(015) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 6
+			(002) ldb      [20]
+			(003) jeq      #0x6             jt 4	jf 6
+			(004) ldh      [56]
+			(005) jeq      #0x19            jt 15	jf 6
+			(006) ldh      [12]
+			(007) jeq      #0x800           jt 8	jf 16
+			(008) ldb      [23]
+			(009) jeq      #0x6             jt 10	jf 16
+			(010) ldh      [20]
+			(011) jset     #0x1fff          jt 16	jf 12
+			(012) ldxb     4*([14]&0xf)
+			(013) ldh      [x + 16]
+			(014) jeq      #0x19            jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
 			',
 	}, # tcp_dst_port
 	{
@@ -11871,6 +11933,40 @@ my @accept_blocks = (
 			(021) ret      #262144
 			(022) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 12
+			(002) ldb      [20]
+			(003) jeq      #0x6             jt 4	jf 12
+			(004) ldh      [54]
+			(005) jge      #0x19            jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x35            jt 8	jf 30
+			(008) ldh      [56]
+			(009) jge      #0x19            jt 10	jf 12
+			(010) ldh      [56]
+			(011) jgt      #0x35            jt 12	jf 30
+			(012) ldh      [12]
+			(013) jeq      #0x800           jt 14	jf 31
+			(014) ldb      [23]
+			(015) jeq      #0x6             jt 16	jf 31
+			(016) ldh      [20]
+			(017) jset     #0x1fff          jt 31	jf 18
+			(018) ldxb     4*([14]&0xf)
+			(019) ldh      [x + 14]
+			(020) jge      #0x19            jt 21	jf 24
+			(021) ldxb     4*([14]&0xf)
+			(022) ldh      [x + 14]
+			(023) jgt      #0x35            jt 24	jf 30
+			(024) ldxb     4*([14]&0xf)
+			(025) ldh      [x + 16]
+			(026) jge      #0x19            jt 27	jf 31
+			(027) ldxb     4*([14]&0xf)
+			(028) ldh      [x + 16]
+			(029) jgt      #0x35            jt 31	jf 30
+			(030) ret      #262144
+			(031) ret      #0
+			',
 	}, # tcp_portrange
 	{
 		name => 'tcp_src_portrange',
@@ -11904,6 +12000,30 @@ my @accept_blocks = (
 			(015) ret      #262144
 			(016) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x6             jt 4	jf 8
+			(004) ldh      [54]
+			(005) jge      #0x19            jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x35            jt 8	jf 20
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x6             jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 14]
+			(016) jge      #0x19            jt 17	jf 21
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 14]
+			(019) jgt      #0x35            jt 21	jf 20
+			(020) ret      #262144
+			(021) ret      #0
+			',
 	}, # tcp_src_portrange
 	{
 		name => 'tcp_dst_portrange',
@@ -11936,6 +12056,30 @@ my @accept_blocks = (
 			(014) jgt      #0x35            jt 16	jf 15
 			(015) ret      #262144
 			(016) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x6             jt 4	jf 8
+			(004) ldh      [56]
+			(005) jge      #0x19            jt 6	jf 8
+			(006) ldh      [56]
+			(007) jgt      #0x35            jt 8	jf 20
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x6             jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 16]
+			(016) jge      #0x19            jt 17	jf 21
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 16]
+			(019) jgt      #0x35            jt 21	jf 20
+			(020) ret      #262144
+			(021) ret      #0
 			',
 	}, # tcp_dst_portrange
 	# In the tests below "domain" depends on getaddrinfo().
@@ -11982,6 +12126,30 @@ my @accept_blocks = (
 			(018) ret      #262144
 			(019) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x11            jt 4	jf 8
+			(004) ldh      [54]
+			(005) jeq      #0x35            jt 20	jf 6
+			(006) ldh      [56]
+			(007) jeq      #0x35            jt 20	jf 8
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x11            jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 14]
+			(016) jeq      #0x35            jt 20	jf 17
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 16]
+			(019) jeq      #0x35            jt 20	jf 21
+			(020) ret      #262144
+			(021) ret      #0
+			',
 	}, # udp_port
 	{
 		name => 'udp_src_port',
@@ -12014,6 +12182,25 @@ my @accept_blocks = (
 			(014) ret      #262144
 			(015) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 6
+			(002) ldb      [20]
+			(003) jeq      #0x11            jt 4	jf 6
+			(004) ldh      [54]
+			(005) jeq      #0x35            jt 15	jf 6
+			(006) ldh      [12]
+			(007) jeq      #0x800           jt 8	jf 16
+			(008) ldb      [23]
+			(009) jeq      #0x11            jt 10	jf 16
+			(010) ldh      [20]
+			(011) jset     #0x1fff          jt 16	jf 12
+			(012) ldxb     4*([14]&0xf)
+			(013) ldh      [x + 14]
+			(014) jeq      #0x35            jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			',
 	}, # udp_src_port
 	{
 		name => 'udp_dst_port',
@@ -12045,6 +12232,25 @@ my @accept_blocks = (
 			(013) jeq      #0x35            jt 14	jf 15
 			(014) ret      #262144
 			(015) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 6
+			(002) ldb      [20]
+			(003) jeq      #0x11            jt 4	jf 6
+			(004) ldh      [56]
+			(005) jeq      #0x35            jt 15	jf 6
+			(006) ldh      [12]
+			(007) jeq      #0x800           jt 8	jf 16
+			(008) ldb      [23]
+			(009) jeq      #0x11            jt 10	jf 16
+			(010) ldh      [20]
+			(011) jset     #0x1fff          jt 16	jf 12
+			(012) ldxb     4*([14]&0xf)
+			(013) ldh      [x + 16]
+			(014) jeq      #0x35            jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
 			',
 	}, # udp_dst_port
 	{
@@ -12093,6 +12299,40 @@ my @accept_blocks = (
 			(021) ret      #262144
 			(022) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 12
+			(002) ldb      [20]
+			(003) jeq      #0x11            jt 4	jf 12
+			(004) ldh      [54]
+			(005) jge      #0x43            jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x44            jt 8	jf 30
+			(008) ldh      [56]
+			(009) jge      #0x43            jt 10	jf 12
+			(010) ldh      [56]
+			(011) jgt      #0x44            jt 12	jf 30
+			(012) ldh      [12]
+			(013) jeq      #0x800           jt 14	jf 31
+			(014) ldb      [23]
+			(015) jeq      #0x11            jt 16	jf 31
+			(016) ldh      [20]
+			(017) jset     #0x1fff          jt 31	jf 18
+			(018) ldxb     4*([14]&0xf)
+			(019) ldh      [x + 14]
+			(020) jge      #0x43            jt 21	jf 24
+			(021) ldxb     4*([14]&0xf)
+			(022) ldh      [x + 14]
+			(023) jgt      #0x44            jt 24	jf 30
+			(024) ldxb     4*([14]&0xf)
+			(025) ldh      [x + 16]
+			(026) jge      #0x43            jt 27	jf 31
+			(027) ldxb     4*([14]&0xf)
+			(028) ldh      [x + 16]
+			(029) jgt      #0x44            jt 31	jf 30
+			(030) ret      #262144
+			(031) ret      #0
+			',
 	}, # udp_portrange
 	{
 		name => 'udp_src_portrange',
@@ -12126,6 +12366,30 @@ my @accept_blocks = (
 			(015) ret      #262144
 			(016) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x11            jt 4	jf 8
+			(004) ldh      [54]
+			(005) jge      #0x43            jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x44            jt 8	jf 20
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x11            jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 14]
+			(016) jge      #0x43            jt 17	jf 21
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 14]
+			(019) jgt      #0x44            jt 21	jf 20
+			(020) ret      #262144
+			(021) ret      #0
+			',
 	}, # udp_src_portrange
 	{
 		name => 'udp_dst_portrange',
@@ -12158,6 +12422,30 @@ my @accept_blocks = (
 			(014) jgt      #0x44            jt 16	jf 15
 			(015) ret      #262144
 			(016) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x11            jt 4	jf 8
+			(004) ldh      [56]
+			(005) jge      #0x43            jt 6	jf 8
+			(006) ldh      [56]
+			(007) jgt      #0x44            jt 8	jf 20
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x11            jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 16]
+			(016) jge      #0x43            jt 17	jf 21
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 16]
+			(019) jgt      #0x44            jt 21	jf 20
+			(020) ret      #262144
+			(021) ret      #0
 			',
 	}, # udp_dst_portrange
 	# SCTP tests below do not use service names because the translation is
@@ -12197,6 +12485,30 @@ my @accept_blocks = (
 			(018) ret      #262144
 			(019) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 8
+			(004) ldh      [54]
+			(005) jeq      #0x1628          jt 20	jf 6
+			(006) ldh      [56]
+			(007) jeq      #0x1628          jt 20	jf 8
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x84            jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 14]
+			(016) jeq      #0x1628          jt 20	jf 17
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 16]
+			(019) jeq      #0x1628          jt 20	jf 21
+			(020) ret      #262144
+			(021) ret      #0
+			',
 	}, # sctp_port
 	{
 		name => 'sctp_src_port',
@@ -12225,6 +12537,25 @@ my @accept_blocks = (
 			(014) ret      #262144
 			(015) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 6
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 6
+			(004) ldh      [54]
+			(005) jeq      #0x1628          jt 15	jf 6
+			(006) ldh      [12]
+			(007) jeq      #0x800           jt 8	jf 16
+			(008) ldb      [23]
+			(009) jeq      #0x84            jt 10	jf 16
+			(010) ldh      [20]
+			(011) jset     #0x1fff          jt 16	jf 12
+			(012) ldxb     4*([14]&0xf)
+			(013) ldh      [x + 14]
+			(014) jeq      #0x1628          jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			',
 	}, # sctp_src_port
 	{
 		name => 'sctp_dst_port',
@@ -12252,6 +12583,25 @@ my @accept_blocks = (
 			(013) jeq      #0x1628          jt 14	jf 15
 			(014) ret      #262144
 			(015) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 6
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 6
+			(004) ldh      [56]
+			(005) jeq      #0x1628          jt 15	jf 6
+			(006) ldh      [12]
+			(007) jeq      #0x800           jt 8	jf 16
+			(008) ldb      [23]
+			(009) jeq      #0x84            jt 10	jf 16
+			(010) ldh      [20]
+			(011) jset     #0x1fff          jt 16	jf 12
+			(012) ldxb     4*([14]&0xf)
+			(013) ldh      [x + 16]
+			(014) jeq      #0x1628          jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
 			',
 	}, # sctp_dst_port
 	{
@@ -12288,6 +12638,40 @@ my @accept_blocks = (
 			(021) ret      #262144
 			(022) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 12
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 12
+			(004) ldh      [54]
+			(005) jge      #0x1             jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x3ff           jt 8	jf 30
+			(008) ldh      [56]
+			(009) jge      #0x1             jt 10	jf 12
+			(010) ldh      [56]
+			(011) jgt      #0x3ff           jt 12	jf 30
+			(012) ldh      [12]
+			(013) jeq      #0x800           jt 14	jf 31
+			(014) ldb      [23]
+			(015) jeq      #0x84            jt 16	jf 31
+			(016) ldh      [20]
+			(017) jset     #0x1fff          jt 31	jf 18
+			(018) ldxb     4*([14]&0xf)
+			(019) ldh      [x + 14]
+			(020) jge      #0x1             jt 21	jf 24
+			(021) ldxb     4*([14]&0xf)
+			(022) ldh      [x + 14]
+			(023) jgt      #0x3ff           jt 24	jf 30
+			(024) ldxb     4*([14]&0xf)
+			(025) ldh      [x + 16]
+			(026) jge      #0x1             jt 27	jf 31
+			(027) ldxb     4*([14]&0xf)
+			(028) ldh      [x + 16]
+			(029) jgt      #0x3ff           jt 31	jf 30
+			(030) ret      #262144
+			(031) ret      #0
+			',
 	}, # sctp_portrange
 	{
 		name => 'sctp_src_portrange',
@@ -12315,6 +12699,30 @@ my @accept_blocks = (
 			(015) ret      #262144
 			(016) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 8
+			(004) ldh      [54]
+			(005) jge      #0x1             jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x3ff           jt 8	jf 20
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x84            jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 14]
+			(016) jge      #0x1             jt 17	jf 21
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 14]
+			(019) jgt      #0x3ff           jt 21	jf 20
+			(020) ret      #262144
+			(021) ret      #0
+			',
 	}, # sctp_src_portrange
 	{
 		name => 'sctp_dst_portrange',
@@ -12341,6 +12749,30 @@ my @accept_blocks = (
 			(014) jgt      #0x3ff           jt 16	jf 15
 			(015) ret      #262144
 			(016) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 8
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 8
+			(004) ldh      [56]
+			(005) jge      #0x1             jt 6	jf 8
+			(006) ldh      [56]
+			(007) jgt      #0x3ff           jt 8	jf 20
+			(008) ldh      [12]
+			(009) jeq      #0x800           jt 10	jf 21
+			(010) ldb      [23]
+			(011) jeq      #0x84            jt 12	jf 21
+			(012) ldh      [20]
+			(013) jset     #0x1fff          jt 21	jf 14
+			(014) ldxb     4*([14]&0xf)
+			(015) ldh      [x + 16]
+			(016) jge      #0x1             jt 17	jf 21
+			(017) ldxb     4*([14]&0xf)
+			(018) ldh      [x + 16]
+			(019) jgt      #0x3ff           jt 21	jf 20
+			(020) ret      #262144
+			(021) ret      #0
 			',
 	}, # sctp_dst_portrange
 	{
@@ -12380,6 +12812,62 @@ my @accept_blocks = (
 			(022) ret      #262144
 			(023) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 20
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 8
+			(004) ldh      [54]
+			(005) jeq      #0x7             jt 52	jf 6
+			(006) ldh      [56]
+			(007) jeq      #0x7             jt 52	jf 8
+			(008) ldb      [20]
+			(009) jeq      #0x6             jt 10	jf 14
+			(010) ldh      [54]
+			(011) jeq      #0x7             jt 52	jf 12
+			(012) ldh      [56]
+			(013) jeq      #0x7             jt 52	jf 14
+			(014) ldb      [20]
+			(015) jeq      #0x11            jt 16	jf 20
+			(016) ldh      [54]
+			(017) jeq      #0x7             jt 52	jf 18
+			(018) ldh      [56]
+			(019) jeq      #0x7             jt 52	jf 20
+			(020) ldh      [12]
+			(021) jeq      #0x800           jt 22	jf 53
+			(022) ldb      [23]
+			(023) jeq      #0x84            jt 24	jf 32
+			(024) ldh      [20]
+			(025) jset     #0x1fff          jt 32	jf 26
+			(026) ldxb     4*([14]&0xf)
+			(027) ldh      [x + 14]
+			(028) jeq      #0x7             jt 52	jf 29
+			(029) ldxb     4*([14]&0xf)
+			(030) ldh      [x + 16]
+			(031) jeq      #0x7             jt 52	jf 32
+			(032) ldb      [23]
+			(033) jeq      #0x6             jt 34	jf 42
+			(034) ldh      [20]
+			(035) jset     #0x1fff          jt 42	jf 36
+			(036) ldxb     4*([14]&0xf)
+			(037) ldh      [x + 14]
+			(038) jeq      #0x7             jt 52	jf 39
+			(039) ldxb     4*([14]&0xf)
+			(040) ldh      [x + 16]
+			(041) jeq      #0x7             jt 52	jf 42
+			(042) ldb      [23]
+			(043) jeq      #0x11            jt 44	jf 53
+			(044) ldh      [20]
+			(045) jset     #0x1fff          jt 53	jf 46
+			(046) ldxb     4*([14]&0xf)
+			(047) ldh      [x + 14]
+			(048) jeq      #0x7             jt 52	jf 49
+			(049) ldxb     4*([14]&0xf)
+			(050) ldh      [x + 16]
+			(051) jeq      #0x7             jt 52	jf 53
+			(052) ret      #262144
+			(053) ret      #0
+			',
 	}, # port
 	{
 		name => 'src_port',
@@ -12412,6 +12900,47 @@ my @accept_blocks = (
 			(018) ret      #262144
 			(019) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 14
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 6
+			(004) ldh      [54]
+			(005) jeq      #0x7             jt 37	jf 6
+			(006) ldb      [20]
+			(007) jeq      #0x6             jt 8	jf 10
+			(008) ldh      [54]
+			(009) jeq      #0x7             jt 37	jf 10
+			(010) ldb      [20]
+			(011) jeq      #0x11            jt 12	jf 14
+			(012) ldh      [54]
+			(013) jeq      #0x7             jt 37	jf 14
+			(014) ldh      [12]
+			(015) jeq      #0x800           jt 16	jf 38
+			(016) ldb      [23]
+			(017) jeq      #0x84            jt 18	jf 23
+			(018) ldh      [20]
+			(019) jset     #0x1fff          jt 23	jf 20
+			(020) ldxb     4*([14]&0xf)
+			(021) ldh      [x + 14]
+			(022) jeq      #0x7             jt 37	jf 23
+			(023) ldb      [23]
+			(024) jeq      #0x6             jt 25	jf 30
+			(025) ldh      [20]
+			(026) jset     #0x1fff          jt 30	jf 27
+			(027) ldxb     4*([14]&0xf)
+			(028) ldh      [x + 14]
+			(029) jeq      #0x7             jt 37	jf 30
+			(030) ldb      [23]
+			(031) jeq      #0x11            jt 32	jf 38
+			(032) ldh      [20]
+			(033) jset     #0x1fff          jt 38	jf 34
+			(034) ldxb     4*([14]&0xf)
+			(035) ldh      [x + 14]
+			(036) jeq      #0x7             jt 37	jf 38
+			(037) ret      #262144
+			(038) ret      #0
+			',
 	}, # src_port
 	{
 		name => 'dst_port',
@@ -12443,6 +12972,47 @@ my @accept_blocks = (
 			(017) jeq      #0x7             jt 18	jf 19
 			(018) ret      #262144
 			(019) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 14
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 6
+			(004) ldh      [56]
+			(005) jeq      #0x7             jt 37	jf 6
+			(006) ldb      [20]
+			(007) jeq      #0x6             jt 8	jf 10
+			(008) ldh      [56]
+			(009) jeq      #0x7             jt 37	jf 10
+			(010) ldb      [20]
+			(011) jeq      #0x11            jt 12	jf 14
+			(012) ldh      [56]
+			(013) jeq      #0x7             jt 37	jf 14
+			(014) ldh      [12]
+			(015) jeq      #0x800           jt 16	jf 38
+			(016) ldb      [23]
+			(017) jeq      #0x84            jt 18	jf 23
+			(018) ldh      [20]
+			(019) jset     #0x1fff          jt 23	jf 20
+			(020) ldxb     4*([14]&0xf)
+			(021) ldh      [x + 16]
+			(022) jeq      #0x7             jt 37	jf 23
+			(023) ldb      [23]
+			(024) jeq      #0x6             jt 25	jf 30
+			(025) ldh      [20]
+			(026) jset     #0x1fff          jt 30	jf 27
+			(027) ldxb     4*([14]&0xf)
+			(028) ldh      [x + 16]
+			(029) jeq      #0x7             jt 37	jf 30
+			(030) ldb      [23]
+			(031) jeq      #0x11            jt 32	jf 38
+			(032) ldh      [20]
+			(033) jset     #0x1fff          jt 38	jf 34
+			(034) ldxb     4*([14]&0xf)
+			(035) ldh      [x + 16]
+			(036) jeq      #0x7             jt 37	jf 38
+			(037) ret      #262144
+			(038) ret      #0
 			',
 	}, # dst_port
 	{
@@ -12481,6 +13051,92 @@ my @accept_blocks = (
 			(025) ret      #262144
 			(026) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 32
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 12
+			(004) ldh      [54]
+			(005) jge      #0x1             jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x3ff           jt 8	jf 82
+			(008) ldh      [56]
+			(009) jge      #0x1             jt 10	jf 12
+			(010) ldh      [56]
+			(011) jgt      #0x3ff           jt 12	jf 82
+			(012) ldb      [20]
+			(013) jeq      #0x6             jt 14	jf 22
+			(014) ldh      [54]
+			(015) jge      #0x1             jt 16	jf 18
+			(016) ldh      [54]
+			(017) jgt      #0x3ff           jt 18	jf 82
+			(018) ldh      [56]
+			(019) jge      #0x1             jt 20	jf 22
+			(020) ldh      [56]
+			(021) jgt      #0x3ff           jt 22	jf 82
+			(022) ldb      [20]
+			(023) jeq      #0x11            jt 24	jf 32
+			(024) ldh      [54]
+			(025) jge      #0x1             jt 26	jf 28
+			(026) ldh      [54]
+			(027) jgt      #0x3ff           jt 28	jf 82
+			(028) ldh      [56]
+			(029) jge      #0x1             jt 30	jf 32
+			(030) ldh      [56]
+			(031) jgt      #0x3ff           jt 32	jf 82
+			(032) ldh      [12]
+			(033) jeq      #0x800           jt 34	jf 83
+			(034) ldb      [23]
+			(035) jeq      #0x84            jt 36	jf 50
+			(036) ldh      [20]
+			(037) jset     #0x1fff          jt 50	jf 38
+			(038) ldxb     4*([14]&0xf)
+			(039) ldh      [x + 14]
+			(040) jge      #0x1             jt 41	jf 44
+			(041) ldxb     4*([14]&0xf)
+			(042) ldh      [x + 14]
+			(043) jgt      #0x3ff           jt 44	jf 82
+			(044) ldxb     4*([14]&0xf)
+			(045) ldh      [x + 16]
+			(046) jge      #0x1             jt 47	jf 50
+			(047) ldxb     4*([14]&0xf)
+			(048) ldh      [x + 16]
+			(049) jgt      #0x3ff           jt 50	jf 82
+			(050) ldb      [23]
+			(051) jeq      #0x6             jt 52	jf 66
+			(052) ldh      [20]
+			(053) jset     #0x1fff          jt 66	jf 54
+			(054) ldxb     4*([14]&0xf)
+			(055) ldh      [x + 14]
+			(056) jge      #0x1             jt 57	jf 60
+			(057) ldxb     4*([14]&0xf)
+			(058) ldh      [x + 14]
+			(059) jgt      #0x3ff           jt 60	jf 82
+			(060) ldxb     4*([14]&0xf)
+			(061) ldh      [x + 16]
+			(062) jge      #0x1             jt 63	jf 66
+			(063) ldxb     4*([14]&0xf)
+			(064) ldh      [x + 16]
+			(065) jgt      #0x3ff           jt 66	jf 82
+			(066) ldb      [23]
+			(067) jeq      #0x11            jt 68	jf 83
+			(068) ldh      [20]
+			(069) jset     #0x1fff          jt 83	jf 70
+			(070) ldxb     4*([14]&0xf)
+			(071) ldh      [x + 14]
+			(072) jge      #0x1             jt 73	jf 76
+			(073) ldxb     4*([14]&0xf)
+			(074) ldh      [x + 14]
+			(075) jgt      #0x3ff           jt 76	jf 82
+			(076) ldxb     4*([14]&0xf)
+			(077) ldh      [x + 16]
+			(078) jge      #0x1             jt 79	jf 83
+			(079) ldxb     4*([14]&0xf)
+			(080) ldh      [x + 16]
+			(081) jgt      #0x3ff           jt 83	jf 82
+			(082) ret      #262144
+			(083) ret      #0
+			',
 	}, # portrange
 	{
 		name => 'src_portrange',
@@ -12512,6 +13168,62 @@ my @accept_blocks = (
 			(019) ret      #262144
 			(020) ret      #0
 			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 20
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 8
+			(004) ldh      [54]
+			(005) jge      #0x1             jt 6	jf 8
+			(006) ldh      [54]
+			(007) jgt      #0x3ff           jt 8	jf 52
+			(008) ldb      [20]
+			(009) jeq      #0x6             jt 10	jf 14
+			(010) ldh      [54]
+			(011) jge      #0x1             jt 12	jf 14
+			(012) ldh      [54]
+			(013) jgt      #0x3ff           jt 14	jf 52
+			(014) ldb      [20]
+			(015) jeq      #0x11            jt 16	jf 20
+			(016) ldh      [54]
+			(017) jge      #0x1             jt 18	jf 20
+			(018) ldh      [54]
+			(019) jgt      #0x3ff           jt 20	jf 52
+			(020) ldh      [12]
+			(021) jeq      #0x800           jt 22	jf 53
+			(022) ldb      [23]
+			(023) jeq      #0x84            jt 24	jf 32
+			(024) ldh      [20]
+			(025) jset     #0x1fff          jt 32	jf 26
+			(026) ldxb     4*([14]&0xf)
+			(027) ldh      [x + 14]
+			(028) jge      #0x1             jt 29	jf 32
+			(029) ldxb     4*([14]&0xf)
+			(030) ldh      [x + 14]
+			(031) jgt      #0x3ff           jt 32	jf 52
+			(032) ldb      [23]
+			(033) jeq      #0x6             jt 34	jf 42
+			(034) ldh      [20]
+			(035) jset     #0x1fff          jt 42	jf 36
+			(036) ldxb     4*([14]&0xf)
+			(037) ldh      [x + 14]
+			(038) jge      #0x1             jt 39	jf 42
+			(039) ldxb     4*([14]&0xf)
+			(040) ldh      [x + 14]
+			(041) jgt      #0x3ff           jt 42	jf 52
+			(042) ldb      [23]
+			(043) jeq      #0x11            jt 44	jf 53
+			(044) ldh      [20]
+			(045) jset     #0x1fff          jt 53	jf 46
+			(046) ldxb     4*([14]&0xf)
+			(047) ldh      [x + 14]
+			(048) jge      #0x1             jt 49	jf 53
+			(049) ldxb     4*([14]&0xf)
+			(050) ldh      [x + 14]
+			(051) jgt      #0x3ff           jt 53	jf 52
+			(052) ret      #262144
+			(053) ret      #0
+			',
 	}, # src_portrange
 	{
 		name => 'dst_portrange',
@@ -12542,6 +13254,62 @@ my @accept_blocks = (
 			(018) jgt      #0x3ff           jt 20	jf 19
 			(019) ret      #262144
 			(020) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x86dd          jt 2	jf 20
+			(002) ldb      [20]
+			(003) jeq      #0x84            jt 4	jf 8
+			(004) ldh      [56]
+			(005) jge      #0x1             jt 6	jf 8
+			(006) ldh      [56]
+			(007) jgt      #0x3ff           jt 8	jf 52
+			(008) ldb      [20]
+			(009) jeq      #0x6             jt 10	jf 14
+			(010) ldh      [56]
+			(011) jge      #0x1             jt 12	jf 14
+			(012) ldh      [56]
+			(013) jgt      #0x3ff           jt 14	jf 52
+			(014) ldb      [20]
+			(015) jeq      #0x11            jt 16	jf 20
+			(016) ldh      [56]
+			(017) jge      #0x1             jt 18	jf 20
+			(018) ldh      [56]
+			(019) jgt      #0x3ff           jt 20	jf 52
+			(020) ldh      [12]
+			(021) jeq      #0x800           jt 22	jf 53
+			(022) ldb      [23]
+			(023) jeq      #0x84            jt 24	jf 32
+			(024) ldh      [20]
+			(025) jset     #0x1fff          jt 32	jf 26
+			(026) ldxb     4*([14]&0xf)
+			(027) ldh      [x + 16]
+			(028) jge      #0x1             jt 29	jf 32
+			(029) ldxb     4*([14]&0xf)
+			(030) ldh      [x + 16]
+			(031) jgt      #0x3ff           jt 32	jf 52
+			(032) ldb      [23]
+			(033) jeq      #0x6             jt 34	jf 42
+			(034) ldh      [20]
+			(035) jset     #0x1fff          jt 42	jf 36
+			(036) ldxb     4*([14]&0xf)
+			(037) ldh      [x + 16]
+			(038) jge      #0x1             jt 39	jf 42
+			(039) ldxb     4*([14]&0xf)
+			(040) ldh      [x + 16]
+			(041) jgt      #0x3ff           jt 42	jf 52
+			(042) ldb      [23]
+			(043) jeq      #0x11            jt 44	jf 53
+			(044) ldh      [20]
+			(045) jset     #0x1fff          jt 53	jf 46
+			(046) ldxb     4*([14]&0xf)
+			(047) ldh      [x + 16]
+			(048) jge      #0x1             jt 49	jf 53
+			(049) ldxb     4*([14]&0xf)
+			(050) ldh      [x + 16]
+			(051) jgt      #0x3ff           jt 53	jf 52
+			(052) ret      #262144
+			(053) ret      #0
 			',
 	}, # dst_portrange
 	{

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -318,6 +318,14 @@ sub skip_no_networks_casecmp {
 		skip_os ('solaris');
 }
 
+sub skip_big_endian {
+	return pack ('S', 0x4245) eq 'BE' ? 'big-endian' : '';
+}
+
+sub skip_little_endian {
+	return pack ('S', 0x454c) eq 'LE' ? 'little-endian' : '';
+}
+
 # In accept_blocks the top-level keys are test block names.  Each test block
 # defines one or more tests.  When possible, a test block name should be easy
 # to relate with the main filter expression, for example, ip_multicast for
@@ -2896,6 +2904,8 @@ my @accept_blocks = (
 			',
 	}, # ether_dst_host_NAME
 
+	# 3 DLTs lead to gen_ether_linktype(), which implements 7 code paths,
+	# let's test these for DLT_EN10MB only.
 	{
 		name => 'ether_proto_aarp',
 		DLT => 'EN10MB',
@@ -2965,6 +2975,7 @@ my @accept_blocks = (
 	{
 		name => 'ether_proto_ip',
 		DLT => 'EN10MB',
+		# gen_ether_linktype() default case
 		aliases => [
 			'ether proto \ip',
 			'ip',
@@ -2976,6 +2987,19 @@ my @accept_blocks = (
 			(003) ret      #0
 			',
 	}, # ether_proto_ip
+	{
+		name => 'ether_proto_6',
+		DLT => 'EN10MB',
+		aliases => ['ether proto 6'], # gen_ether_linktype() LLCSAP_IP
+		unopt => '
+			(000) ldh      [12]
+			(001) jgt      #0x5dc           jt 5	jf 2
+			(002) ldh      [14]
+			(003) jeq      #0x606           jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # ether_proto_6
 	{
 		name => 'ether_proto_ip6',
 		DLT => 'EN10MB',
@@ -3152,6 +3176,1477 @@ my @accept_blocks = (
 			(005) ret      #0
 			',
 	}, # ether_proto_stp
+
+	# The complete cartesian product of all DLTs and all link-layer protocol
+	# numbers in gen_linktype() is not a practicable test space.  Try testing
+	# all unique code paths and eliminate/coalesce code points as necessary.
+	{
+		name => 'link_proto_ip_NETANALYZER',
+		DLT => 'NETANALYZER',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [16]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_NETANALYZER
+	{
+		name => 'link_proto_ip_NETANALYZER_TRANSPARENT',
+		DLT => 'NETANALYZER_TRANSPARENT',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [24]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_NETANALYZER_TRANSPARENT
+	{
+		name => 'link_proto_ip_C_HDLC',
+		DLT => 'C_HDLC',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_C_HDLC
+	{
+		name => 'link_proto_iso_C_HDLC',
+		DLT => 'C_HDLC',
+		aliases => ['link proto \iso'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0xfefe          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_iso_C_HDLC
+	{
+		name => 'link_proto_ip_IEEE802_11',
+		DLT => 'IEEE802_11',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldx      #0x0
+			(001) txa
+			(002) add      #24
+			(003) st       M[0]
+			(004) ldb      [x + 0]
+			(005) jset     #0x8             jt 6	jf 11
+			(006) jset     #0x4             jt 11	jf 7
+			(007) jset     #0x80            jt 8	jf 11
+			(008) ld       M[0]
+			(009) add      #2
+			(010) st       M[0]
+			(011) ldb      [0]
+			(012) and      #0xc
+			(013) jeq      #0x8             jt 14	jf 18
+			(014) ldx      M[0]
+			(015) ldh      [x + 6]
+			(016) jeq      #0x800           jt 17	jf 18
+			(017) ret      #262144
+			(018) ret      #0
+			',
+	}, # link_proto_ip_IEEE802_11
+	{
+		name => 'link_proto_ip_PRISM_HEADER',
+		DLT => 'PRISM_HEADER',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) and      #0xfffff000
+			(002) jeq      #0x80211000      jt 3	jf 5
+			(003) ld       [4]
+			(004) ja       6
+			(005) ld       #0x90
+			(006) st       M[0]
+			(007) tax
+			(008) txa
+			(009) add      #24
+			(010) st       M[1]
+			(011) ldb      [x + 0]
+			(012) jset     #0x8             jt 13	jf 18
+			(013) jset     #0x4             jt 18	jf 14
+			(014) jset     #0x80            jt 15	jf 18
+			(015) ld       M[1]
+			(016) add      #2
+			(017) st       M[1]
+			(018) ldx      M[0]
+			(019) ldb      [x + 0]
+			(020) and      #0xc
+			(021) jeq      #0x8             jt 22	jf 26
+			(022) ldx      M[1]
+			(023) ldh      [x + 6]
+			(024) jeq      #0x800           jt 25	jf 26
+			(025) ret      #262144
+			(026) ret      #0
+			',
+	}, # link_proto_ip_PRISM_HEADER
+	{
+		name => 'link_proto_ip_IEEE802_11_RADIO',
+		DLT => 'IEEE802_11_RADIO',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [3]
+			(001) lsh      #8
+			(002) tax
+			(003) ldb      [2]
+			(004) or       x
+			(005) st       M[0]
+			(006) tax
+			(007) txa
+			(008) add      #24
+			(009) st       M[1]
+			(010) ldb      [x + 0]
+			(011) jset     #0x8             jt 12	jf 29
+			(012) jset     #0x4             jt 29	jf 13
+			(013) jset     #0x80            jt 14	jf 17
+			(014) ld       M[1]
+			(015) add      #2
+			(016) st       M[1]
+			(017) ld       [4]
+			(018) jset     #0x2000000       jt 19	jf 29
+			(019) jset     #0x80            jt 29	jf 20
+			(020) jset     #0x1000000       jt 21	jf 23
+			(021) ldb      [16]
+			(022) jset     #0x20            jt 25	jf 29
+			(023) ldb      [8]
+			(024) jset     #0x20            jt 25	jf 29
+			(025) ld       M[1]
+			(026) add      #3
+			(027) and      #0xfffffffc
+			(028) st       M[1]
+			(029) ldx      M[0]
+			(030) ldb      [x + 0]
+			(031) and      #0xc
+			(032) jeq      #0x8             jt 33	jf 37
+			(033) ldx      M[1]
+			(034) ldh      [x + 6]
+			(035) jeq      #0x800           jt 36	jf 37
+			(036) ret      #262144
+			(037) ret      #0
+			',
+	}, # link_proto_ip_IEEE802_11_RADIO
+	{
+		name => 'link_proto_ip_IEEE802_11_RADIO_AVS',
+		DLT => 'IEEE802_11_RADIO_AVS',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [4]
+			(001) st       M[0]
+			(002) tax
+			(003) txa
+			(004) add      #24
+			(005) st       M[1]
+			(006) ldb      [x + 0]
+			(007) jset     #0x8             jt 8	jf 13
+			(008) jset     #0x4             jt 13	jf 9
+			(009) jset     #0x80            jt 10	jf 13
+			(010) ld       M[1]
+			(011) add      #2
+			(012) st       M[1]
+			(013) ldx      M[0]
+			(014) ldb      [x + 0]
+			(015) and      #0xc
+			(016) jeq      #0x8             jt 17	jf 21
+			(017) ldx      M[1]
+			(018) ldh      [x + 6]
+			(019) jeq      #0x800           jt 20	jf 21
+			(020) ret      #262144
+			(021) ret      #0
+			',
+	}, # link_proto_ip_IEEE802_11_RADIO_AVS
+	{
+		name => 'link_proto_ip_PPI',
+		DLT => 'PPI',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [4]
+			(001) jeq      #0x69000000      jt 2	jf 27
+			(002) ldb      [3]
+			(003) lsh      #8
+			(004) tax
+			(005) ldb      [2]
+			(006) or       x
+			(007) st       M[0]
+			(008) tax
+			(009) txa
+			(010) add      #24
+			(011) st       M[1]
+			(012) ldb      [x + 0]
+			(013) jset     #0x8             jt 14	jf 19
+			(014) jset     #0x4             jt 19	jf 15
+			(015) jset     #0x80            jt 16	jf 19
+			(016) ld       M[1]
+			(017) add      #2
+			(018) st       M[1]
+			(019) ldx      M[0]
+			(020) ldb      [x + 0]
+			(021) and      #0xc
+			(022) jeq      #0x8             jt 23	jf 27
+			(023) ldx      M[1]
+			(024) ldh      [x + 6]
+			(025) jeq      #0x800           jt 26	jf 27
+			(026) ret      #262144
+			(027) ret      #0
+			',
+	}, # link_proto_ip_PPI
+	{
+		name => 'link_proto_ip_FDDI',
+		DLT => 'FDDI',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [19]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_FDDI
+	# 11 DLTs lead to gen_llc_linktype(), which implements 6 code paths,
+	# let's test these for DLT_IEEE802 only.
+	{
+		name => 'link_proto_ip_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \ip'], # gen_llc_linktype() default case
+		unopt => '
+			(000) ldh      [20]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_IEEE802
+	{
+		name => 'link_proto_6_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto 6'], # gen_llc_linktype() LLCSAP_IP
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0x606           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_6_IEEE802
+	{
+		name => 'link_proto_iso_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \iso'],
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0xfefe          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_iso_IEEE802
+	{
+		name => 'link_proto_netbeui_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \netbeui'],
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0xf0f0          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_netbeui_IEEE802
+	{
+		name => 'link_proto_ipx_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \ipx'],
+		unopt => '
+			(000) ldb      [14]
+			(001) jeq      #0xe0            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ipx_IEEE802
+	{
+		name => 'link_proto_atalk_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \atalk'],
+		unopt => '
+			(000) ld       [18]
+			(001) jeq      #0x7809b         jt 2	jf 5
+			(002) ld       [14]
+			(003) jeq      #0xaaaa0308      jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_atalk_IEEE802
+	{
+		name => 'link_proto_aarp_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \aarp'],
+		unopt => '
+			(000) ldh      [20]
+			(001) jeq      #0x80f3          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_aarp_IEEE802
+	{
+		name => 'link_proto_stp_IEEE802',
+		DLT => 'IEEE802',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ldb      [14]
+			(001) jeq      #0x42            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_IEEE802
+	{
+		name => 'link_proto_ip_ATM_RFC1483',
+		DLT => 'ATM_RFC1483',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [6]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_ATM_RFC1483
+	{
+		name => 'link_proto_ip_ATM_CLIP',
+		DLT => 'ATM_CLIP',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [6]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_ATM_CLIP
+	{
+		name => 'link_proto_ip_IP_OVER_FC',
+		DLT => 'IP_OVER_FC',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [22]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_IP_OVER_FC
+	{
+		name => 'link_proto_ip_SUNATM',
+		DLT => 'SUNATM',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf
+			(002) jeq      #0x2             jt 3	jf 6
+			(003) ldh      [10]
+			(004) jeq      #0x800           jt 5	jf 6
+			(005) ret      #262144
+			(006) ret      #0
+			',
+	}, # link_proto_ip_SUNATM
+	{
+		name => 'lane_and_link_proto_ip_SUNATM',
+		DLT => 'SUNATM',
+		aliases => ['lane and link proto \ip'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf
+			(002) jeq      #0x1             jt 3	jf 8
+			(003) ldh      [4]
+			(004) jeq      #0xff00          jt 8	jf 5
+			(005) ldh      [18]
+			(006) jeq      #0x800           jt 7	jf 8
+			(007) ret      #262144
+			(008) ret      #0
+			',
+	}, # lane_and_link_proto_ip_SUNATM
+	{
+		name => 'link_proto_ip_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \ip'], # gen_linux_sll_linktype() default case
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_LINUX_SLL
+	{
+		name => 'link_proto_ip_LINUX_SLL2',
+		DLT => 'LINUX_SLL2', # gen_linktype() default case
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [0]
+			(001) jeq      #0x800           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_LINUX_SLL
+	{
+		name => 'link_proto_ip6_LINUX_SLL',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \ip6'], # gen_linux_sll_linktype() default case
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0x86dd          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_LINUX_SLL
+	{
+		name => 'link_proto_6_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto 6'], # gen_linux_sll_linktype() LLCSAP_IP
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0x4             jt 2	jf 5
+			(002) ldh      [16]
+			(003) jeq      #0x606           jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_6_LINUX_SLL
+	{
+		name => 'link_proto_iso_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \iso'],
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0x4             jt 2	jf 5
+			(002) ldh      [16]
+			(003) jeq      #0xfefe          jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_iso_LINUX_SLL
+	{
+		name => 'link_proto_netbeui_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \netbeui'],
+		unopt => '
+			(000) ldh      [14]
+			(001) jeq      #0x4             jt 2	jf 5
+			(002) ldh      [16]
+			(003) jeq      #0xf0f0          jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_netbeui_LINUX_SLL
+	{
+		name => 'link_proto_ipx_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \ipx'],
+		opt => '
+			(000) ldh      [14]
+			(001) jeq      #0x8137          jt 10	jf 2
+			(002) jeq      #0x1             jt 10	jf 3
+			(003) jeq      #0x4             jt 4	jf 11
+			(004) ldb      [16]
+			(005) jeq      #0xe0            jt 10	jf 6
+			(006) ld       [20]
+			(007) jeq      #0x8137          jt 8	jf 11
+			(008) ld       [16]
+			(009) jeq      #0xaaaa0300      jt 10	jf 11
+			(010) ret      #262144
+			(011) ret      #0
+			',
+	}, # link_proto_ipx_LINUX_SLL
+	{
+		name => 'link_proto_atalk_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \atalk'],
+		opt => '
+			(000) ldh      [14]
+			(001) jeq      #0x809b          jt 7	jf 2
+			(002) jeq      #0x4             jt 3	jf 8
+			(003) ld       [20]
+			(004) jeq      #0x7809b         jt 5	jf 8
+			(005) ld       [16]
+			(006) jeq      #0xaaaa0308      jt 7	jf 8
+			(007) ret      #262144
+			(008) ret      #0
+			',
+	}, # link_proto_atalk_LINUX_SLL
+	{
+		name => 'link_proto_aarp_LINUX_SLL',
+		DLT => 'LINUX_SLL',
+		aliases => ['link proto \aarp'],
+		opt => '
+			(000) ldh      [14]
+			(001) jeq      #0x80f3          jt 7	jf 2
+			(002) jeq      #0x4             jt 3	jf 8
+			(003) ld       [20]
+			(004) jeq      #0x80f3          jt 5	jf 8
+			(005) ld       [16]
+			(006) jeq      #0xaaaa0300      jt 7	jf 8
+			(007) ret      #262144
+			(008) ret      #0
+			',
+	}, # link_proto_aarp_LINUX_SLL
+	{
+		name => 'link_proto_ip_SLIP',
+		DLT => 'SLIP',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x40            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_SLIP
+	{
+		name => 'link_proto_ip_SLIP_BSDOS',
+		DLT => 'SLIP_BSDOS',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x40            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_SLIP_BSDOS
+	{
+		name => 'link_proto_ip_RAW',
+		DLT => 'RAW',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x40            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_RAW
+	{
+		name => 'link_proto_ip6_RAW',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'RAW',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldb      [0]
+			(001) and      #0xf0
+			(002) jeq      #0x60            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip6_RAW
+	{
+		name => 'link_proto_stp_RAW',
+		DLT => 'RAW',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_RAW
+	{
+		name => 'link_proto_ip_IPV4',
+		DLT => 'IPV4',
+		aliases => ['link proto \ip'],
+		opt => '
+			(000) ret      #262144
+			',
+	}, # link_proto_ip_IPV4
+	{
+		name => 'link_proto_ip6_IPV4',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'IPV4',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_IPV4
+	{
+		name => 'link_proto_ip6_IPV6',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'IPV6',
+		aliases => ['link proto \ip6'],
+		opt => '
+			(000) ret      #262144
+			',
+	}, # link_proto_ip6_IPV6
+	{
+		name => 'link_proto_ip_IPV6',
+		DLT => 'IPV6',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_IPV6
+	# 4 DLTs lead to ethertype_to_ppptype(), which implements 9 code paths,
+	# let's test these for DLT_PPP only.
+	{
+		name => 'link_proto_ip_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x21            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_PPP
+	{
+		name => 'link_proto_ip6_PPP',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'PPP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x57            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_PPP
+	{
+		name => 'link_proto_decnet_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \decnet'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x27            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_decnet_PPP
+	{
+		name => 'link_proto_atalk_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \atalk'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x29            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_atalk_PPP
+	{
+		name => 'link_proto_xnsidp_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto 0x0600'], # ethertype_to_ppptype() ETHERTYPE_NS
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x25            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_xnsidp_PPP
+	{
+		name => 'link_proto_iso_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \iso'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x23            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_iso_PPP
+	{
+		name => 'link_proto_stp_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x31            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_PPP
+	{
+		name => 'link_proto_lat_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \lat'], # ethertype_to_ppptype() default case
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x6004          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_lat_PPP
+	{
+		name => 'link_proto_ipx_PPP',
+		DLT => 'PPP',
+		aliases => ['link proto \ipx'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x2b            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ipx_PPP
+	{
+		name => 'link_proto_ip_PPP_PPPD',
+		DLT => 'PPP_PPPD',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x21            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_PPP_PPPD
+	{
+		name => 'link_proto_ip_PPP_SERIAL',
+		DLT => 'PPP_SERIAL',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x21            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_PPP_SERIAL
+	{
+		name => 'link_proto_ip_PPP_ETHER',
+		DLT => 'PPP_ETHER',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [6]
+			(001) jeq      #0x21            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_PPP_ETHER
+	{
+		name => 'link_proto_ip_PPP_BSDOS',
+		DLT => 'PPP_BSDOS',
+		aliases => ['link proto \ip'],
+		opt => '
+			(000) ldh      [5]
+			(001) jeq      #0x21            jt 4	jf 2
+			(002) jeq      #0x2d            jt 4	jf 3
+			(003) jeq      #0x2f            jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_ip_PPP_BSDOS
+	{
+		name => 'link_proto_ip6_PPP_BSDOS',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'PPP_BSDOS',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldh      [5]
+			(001) jeq      #0x57            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_PPP_BSDOS
+
+	# DLT_NULL and DLT_ENC depend on the values of AF_INET and AF_INET6,
+	# which are OS-specific, and on the host byte order.  Exercise these
+	# dimensions completely for DLT_NULL only.
+	{
+		name => 'link_proto_ip_1LE_NULL',
+		skip => skip_big_endian() ||
+			skip_os_not ('haiku'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1000000       jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_1LE_NULL
+	{
+		name => 'link_proto_ip_2LE_NULL',
+		skip => skip_big_endian() ||
+			skip_os ('haiku'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x2000000       jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_2LE_NULL
+	{
+		name => 'link_proto_ip_2BE_NULL',
+		skip => skip_little_endian(),
+		DLT => 'NULL',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x2             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_2BE_NULL
+	{
+		name => 'link_proto_ip6_5LE_NULL',
+		skip => skip_big_endian() ||
+			skip_os_not ('haiku') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x5000000       jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_5LE_NULL
+	{
+		name => 'link_proto_ip6_10LE_NULL',
+		skip => skip_big_endian() ||
+			skip_os_not ('linux') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0xa000000       jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_10LE_NULL
+	{
+		name => 'link_proto_ip6_10BE_NULL',
+		skip => skip_little_endian() ||
+			skip_os_not ('linux') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0xa             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_10BE_NULL
+	{
+		name => 'link_proto_ip6_22BE_NULL',
+		skip => skip_little_endian() ||
+			skip_os_not ('hpux') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x16            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_22BE_NULL
+	{
+		name => 'link_proto_ip6_24LE_NULL',
+		skip => skip_big_endian() ||
+			(skip_os_not ('aix') && skip_os_not ('netbsd') && skip_os_not ('openbsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x18000000      jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_24LE_NULL
+	{
+		name => 'link_proto_ip6_24BE_NULL',
+		skip => skip_little_endian() ||
+			(skip_os_not ('aix') && skip_os_not ('netbsd') && skip_os_not ('openbsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x18            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_24BE_NULL
+	{
+		name => 'link_proto_ip6_26LE_NULL',
+		skip => skip_big_endian() ||
+			skip_os_not ('solaris') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1a000000      jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_26LE_NULL
+	{
+		name => 'link_proto_ip6_26BE_NULL',
+		skip => skip_little_endian() ||
+			skip_os_not ('solaris') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1a            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_26BE_NULL
+	{
+		name => 'link_proto_ip6_28LE_NULL',
+		skip => skip_big_endian() ||
+			(skip_os_not ('dragonfly') && skip_os_not ('freebsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1c000000      jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_28LE_NULL
+	{
+		name => 'link_proto_ip6_28BE_NULL',
+		skip => skip_little_endian() ||
+			(skip_os_not ('dragonfly') && skip_os_not ('freebsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1c            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_28BE_NULL
+	{
+		name => 'link_proto_ip6_30LE_NULL',
+		skip => skip_big_endian() ||
+			skip_os_not ('darwin') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1e000000      jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_30LE_NULL
+	{
+		name => 'link_proto_ip6_30BE_NULL',
+		skip => skip_little_endian() ||
+			skip_os_not ('darwin') ||
+			skip_config_undef ('INET6'),
+		DLT => 'NULL',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1e            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_30BE_NULL
+	{
+		name => 'link_proto_stp_NULL',
+		# The same code path for DLT_ENC and DLT_LOOP.
+		DLT => 'NULL',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_NULL
+	{
+		name => 'link_proto_ip_2LE_ENC',
+		skip => skip_big_endian() ||
+			skip_os_not ('linux'),
+		DLT => 'ENC',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x2000000       jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_2LE_ENC
+	{
+		name => 'link_proto_ip6_28LE_ENC',
+		skip => skip_big_endian() ||
+			(skip_os_not ('dragonfly') && skip_os_not ('freebsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'ENC',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1c000000      jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_28LE_ENC
+	# DLT_LOOP and DLT_PFLOG depend on the values of AF_INET and AF_INET6,
+	# which are OS-specific.  Exercise this dimension completely for
+	# DLT_LOOP only.
+	{
+		name => 'link_proto_ip_1_LOOP',
+		skip => skip_os_not ('haiku'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_1_LOOP
+	{
+		name => 'link_proto_ip_2_LOOP',
+		skip => skip_os ('haiku'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x2             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_2_LOOP
+	{
+		name => 'link_proto_ip6_5_LOOP',
+		skip => skip_os_not ('haiku') ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x5             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_5_LOOP
+	{
+		name => 'link_proto_ip6_10_LOOP',
+		skip => skip_os_not ('linux') ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0xa             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_10_LOOP
+	{
+		name => 'link_proto_ip6_22_LOOP',
+		skip => skip_os_not ('hpux') ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x16            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_22_LOOP
+	{
+		name => 'link_proto_ip6_24_LOOP',
+		skip => (skip_os_not ('aix') && skip_os_not ('netbsd') && skip_os_not ('openbsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x18            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_24_LOOP
+	{
+		name => 'link_proto_ip6_26_LOOP',
+		skip => skip_os_not ('solaris') ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1a            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_26_LOOP
+	{
+		name => 'link_proto_ip6_28_LOOP',
+		skip => (skip_os_not ('dragonfly') && skip_os_not ('freebsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1c            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_28_LOOP
+	{
+		name => 'link_proto_ip6_30_LOOP',
+		skip => skip_os_not ('darwin') ||
+			skip_config_undef ('INET6'),
+		DLT => 'LOOP',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ld       [0]
+			(001) jeq      #0x1e            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_30_LOOP
+	{
+		name => 'link_proto_ip_2_PFLOG',
+		skip => skip_os ('haiku'),
+		DLT => 'PFLOG',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [1]
+			(001) jeq      #0x2             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_2_PFLOG
+	{
+		name => 'link_proto_ip6_24_PFLOG',
+		skip => (skip_os_not ('aix') && skip_os_not ('netbsd') && skip_os_not ('openbsd')) ||
+			skip_config_undef ('INET6'),
+		DLT => 'PFLOG',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldb      [1]
+			(001) jeq      #0x18            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_PFLOG
+	{
+		name => 'link_proto_stp_PFLOG',
+		DLT => 'PFLOG',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_PFLOG
+	{
+		name => 'link_proto_stp_ARCNET',
+		DLT => 'ARCNET',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_ARCNET
+	{
+		name => 'link_proto_ip6_ARCNET',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'ARCNET',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldb      [2]
+			(001) jeq      #0xc4            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_ARCNET
+	{
+		name => 'link_proto_ip_ARCNET',
+		DLT => 'ARCNET',
+		aliases => ['link proto \ip'],
+		opt => '
+			(000) ldb      [2]
+			(001) jeq      #0xd4            jt 3	jf 2
+			(002) jeq      #0xf0            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_ARCNET
+	{
+		name => 'link_proto_arp_ARCNET',
+		DLT => 'ARCNET',
+		aliases => ['link proto \arp'],
+		opt => '
+			(000) ldb      [2]
+			(001) jeq      #0xd5            jt 3	jf 2
+			(002) jeq      #0xf1            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_arp_ARCNET
+	{
+		name => 'link_proto_rarp_ARCNET',
+		DLT => 'ARCNET',
+		aliases => ['link proto \rarp'],
+		unopt => '
+			(000) ldb      [2]
+			(001) jeq      #0xd6            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_rarp_ARCNET
+	{
+		name => 'link_proto_atalk_ARCNET',
+		DLT => 'ARCNET',
+		aliases => ['link proto \atalk'],
+		unopt => '
+			(000) ldb      [2]
+			(001) jeq      #0xdd            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_atalk_ARCNET
+	{
+		name => 'link_proto_ip6_ARCNET_LINUX',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'ARCNET_LINUX',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldb      [4]
+			(001) jeq      #0xc4            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_ARCNET_LINUX
+	{
+		name => 'link_proto_ip_ARCNET_LINUX',
+		DLT => 'ARCNET_LINUX',
+		aliases => ['link proto \ip'],
+		opt => '
+			(000) ldb      [4]
+			(001) jeq      #0xd4            jt 3	jf 2
+			(002) jeq      #0xf0            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_ARCNET_LINUX
+	{
+		name => 'link_proto_arp_ARCNET_LINUX',
+		DLT => 'ARCNET_LINUX',
+		aliases => ['link proto \arp'],
+		opt => '
+			(000) ldb      [4]
+			(001) jeq      #0xd5            jt 3	jf 2
+			(002) jeq      #0xf1            jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_arp_ARCNET_LINUX
+	{
+		name => 'link_proto_rarp_ARCNET_LINUX',
+		DLT => 'ARCNET_LINUX',
+		aliases => ['link proto \rarp'],
+		unopt => '
+			(000) ldb      [4]
+			(001) jeq      #0xd6            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_rarp_ARCNET_LINUX
+	{
+		name => 'link_proto_atalk_ARCNET_LINUX',
+		DLT => 'ARCNET_LINUX',
+		aliases => ['link proto \atalk'],
+		unopt => '
+			(000) ldb      [4]
+			(001) jeq      #0xdd            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_atalk_ARCNET_LINUX
+	{
+		name => 'link_proto_atalk_LTALK',
+		DLT => 'LTALK',
+		aliases => ['link proto \atalk'],
+		opt => '
+			(000) ret      #262144
+			',
+	}, # link_proto_atalk_LTALK
+	{
+		name => 'link_proto_ip_LTALK',
+		DLT => 'LTALK',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_LTALK
+	{
+		name => 'link_proto_ip_FRELAY',
+		DLT => 'FRELAY',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x3cc           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_FRELAY
+	{
+		name => 'link_proto_ip6_FRELAY',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'FRELAY',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldh      [2]
+			(001) jeq      #0x38e           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_FRELAY
+	{
+		name => 'link_proto_iso_FRELAY',
+		DLT => 'FRELAY',
+		aliases => ['link proto \iso'],
+		opt => '
+			(000) ldh      [2]
+			(001) jeq      #0x381           jt 4	jf 2
+			(002) jeq      #0x382           jt 4	jf 3
+			(003) jeq      #0x383           jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_iso_FRELAY
+	{
+		name => 'link_proto_stp_FRELAY',
+		DLT => 'FRELAY',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_arp_FRELAY
+	{
+		name => 'link_proto_ip_JUNIPER_MFR',
+		DLT => 'JUNIPER_MFR',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) and      #0xffffff00
+			(002) jeq      #0x4d474300      jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_JUNIPER_MFR
+	{
+		name => 'link_proto_ip_BACNET_MS_TP',
+		DLT => 'BACNET_MS_TP',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ld       [0]
+			(001) and      #0xffff0000
+			(002) jeq      #0x55ff0000      jt 3	jf 4
+			(003) ret      #262144
+			(004) ret      #0
+			',
+	}, # link_proto_ip_BACNET_MS_TP
+	{
+		name => 'link_proto_ip_IPNET',
+		DLT => 'IPNET',
+		aliases => ['link proto \ip'],
+		unopt => '
+			(000) ldb      [1]
+			(001) jeq      #0x2             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip_IPNET
+	{
+		name => 'link_proto_ip6_IPNET',
+		skip => skip_config_undef ('INET6'),
+		DLT => 'IPNET',
+		aliases => ['link proto \ip6'],
+		unopt => '
+			(000) ldb      [1]
+			(001) jeq      #0x1a            jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_ip6_IPNET
+	{
+		name => 'link_proto_stp_IPNET',
+		DLT => 'IPNET',
+		aliases => ['link proto \stp'],
+		unopt => '
+			(000) ld       #0x1
+			(001) jeq      #0x0             jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_stp_IPNET
+
+	# Edge cases for LLC/EtherType.
+	{
+		name => 'link_proto_0_EN10MB',
+		DLT => 'EN10MB',
+		aliases => ['link proto 0'],
+		unopt => '
+			(000) ldh      [12]
+			(001) jgt      #0x5dc           jt 5	jf 2
+			(002) ldb      [14]
+			(003) jeq      #0x0             jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_0_EN10MB
+	{
+		name => 'link_proto_255_EN10MB',
+		DLT => 'EN10MB',
+		aliases => ['link proto 255'],
+		unopt => '
+			(000) ldh      [12]
+			(001) jgt      #0x5dc           jt 5	jf 2
+			(002) ldb      [14]
+			(003) jeq      #0xff            jt 4	jf 5
+			(004) ret      #262144
+			(005) ret      #0
+			',
+	}, # link_proto_255_EN10MB
+	{
+		name => 'link_proto_1501_EN10MB',
+		DLT => 'EN10MB',
+		aliases => ['link proto 1501'],
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x5dd           jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_1501_EN10MB
+	{
+		name => 'link_proto_65535_EN10MB',
+		DLT => 'EN10MB',
+		aliases => ['link proto 65535'],
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0xffff          jt 2	jf 3
+			(002) ret      #262144
+			(003) ret      #0
+			',
+	}, # link_proto_65535_EN10MB
 
 	# ARP and RARP tests are interleaved for ease of cross-reference
 	# because ARP filter programs and RARP filter programs differ in the

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -12814,59 +12814,35 @@ my @accept_blocks = (
 			',
 		unopt => '
 			(000) ldh      [12]
-			(001) jeq      #0x86dd          jt 2	jf 20
+			(001) jeq      #0x86dd          jt 2	jf 12
 			(002) ldb      [20]
-			(003) jeq      #0x84            jt 4	jf 8
-			(004) ldh      [54]
-			(005) jeq      #0x7             jt 52	jf 6
-			(006) ldh      [56]
-			(007) jeq      #0x7             jt 52	jf 8
-			(008) ldb      [20]
-			(009) jeq      #0x6             jt 10	jf 14
-			(010) ldh      [54]
-			(011) jeq      #0x7             jt 52	jf 12
-			(012) ldh      [56]
-			(013) jeq      #0x7             jt 52	jf 14
-			(014) ldb      [20]
-			(015) jeq      #0x11            jt 16	jf 20
-			(016) ldh      [54]
-			(017) jeq      #0x7             jt 52	jf 18
-			(018) ldh      [56]
-			(019) jeq      #0x7             jt 52	jf 20
-			(020) ldh      [12]
-			(021) jeq      #0x800           jt 22	jf 53
-			(022) ldb      [23]
-			(023) jeq      #0x84            jt 24	jf 32
-			(024) ldh      [20]
-			(025) jset     #0x1fff          jt 32	jf 26
-			(026) ldxb     4*([14]&0xf)
-			(027) ldh      [x + 14]
-			(028) jeq      #0x7             jt 52	jf 29
-			(029) ldxb     4*([14]&0xf)
-			(030) ldh      [x + 16]
-			(031) jeq      #0x7             jt 52	jf 32
-			(032) ldb      [23]
-			(033) jeq      #0x6             jt 34	jf 42
-			(034) ldh      [20]
-			(035) jset     #0x1fff          jt 42	jf 36
-			(036) ldxb     4*([14]&0xf)
-			(037) ldh      [x + 14]
-			(038) jeq      #0x7             jt 52	jf 39
-			(039) ldxb     4*([14]&0xf)
-			(040) ldh      [x + 16]
-			(041) jeq      #0x7             jt 52	jf 42
-			(042) ldb      [23]
-			(043) jeq      #0x11            jt 44	jf 53
-			(044) ldh      [20]
-			(045) jset     #0x1fff          jt 53	jf 46
-			(046) ldxb     4*([14]&0xf)
-			(047) ldh      [x + 14]
-			(048) jeq      #0x7             jt 52	jf 49
-			(049) ldxb     4*([14]&0xf)
-			(050) ldh      [x + 16]
-			(051) jeq      #0x7             jt 52	jf 53
-			(052) ret      #262144
-			(053) ret      #0
+			(003) jeq      #0x84            jt 8	jf 4
+			(004) ldb      [20]
+			(005) jeq      #0x6             jt 8	jf 6
+			(006) ldb      [20]
+			(007) jeq      #0x11            jt 8	jf 12
+			(008) ldh      [54]
+			(009) jeq      #0x7             jt 28	jf 10
+			(010) ldh      [56]
+			(011) jeq      #0x7             jt 28	jf 12
+			(012) ldh      [12]
+			(013) jeq      #0x800           jt 14	jf 29
+			(014) ldb      [23]
+			(015) jeq      #0x84            jt 20	jf 16
+			(016) ldb      [23]
+			(017) jeq      #0x6             jt 20	jf 18
+			(018) ldb      [23]
+			(019) jeq      #0x11            jt 20	jf 29
+			(020) ldh      [20]
+			(021) jset     #0x1fff          jt 29	jf 22
+			(022) ldxb     4*([14]&0xf)
+			(023) ldh      [x + 14]
+			(024) jeq      #0x7             jt 28	jf 25
+			(025) ldxb     4*([14]&0xf)
+			(026) ldh      [x + 16]
+			(027) jeq      #0x7             jt 28	jf 29
+			(028) ret      #262144
+			(029) ret      #0
 			',
 	}, # port
 	{
@@ -12902,44 +12878,30 @@ my @accept_blocks = (
 			',
 		unopt => '
 			(000) ldh      [12]
-			(001) jeq      #0x86dd          jt 2	jf 14
+			(001) jeq      #0x86dd          jt 2	jf 10
 			(002) ldb      [20]
-			(003) jeq      #0x84            jt 4	jf 6
-			(004) ldh      [54]
-			(005) jeq      #0x7             jt 37	jf 6
+			(003) jeq      #0x84            jt 8	jf 4
+			(004) ldb      [20]
+			(005) jeq      #0x6             jt 8	jf 6
 			(006) ldb      [20]
-			(007) jeq      #0x6             jt 8	jf 10
+			(007) jeq      #0x11            jt 8	jf 10
 			(008) ldh      [54]
-			(009) jeq      #0x7             jt 37	jf 10
-			(010) ldb      [20]
-			(011) jeq      #0x11            jt 12	jf 14
-			(012) ldh      [54]
-			(013) jeq      #0x7             jt 37	jf 14
-			(014) ldh      [12]
-			(015) jeq      #0x800           jt 16	jf 38
+			(009) jeq      #0x7             jt 23	jf 10
+			(010) ldh      [12]
+			(011) jeq      #0x800           jt 12	jf 24
+			(012) ldb      [23]
+			(013) jeq      #0x84            jt 18	jf 14
+			(014) ldb      [23]
+			(015) jeq      #0x6             jt 18	jf 16
 			(016) ldb      [23]
-			(017) jeq      #0x84            jt 18	jf 23
+			(017) jeq      #0x11            jt 18	jf 24
 			(018) ldh      [20]
-			(019) jset     #0x1fff          jt 23	jf 20
+			(019) jset     #0x1fff          jt 24	jf 20
 			(020) ldxb     4*([14]&0xf)
 			(021) ldh      [x + 14]
-			(022) jeq      #0x7             jt 37	jf 23
-			(023) ldb      [23]
-			(024) jeq      #0x6             jt 25	jf 30
-			(025) ldh      [20]
-			(026) jset     #0x1fff          jt 30	jf 27
-			(027) ldxb     4*([14]&0xf)
-			(028) ldh      [x + 14]
-			(029) jeq      #0x7             jt 37	jf 30
-			(030) ldb      [23]
-			(031) jeq      #0x11            jt 32	jf 38
-			(032) ldh      [20]
-			(033) jset     #0x1fff          jt 38	jf 34
-			(034) ldxb     4*([14]&0xf)
-			(035) ldh      [x + 14]
-			(036) jeq      #0x7             jt 37	jf 38
-			(037) ret      #262144
-			(038) ret      #0
+			(022) jeq      #0x7             jt 23	jf 24
+			(023) ret      #262144
+			(024) ret      #0
 			',
 	}, # src_port
 	{
@@ -12975,44 +12937,30 @@ my @accept_blocks = (
 			',
 		unopt => '
 			(000) ldh      [12]
-			(001) jeq      #0x86dd          jt 2	jf 14
+			(001) jeq      #0x86dd          jt 2	jf 10
 			(002) ldb      [20]
-			(003) jeq      #0x84            jt 4	jf 6
-			(004) ldh      [56]
-			(005) jeq      #0x7             jt 37	jf 6
+			(003) jeq      #0x84            jt 8	jf 4
+			(004) ldb      [20]
+			(005) jeq      #0x6             jt 8	jf 6
 			(006) ldb      [20]
-			(007) jeq      #0x6             jt 8	jf 10
+			(007) jeq      #0x11            jt 8	jf 10
 			(008) ldh      [56]
-			(009) jeq      #0x7             jt 37	jf 10
-			(010) ldb      [20]
-			(011) jeq      #0x11            jt 12	jf 14
-			(012) ldh      [56]
-			(013) jeq      #0x7             jt 37	jf 14
-			(014) ldh      [12]
-			(015) jeq      #0x800           jt 16	jf 38
+			(009) jeq      #0x7             jt 23	jf 10
+			(010) ldh      [12]
+			(011) jeq      #0x800           jt 12	jf 24
+			(012) ldb      [23]
+			(013) jeq      #0x84            jt 18	jf 14
+			(014) ldb      [23]
+			(015) jeq      #0x6             jt 18	jf 16
 			(016) ldb      [23]
-			(017) jeq      #0x84            jt 18	jf 23
+			(017) jeq      #0x11            jt 18	jf 24
 			(018) ldh      [20]
-			(019) jset     #0x1fff          jt 23	jf 20
+			(019) jset     #0x1fff          jt 24	jf 20
 			(020) ldxb     4*([14]&0xf)
 			(021) ldh      [x + 16]
-			(022) jeq      #0x7             jt 37	jf 23
-			(023) ldb      [23]
-			(024) jeq      #0x6             jt 25	jf 30
-			(025) ldh      [20]
-			(026) jset     #0x1fff          jt 30	jf 27
-			(027) ldxb     4*([14]&0xf)
-			(028) ldh      [x + 16]
-			(029) jeq      #0x7             jt 37	jf 30
-			(030) ldb      [23]
-			(031) jeq      #0x11            jt 32	jf 38
-			(032) ldh      [20]
-			(033) jset     #0x1fff          jt 38	jf 34
-			(034) ldxb     4*([14]&0xf)
-			(035) ldh      [x + 16]
-			(036) jeq      #0x7             jt 37	jf 38
-			(037) ret      #262144
-			(038) ret      #0
+			(022) jeq      #0x7             jt 23	jf 24
+			(023) ret      #262144
+			(024) ret      #0
 			',
 	}, # dst_port
 	{
@@ -13053,89 +13001,45 @@ my @accept_blocks = (
 			',
 		unopt => '
 			(000) ldh      [12]
-			(001) jeq      #0x86dd          jt 2	jf 32
+			(001) jeq      #0x86dd          jt 2	jf 16
 			(002) ldb      [20]
-			(003) jeq      #0x84            jt 4	jf 12
-			(004) ldh      [54]
-			(005) jge      #0x1             jt 6	jf 8
-			(006) ldh      [54]
-			(007) jgt      #0x3ff           jt 8	jf 82
-			(008) ldh      [56]
+			(003) jeq      #0x84            jt 8	jf 4
+			(004) ldb      [20]
+			(005) jeq      #0x6             jt 8	jf 6
+			(006) ldb      [20]
+			(007) jeq      #0x11            jt 8	jf 16
+			(008) ldh      [54]
 			(009) jge      #0x1             jt 10	jf 12
-			(010) ldh      [56]
-			(011) jgt      #0x3ff           jt 12	jf 82
-			(012) ldb      [20]
-			(013) jeq      #0x6             jt 14	jf 22
-			(014) ldh      [54]
-			(015) jge      #0x1             jt 16	jf 18
-			(016) ldh      [54]
-			(017) jgt      #0x3ff           jt 18	jf 82
-			(018) ldh      [56]
-			(019) jge      #0x1             jt 20	jf 22
-			(020) ldh      [56]
-			(021) jgt      #0x3ff           jt 22	jf 82
-			(022) ldb      [20]
-			(023) jeq      #0x11            jt 24	jf 32
-			(024) ldh      [54]
-			(025) jge      #0x1             jt 26	jf 28
-			(026) ldh      [54]
-			(027) jgt      #0x3ff           jt 28	jf 82
-			(028) ldh      [56]
-			(029) jge      #0x1             jt 30	jf 32
-			(030) ldh      [56]
-			(031) jgt      #0x3ff           jt 32	jf 82
-			(032) ldh      [12]
-			(033) jeq      #0x800           jt 34	jf 83
-			(034) ldb      [23]
-			(035) jeq      #0x84            jt 36	jf 50
-			(036) ldh      [20]
-			(037) jset     #0x1fff          jt 50	jf 38
-			(038) ldxb     4*([14]&0xf)
-			(039) ldh      [x + 14]
-			(040) jge      #0x1             jt 41	jf 44
-			(041) ldxb     4*([14]&0xf)
-			(042) ldh      [x + 14]
-			(043) jgt      #0x3ff           jt 44	jf 82
-			(044) ldxb     4*([14]&0xf)
-			(045) ldh      [x + 16]
-			(046) jge      #0x1             jt 47	jf 50
-			(047) ldxb     4*([14]&0xf)
-			(048) ldh      [x + 16]
-			(049) jgt      #0x3ff           jt 50	jf 82
-			(050) ldb      [23]
-			(051) jeq      #0x6             jt 52	jf 66
-			(052) ldh      [20]
-			(053) jset     #0x1fff          jt 66	jf 54
-			(054) ldxb     4*([14]&0xf)
-			(055) ldh      [x + 14]
-			(056) jge      #0x1             jt 57	jf 60
-			(057) ldxb     4*([14]&0xf)
-			(058) ldh      [x + 14]
-			(059) jgt      #0x3ff           jt 60	jf 82
-			(060) ldxb     4*([14]&0xf)
-			(061) ldh      [x + 16]
-			(062) jge      #0x1             jt 63	jf 66
-			(063) ldxb     4*([14]&0xf)
-			(064) ldh      [x + 16]
-			(065) jgt      #0x3ff           jt 66	jf 82
-			(066) ldb      [23]
-			(067) jeq      #0x11            jt 68	jf 83
-			(068) ldh      [20]
-			(069) jset     #0x1fff          jt 83	jf 70
-			(070) ldxb     4*([14]&0xf)
-			(071) ldh      [x + 14]
-			(072) jge      #0x1             jt 73	jf 76
-			(073) ldxb     4*([14]&0xf)
-			(074) ldh      [x + 14]
-			(075) jgt      #0x3ff           jt 76	jf 82
-			(076) ldxb     4*([14]&0xf)
-			(077) ldh      [x + 16]
-			(078) jge      #0x1             jt 79	jf 83
-			(079) ldxb     4*([14]&0xf)
-			(080) ldh      [x + 16]
-			(081) jgt      #0x3ff           jt 83	jf 82
-			(082) ret      #262144
-			(083) ret      #0
+			(010) ldh      [54]
+			(011) jgt      #0x3ff           jt 12	jf 38
+			(012) ldh      [56]
+			(013) jge      #0x1             jt 14	jf 16
+			(014) ldh      [56]
+			(015) jgt      #0x3ff           jt 16	jf 38
+			(016) ldh      [12]
+			(017) jeq      #0x800           jt 18	jf 39
+			(018) ldb      [23]
+			(019) jeq      #0x84            jt 24	jf 20
+			(020) ldb      [23]
+			(021) jeq      #0x6             jt 24	jf 22
+			(022) ldb      [23]
+			(023) jeq      #0x11            jt 24	jf 39
+			(024) ldh      [20]
+			(025) jset     #0x1fff          jt 39	jf 26
+			(026) ldxb     4*([14]&0xf)
+			(027) ldh      [x + 14]
+			(028) jge      #0x1             jt 29	jf 32
+			(029) ldxb     4*([14]&0xf)
+			(030) ldh      [x + 14]
+			(031) jgt      #0x3ff           jt 32	jf 38
+			(032) ldxb     4*([14]&0xf)
+			(033) ldh      [x + 16]
+			(034) jge      #0x1             jt 35	jf 39
+			(035) ldxb     4*([14]&0xf)
+			(036) ldh      [x + 16]
+			(037) jgt      #0x3ff           jt 39	jf 38
+			(038) ret      #262144
+			(039) ret      #0
 			',
 	}, # portrange
 	{
@@ -13170,59 +13074,35 @@ my @accept_blocks = (
 			',
 		unopt => '
 			(000) ldh      [12]
-			(001) jeq      #0x86dd          jt 2	jf 20
+			(001) jeq      #0x86dd          jt 2	jf 12
 			(002) ldb      [20]
-			(003) jeq      #0x84            jt 4	jf 8
-			(004) ldh      [54]
-			(005) jge      #0x1             jt 6	jf 8
-			(006) ldh      [54]
-			(007) jgt      #0x3ff           jt 8	jf 52
-			(008) ldb      [20]
-			(009) jeq      #0x6             jt 10	jf 14
+			(003) jeq      #0x84            jt 8	jf 4
+			(004) ldb      [20]
+			(005) jeq      #0x6             jt 8	jf 6
+			(006) ldb      [20]
+			(007) jeq      #0x11            jt 8	jf 12
+			(008) ldh      [54]
+			(009) jge      #0x1             jt 10	jf 12
 			(010) ldh      [54]
-			(011) jge      #0x1             jt 12	jf 14
-			(012) ldh      [54]
-			(013) jgt      #0x3ff           jt 14	jf 52
-			(014) ldb      [20]
-			(015) jeq      #0x11            jt 16	jf 20
-			(016) ldh      [54]
-			(017) jge      #0x1             jt 18	jf 20
-			(018) ldh      [54]
-			(019) jgt      #0x3ff           jt 20	jf 52
-			(020) ldh      [12]
-			(021) jeq      #0x800           jt 22	jf 53
-			(022) ldb      [23]
-			(023) jeq      #0x84            jt 24	jf 32
-			(024) ldh      [20]
-			(025) jset     #0x1fff          jt 32	jf 26
-			(026) ldxb     4*([14]&0xf)
-			(027) ldh      [x + 14]
-			(028) jge      #0x1             jt 29	jf 32
-			(029) ldxb     4*([14]&0xf)
-			(030) ldh      [x + 14]
-			(031) jgt      #0x3ff           jt 32	jf 52
-			(032) ldb      [23]
-			(033) jeq      #0x6             jt 34	jf 42
-			(034) ldh      [20]
-			(035) jset     #0x1fff          jt 42	jf 36
-			(036) ldxb     4*([14]&0xf)
-			(037) ldh      [x + 14]
-			(038) jge      #0x1             jt 39	jf 42
-			(039) ldxb     4*([14]&0xf)
-			(040) ldh      [x + 14]
-			(041) jgt      #0x3ff           jt 42	jf 52
-			(042) ldb      [23]
-			(043) jeq      #0x11            jt 44	jf 53
-			(044) ldh      [20]
-			(045) jset     #0x1fff          jt 53	jf 46
-			(046) ldxb     4*([14]&0xf)
-			(047) ldh      [x + 14]
-			(048) jge      #0x1             jt 49	jf 53
-			(049) ldxb     4*([14]&0xf)
-			(050) ldh      [x + 14]
-			(051) jgt      #0x3ff           jt 53	jf 52
-			(052) ret      #262144
-			(053) ret      #0
+			(011) jgt      #0x3ff           jt 12	jf 28
+			(012) ldh      [12]
+			(013) jeq      #0x800           jt 14	jf 29
+			(014) ldb      [23]
+			(015) jeq      #0x84            jt 20	jf 16
+			(016) ldb      [23]
+			(017) jeq      #0x6             jt 20	jf 18
+			(018) ldb      [23]
+			(019) jeq      #0x11            jt 20	jf 29
+			(020) ldh      [20]
+			(021) jset     #0x1fff          jt 29	jf 22
+			(022) ldxb     4*([14]&0xf)
+			(023) ldh      [x + 14]
+			(024) jge      #0x1             jt 25	jf 29
+			(025) ldxb     4*([14]&0xf)
+			(026) ldh      [x + 14]
+			(027) jgt      #0x3ff           jt 29	jf 28
+			(028) ret      #262144
+			(029) ret      #0
 			',
 	}, # src_portrange
 	{
@@ -13257,59 +13137,35 @@ my @accept_blocks = (
 			',
 		unopt => '
 			(000) ldh      [12]
-			(001) jeq      #0x86dd          jt 2	jf 20
+			(001) jeq      #0x86dd          jt 2	jf 12
 			(002) ldb      [20]
-			(003) jeq      #0x84            jt 4	jf 8
-			(004) ldh      [56]
-			(005) jge      #0x1             jt 6	jf 8
-			(006) ldh      [56]
-			(007) jgt      #0x3ff           jt 8	jf 52
-			(008) ldb      [20]
-			(009) jeq      #0x6             jt 10	jf 14
+			(003) jeq      #0x84            jt 8	jf 4
+			(004) ldb      [20]
+			(005) jeq      #0x6             jt 8	jf 6
+			(006) ldb      [20]
+			(007) jeq      #0x11            jt 8	jf 12
+			(008) ldh      [56]
+			(009) jge      #0x1             jt 10	jf 12
 			(010) ldh      [56]
-			(011) jge      #0x1             jt 12	jf 14
-			(012) ldh      [56]
-			(013) jgt      #0x3ff           jt 14	jf 52
-			(014) ldb      [20]
-			(015) jeq      #0x11            jt 16	jf 20
-			(016) ldh      [56]
-			(017) jge      #0x1             jt 18	jf 20
-			(018) ldh      [56]
-			(019) jgt      #0x3ff           jt 20	jf 52
-			(020) ldh      [12]
-			(021) jeq      #0x800           jt 22	jf 53
-			(022) ldb      [23]
-			(023) jeq      #0x84            jt 24	jf 32
-			(024) ldh      [20]
-			(025) jset     #0x1fff          jt 32	jf 26
-			(026) ldxb     4*([14]&0xf)
-			(027) ldh      [x + 16]
-			(028) jge      #0x1             jt 29	jf 32
-			(029) ldxb     4*([14]&0xf)
-			(030) ldh      [x + 16]
-			(031) jgt      #0x3ff           jt 32	jf 52
-			(032) ldb      [23]
-			(033) jeq      #0x6             jt 34	jf 42
-			(034) ldh      [20]
-			(035) jset     #0x1fff          jt 42	jf 36
-			(036) ldxb     4*([14]&0xf)
-			(037) ldh      [x + 16]
-			(038) jge      #0x1             jt 39	jf 42
-			(039) ldxb     4*([14]&0xf)
-			(040) ldh      [x + 16]
-			(041) jgt      #0x3ff           jt 42	jf 52
-			(042) ldb      [23]
-			(043) jeq      #0x11            jt 44	jf 53
-			(044) ldh      [20]
-			(045) jset     #0x1fff          jt 53	jf 46
-			(046) ldxb     4*([14]&0xf)
-			(047) ldh      [x + 16]
-			(048) jge      #0x1             jt 49	jf 53
-			(049) ldxb     4*([14]&0xf)
-			(050) ldh      [x + 16]
-			(051) jgt      #0x3ff           jt 53	jf 52
-			(052) ret      #262144
-			(053) ret      #0
+			(011) jgt      #0x3ff           jt 12	jf 28
+			(012) ldh      [12]
+			(013) jeq      #0x800           jt 14	jf 29
+			(014) ldb      [23]
+			(015) jeq      #0x84            jt 20	jf 16
+			(016) ldb      [23]
+			(017) jeq      #0x6             jt 20	jf 18
+			(018) ldb      [23]
+			(019) jeq      #0x11            jt 20	jf 29
+			(020) ldh      [20]
+			(021) jset     #0x1fff          jt 29	jf 22
+			(022) ldxb     4*([14]&0xf)
+			(023) ldh      [x + 16]
+			(024) jge      #0x1             jt 25	jf 29
+			(025) ldxb     4*([14]&0xf)
+			(026) ldh      [x + 16]
+			(027) jgt      #0x3ff           jt 29	jf 28
+			(028) ret      #262144
+			(029) ret      #0
 			',
 	}, # dst_portrange
 	{

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -13830,16 +13830,34 @@ my @reject_tests = (
 		errstr => 'unknown ip proto',
 	},
 	{
+		name => 'proto_256',
+		DLT => 'RAW',
+		expr => 'proto 256',
+		errstr => 'protocol number 256 greater than maximum 255',
+	},
+	{
 		name => 'ip_proto_invalid',
 		DLT => 'RAW',
 		expr => 'ip proto nosuchprotocol',
 		errstr => 'unknown ip proto',
 	},
 	{
+		name => 'ip_proto_256',
+		DLT => 'RAW',
+		expr => 'ip proto 256',
+		errstr => 'protocol number 256 greater than maximum 255',
+	},
+	{
 		name => 'ip6_proto_invalid',
 		DLT => 'RAW',
 		expr => 'ip6 proto nosuchprotocol',
 		errstr => 'unknown ip proto',
+	},
+	{
+		name => 'ip6_proto_256',
+		DLT => 'RAW',
+		expr => 'ip6 proto 256',
+		errstr => 'protocol number 256 greater than maximum 255',
 	},
 	{
 		name => 'proto_1_2_3_4',

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -13108,6 +13108,9 @@ foreach my $test (@accept_blocks) {
 		next if defined $test->{$_};
 		die "Internal error: accept test block '$test->{name}' does not define key '$_'";
 	}
+	if ($test->{DLT} eq '') {
+		die "Internal error: key 'DLT' is an empty string in apply test block '$test->{name}'";
+	}
 	if (! scalar @{$test->{aliases}}) {
 		die "Internal error: accept test block '$test->{name}' defines zero aliases";
 	} else {


### PR DESCRIPTION
This implements better validation of some `protocol` forms and cleaner unoptimized filter programs for `port` and `portrange` forms without a protocol qualifier.