### PR TITLE
Adding Cifuzz for Continuous fuzzing

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -1,0 +1,45 @@
+name: CIFuzz
+on:
+  pull_request:
+    branches:
+      - master
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: true
+
+permissions: {}
+jobs:
+ Fuzzing:
+   runs-on: ubuntu-latest
+   permissions:
+     security-events: write
+
+   strategy:
+     fail-fast: false
+     matrix:
+      sanitizer: [address, undefined, memory]
+
+   steps:
+   - name: Build Fuzzers (${{ matrix.sanitizer }})
+     id: build
+     uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'libpcap'
+       language: c
+       sanitizer: ${{ matrix.sanitizer }}
+
+   - name: Run Fuzzers (${{ matrix.sanitizer }})
+     uses: google/oss-fuzz/infra/cifuzz/actions/run_fuzzers@master
+     with:
+       oss-fuzz-project-name: 'libpcap'
+       language: c
+       fuzz-seconds: 600
+       sanitizer: ${{ matrix.sanitizer }}
+       
+   - name: Upload Crash
+     uses: actions/upload-artifact@v3
+     if: failure() && steps.build.outcome == 'success'
+     with:
+       name: ${{ matrix.sanitizer }}-artifacts
+       path: ./out/artifacts


### PR DESCRIPTION
Hello, i would like to add Cifuzz from oss-fuzz because you already have fuzz targets.
Cifuzz is supposed to fuzz code on every pull request (for 600 seconds, this can be more if you are fine with it) with fuzz targets from testprogs/fuzz.

I am aware of #908 and i want to say login with github is also possible.. https://oss-fuzz.com/login :)