### PR TITLE
Define ETHERTYPE_{SLOW,LLDP} and accept them in pcap_nametoeproto()

### DIFF
--- a/ethertype.h
+++ b/ethertype.h
@@ -100,6 +100,9 @@
 #ifndef ETHERTYPE_IPV6
 #define ETHERTYPE_IPV6		0x86dd
 #endif
+#ifndef ETHERTYPE_SLOW
+#define ETHERTYPE_SLOW		0x8809
+#endif
 #ifndef ETHERTYPE_MPLS
 #define ETHERTYPE_MPLS		0x8847
 #endif
@@ -114,6 +117,9 @@
 #endif
 #ifndef ETHERTYPE_8021AD
 #define ETHERTYPE_8021AD	0x88a8
+#endif
+#ifndef ETHERTYPE_LLDP
+#define ETHERTYPE_LLDP		0x88cc
 #endif
 #ifndef	ETHERTYPE_LOOPBACK
 #define ETHERTYPE_LOOPBACK	0x9000

--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -571,11 +571,13 @@ PCAP_API_DEF struct eproto eproto_db[] = {
 	{ "ip", ETHERTYPE_IP },
 	{ "ip6", ETHERTYPE_IPV6 },
 	{ "lat", ETHERTYPE_LAT },
+	{ "lldp", ETHERTYPE_LLDP },
 	{ "loopback", ETHERTYPE_LOOPBACK },
 	{ "mopdl", ETHERTYPE_MOPDL },
 	{ "moprc", ETHERTYPE_MOPRC },
 	{ "rarp", ETHERTYPE_REVARP },
 	{ "sca", ETHERTYPE_SCA },
+	{ "slow", ETHERTYPE_SLOW },
 	{ (char *)0, 0 }
 };
 


### PR DESCRIPTION
Linux has
```c
#define ETH_P_SLOW	0x8809		/* Slow Protocol. See 802.3ad 43B */
#define ETH_P_LLDP	0x88CC		/* Link Layer Discovery Protocol */
```
for these.

SLOW carries IEEE 802.3 LACP, both defined in annex 57A of [802.3-2018](https://ieeexplore.ieee.org/stamp/stamp.jsp?tp=&arnumber=8457469) and LLDP is defined in sexion 79 of the same.