### PR TITLE
Linux: Always request and wait for an ACK from nl80211

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -121,6 +121,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
     Linux:
       Do not use ether_hostton() from musl libc.
       Fix propagation of getprotobyname_r() errors.
+      Fix returning PCAP_ERROR_RFMON_NOTSUP with libnl.
     Haiku:
       Look for ethers(5) in /boot/system/settings/network/.
     DAG:

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -756,7 +756,10 @@ DIAG_ON_NARROWING
 
 	err = nl_send_sync(state->nl_sock, msg); // calls nlmsg_free()
 	if (err < 0) {
-		if (err == -NLE_FAILURE) {
+		switch (err) {
+
+		case -NLE_FAILURE:
+		case -NLE_AGAIN:
 			/*
 			 * Device not available; our caller should just
 			 * keep trying.  (libnl 2.x maps ENFILE to
@@ -765,10 +768,20 @@ DIAG_ON_NARROWING
 			 * about that.)
 			 */
 			return 0;
-		} else {
+
+		case -NLE_OPNOTSUPP:
+			/*
+			 * Device is a mac80211 device but adding it as a
+			 * monitor mode device isn't supported.  Report our
+			 * error.
+			 */
+			return PCAP_ERROR_RFMON_NOTSUP;
+
+		default:
 			/*
 			 * Real failure, not just "that device is not
-			 * available.
+			 * available."  Report a generic error, using the
+			 * error message from libnl.
 			 */
 			snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
 			    "%s: nl_send_sync failed adding %s interface: %s",

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -644,9 +644,6 @@ get_if_type(pcap_t *handle, int sock_fd, struct nl80211_state *state,
 	if (ifindex == -1)
 		return PCAP_ERROR;
 
-	struct nl_cb *cb = nl_cb_alloc(NL_CB_DEFAULT);
-	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, if_type_cb, (void*)type);
-
 	msg = nlmsg_alloc();
 	if (!msg) {
 		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
@@ -683,7 +680,10 @@ get_if_type(pcap_t *handle, int sock_fd, struct nl80211_state *state,
 		}
 	}
 
+	struct nl_cb *cb = nl_cb_alloc(NL_CB_DEFAULT);
+	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, if_type_cb, (void*)type);
 	nl_recvmsgs(state->nl_sock, cb);
+	nl_cb_put(cb);
 
 	/*
 	 * Success.
@@ -695,6 +695,7 @@ nla_put_failure:
 	    "%s: nl_put failed getting interface type",
 	    device);
 	nlmsg_free(msg);
+	// Do not call nl_cb_put(): nl_cb_alloc() has not been called.
 	return PCAP_ERROR;
 }
 

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -624,12 +624,17 @@ if_type_cb(struct nl_msg *msg, void* arg)
 	nla_parse(tb_msg, NL80211_ATTR_MAX, genlmsg_attrdata(gnlh, 0),
 		genlmsg_attrlen(gnlh, 0), NULL);
 
-	if (!tb_msg[NL80211_ATTR_IFTYPE]) {
-		return NL_SKIP;
+	/*
+	 * We sent a message asking for info about a single index.
+	 * To be really paranoid, we could check if the index matched
+	 * by examining nla_get_u32(tb_msg[NL80211_ATTR_IFINDEX]).
+	 */
+
+	if (tb_msg[NL80211_ATTR_IFTYPE]) {
+		*type = nla_get_u32(tb_msg[NL80211_ATTR_IFTYPE]);
 	}
 
-	*type = nla_get_u32(tb_msg[NL80211_ATTR_IFTYPE]);
-	return NL_STOP;
+	return NL_SKIP;
 }
 
 static int
@@ -682,8 +687,29 @@ get_if_type(pcap_t *handle, int sock_fd, struct nl80211_state *state,
 
 	struct nl_cb *cb = nl_cb_alloc(NL_CB_DEFAULT);
 	nl_cb_set(cb, NL_CB_VALID, NL_CB_CUSTOM, if_type_cb, (void*)type);
-	nl_recvmsgs(state->nl_sock, cb);
+	err = nl_recvmsgs(state->nl_sock, cb);
 	nl_cb_put(cb);
+
+	if (err < 0) {
+		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+		    "%s: nl_recvmsgs failed getting interface type: %s",
+		    device, nl_geterror(-err));
+		return PCAP_ERROR;
+	}
+
+	/*
+	* If this is a mac80211 device not in monitor mode, nl_sock will be
+	* reused for add_mon_if. So we must wait for the ACK here so that
+	* add_mon_if does not receive it instead and incorrectly interpret
+	* the ACK as its NEW_INTERFACE command succeeding, even when it fails.
+	*/
+	err = nl_wait_for_ack(state->nl_sock);
+	if (err < 0) {
+		snprintf(handle->errbuf, PCAP_ERRBUF_SIZE,
+		    "%s: nl_wait_for_ack failed getting interface type: %s",
+		    device, nl_geterror(-err));
+		return PCAP_ERROR;
+	}
 
 	/*
 	 * Success.


### PR DESCRIPTION
The Linux kernel documentation for Netlink says:

"Note that unless the NLM_F_ACK flag is set on the request Netlink will not respond with NLMSG_ERROR if there is no error. To avoid having to special-case this quirk it is recommended to always set NLM_F_ACK." (https://docs.kernel.org/userspace-api/netlink/intro.html#nl-msg-type)

In other places, it suggests that sockets do have Auto-ACK enabled by default, however.

Regardless, follow instructions and always set NLM_F_ACK, and receive messages until we get the ACK.

Fix #1508