### PR TITLE
DRAFT: Factor gen_host46_byname() out.

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -935,7 +935,7 @@ pqkw(const unsigned id)
 static const char *
 dqkw(const unsigned id)
 {
-	const char * map[] = {
+	const char * tokens[] = {
 		[Q_SRC] = "src",
 		[Q_DST] = "dst",
 		[Q_OR] = "src or dst",
@@ -947,7 +947,7 @@ dqkw(const unsigned id)
 		[Q_RA] = "ra",
 		[Q_TA] = "ta",
 	};
-	return qual2kw("dir", id, map, sizeof(map) / sizeof(map[0]));
+	return qual2kw("dir", id, tokens, sizeof(tokens) / sizeof(tokens[0]));
 }
 
 // ATM keywords

--- a/gencode.c
+++ b/gencode.c
@@ -680,6 +680,8 @@ static struct block *gen_host(compiler_state_t *, bpf_u_int32, bpf_u_int32,
     int, int, int);
 static struct block *gen_host6(compiler_state_t *, struct in6_addr *,
     struct in6_addr *, int, int, int);
+static struct block *gen_host46_byname(compiler_state_t *, const char *,
+    const u_char, const u_char, const u_char);
 static struct block *gen_gateway(compiler_state_t *, const char *, const int);
 static struct block *gen_ip_proto(compiler_state_t *, const uint8_t);
 static struct block *gen_ip6_proto(compiler_state_t *, const uint8_t);
@@ -5192,6 +5194,55 @@ gen_host6(compiler_state_t *cstate, struct in6_addr *addr,
 	/*NOTREACHED*/
 }
 
+static struct block *
+gen_host46_byname(compiler_state_t *cstate, const char *name,
+    const u_char proto4, const u_char proto6, const u_char dir)
+{
+	if (! (cstate->ai = pcap_nametoaddrinfo(name)))
+		bpf_error(cstate, ERRSTR_UNKNOWN_HOST, name);
+	struct block *ret = NULL;
+	struct in6_addr mask128;
+	memset(&mask128, 0xff, sizeof(mask128));
+	for (struct addrinfo *ai = cstate->ai; ai; ai = ai->ai_next) {
+		struct block *tmp = NULL;
+		switch (ai->ai_family) {
+		case AF_INET:
+			switch (proto4) {
+			case Q_IP:
+			case Q_ARP:
+			case Q_RARP:
+			case Q_DEFAULT:
+				struct sockaddr_in *sin4 =
+				    (struct sockaddr_in *)ai->ai_addr;
+				tmp = gen_host(cstate, ntohl(sin4->sin_addr.s_addr),
+				    0xffffffff, proto4, dir, Q_HOST);
+			}
+			break;
+		case AF_INET6:
+			switch (proto6) {
+			case Q_IPV6:
+			case Q_DEFAULT:
+				struct sockaddr_in6 *sin6 =
+				    (struct sockaddr_in6 *)ai->ai_addr;
+				tmp = gen_host6(cstate, &sin6->sin6_addr,
+				    &mask128, proto6, dir, Q_HOST);
+			}
+			break;
+		}
+		if (! tmp)
+			continue;
+		if (ret)
+			gen_or(ret, tmp);
+		ret = tmp;
+	}
+	free(cstate->ai);
+	cstate->ai = NULL;
+
+	if (! ret)
+		bpf_error(cstate, ERRSTR_UNKNOWN_HOST, name);
+	return ret;
+}
+
 static unsigned char
 is_mac48_linktype(const int linktype)
 {
@@ -5325,50 +5376,7 @@ gen_gateway(compiler_state_t *cstate, const char *name, const int proto)
 	}
 
 	struct block *b0 = gen_mac48host_byname(cstate, name, Q_OR, "gateway");
-
-	cstate->ai = pcap_nametoaddrinfo(name);
-	if (cstate->ai == NULL)
-		bpf_error(cstate, ERRSTR_UNKNOWN_HOST, name);
-	struct block *b1 = NULL;
-	for (struct addrinfo *ai = cstate->ai; ai != NULL; ai = ai->ai_next) {
-		// Pick IPv4 addresses only.
-		if (ai->ai_family != AF_INET)
-			continue;
-		/*
-		 * Generate an entry for it.
-		 */
-		struct sockaddr_in *sin =
-		    (struct sockaddr_in *)ai->ai_addr;
-		struct block *tmp = gen_host(cstate,
-		    ntohl(sin->sin_addr.s_addr),
-		    0xffffffff, proto, Q_OR, Q_HOST);
-		/*
-		 * Is it the *first* IPv4 address?
-		 */
-		if (b1 == NULL) {
-			/*
-			 * Yes, so start with it.
-			 */
-			b1 = tmp;
-		} else {
-			/*
-			 * No, so OR it into the
-			 * existing set of
-			 * addresses.
-			 */
-			gen_or(b1, tmp);
-			b1 = tmp;
-		}
-	}
-	freeaddrinfo(cstate->ai);
-	cstate->ai = NULL;
-
-	if (b1 == NULL) {
-		/*
-		 * No IPv4 addresses found.
-		 */
-		bpf_error(cstate, ERRSTR_UNKNOWN_HOST, name);
-	}
+	struct block *b1 = gen_host46_byname(cstate, name, proto, proto, Q_OR);
 	gen_not(b1);
 	gen_and(b0, b1);
 	return b1;
@@ -6707,14 +6715,8 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 {
 	int proto = q.proto;
 	int dir = q.dir;
-	int tproto;
 	bpf_u_int32 mask, addr;
-	struct addrinfo *res, *res0;
-	struct sockaddr_in *sin4;
-	int tproto6;
-	struct sockaddr_in6 *sin6;
-	struct in6_addr mask128;
-	struct block *b, *tmp;
+	struct block *b;
 	int port, real_proto;
 	bpf_u_int32 port1, port2;
 
@@ -6751,55 +6753,21 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 			 */
 			bpf_error(cstate, "invalid DECnet address '%s'", name);
 		} else {
-			memset(&mask128, 0xff, sizeof(mask128));
-			res0 = res = pcap_nametoaddrinfo(name);
-			if (res == NULL)
-				bpf_error(cstate, "unknown host '%s'", name);
-			cstate->ai = res;
-			b = tmp = NULL;
-			tproto = proto;
-			tproto6 = proto;
+			u_char tproto = q.proto;
+			u_char tproto6 = q.proto;
 			if (cstate->off_linktype.constant_part == OFFSET_NOT_SET &&
 			    tproto == Q_DEFAULT) {
+				/*
+				 * For certain DLTs have "host NAME" mean
+				 * "ip host NAME or ip6 host NAME", but not
+				 * "arp host NAME or rarp host NAME" (here may
+				 * be not the best place for this though).
+				 */
 				tproto = Q_IP;
 				tproto6 = Q_IPV6;
 			}
-			for (res = res0; res; res = res->ai_next) {
-				switch (res->ai_family) {
-				case AF_INET:
-					if (tproto == Q_IPV6)
-						continue;
-
-					sin4 = (struct sockaddr_in *)
-						res->ai_addr;
-					tmp = gen_host(cstate, ntohl(sin4->sin_addr.s_addr),
-						0xffffffff, tproto, dir, q.addr);
-					break;
-				case AF_INET6:
-					if (tproto6 == Q_IP)
-						continue;
-
-					sin6 = (struct sockaddr_in6 *)
-						res->ai_addr;
-					tmp = gen_host6(cstate, &sin6->sin6_addr,
-						&mask128, tproto6, dir, q.addr);
-					break;
-				default:
-					continue;
-				}
-				if (b)
-					gen_or(b, tmp);
-				b = tmp;
-			}
-			cstate->ai = NULL;
-			freeaddrinfo(res0);
-			if (b == NULL) {
-				bpf_error(cstate, "unknown host '%s'%s", name,
-				    (proto == Q_DEFAULT)
-					? ""
-					: " for specified address family");
-			}
-			return b;
+			return gen_host46_byname(cstate, name, tproto,
+			    tproto6, q.dir);
 		}
 
 	case Q_PORT:

--- a/gencode.c
+++ b/gencode.c
@@ -680,8 +680,7 @@ static struct block *gen_host(compiler_state_t *, bpf_u_int32, bpf_u_int32,
     int, int, int);
 static struct block *gen_host6(compiler_state_t *, struct in6_addr *,
     struct in6_addr *, int, int, int);
-static struct block *gen_gateway(compiler_state_t *, const char *,
-    struct addrinfo *, int);
+static struct block *gen_gateway(compiler_state_t *, const char *, const int);
 static struct block *gen_ip_proto(compiler_state_t *, const uint8_t);
 static struct block *gen_ip6_proto(compiler_state_t *, const uint8_t);
 static struct block *gen_ipfrag(compiler_state_t *);
@@ -1054,6 +1053,7 @@ assert_maxval(compiler_state_t *cstate, const char *name,
 #define ERRSTR_802_11_ONLY_KW "'%s' is valid for 802.11 syntax only"
 #define ERRSTR_INVALID_QUAL "'%s' is not a valid qualifier for '%s'"
 #define ERRSTR_UNKNOWN_MAC48HOST "unknown Ethernet-like host '%s'"
+#define ERRSTR_UNKNOWN_HOST "unknown host '%s'"
 
 // Validate a port/portrange proto qualifier and map to an IP protocol number.
 static int
@@ -5312,68 +5312,66 @@ gen_mac48host_byname(compiler_state_t *cstate, const char *name,
  * to qualify it with a direction.
  */
 static struct block *
-gen_gateway(compiler_state_t *cstate, const char *name,
-    struct addrinfo *alist, int proto)
+gen_gateway(compiler_state_t *cstate, const char *name, const int proto)
 {
-	struct block *b0, *b1, *tmp;
-	struct addrinfo *ai;
-	struct sockaddr_in *sin;
-
 	switch (proto) {
 	case Q_DEFAULT:
 	case Q_IP:
 	case Q_ARP:
 	case Q_RARP:
-		b0 = gen_mac48host_byname(cstate, name, Q_OR, "gateway");
-		b1 = NULL;
-		for (ai = alist; ai != NULL; ai = ai->ai_next) {
-			/*
-			 * Does it have an address?
-			 */
-			if (ai->ai_addr != NULL) {
-				/*
-				 * Yes.  Is it an IPv4 address?
-				 */
-				if (ai->ai_addr->sa_family == AF_INET) {
-					/*
-					 * Generate an entry for it.
-					 */
-					sin = (struct sockaddr_in *)ai->ai_addr;
-					tmp = gen_host(cstate,
-					    ntohl(sin->sin_addr.s_addr),
-					    0xffffffff, proto, Q_OR, Q_HOST);
-					/*
-					 * Is it the *first* IPv4 address?
-					 */
-					if (b1 == NULL) {
-						/*
-						 * Yes, so start with it.
-						 */
-						b1 = tmp;
-					} else {
-						/*
-						 * No, so OR it into the
-						 * existing set of
-						 * addresses.
-						 */
-						gen_or(b1, tmp);
-						b1 = tmp;
-					}
-				}
-			}
-		}
+		break;
+	default:
+		bpf_error(cstate, ERRSTR_INVALID_QUAL, pqkw(proto), "gateway");
+	}
+
+	struct block *b0 = gen_mac48host_byname(cstate, name, Q_OR, "gateway");
+
+	cstate->ai = pcap_nametoaddrinfo(name);
+	if (cstate->ai == NULL)
+		bpf_error(cstate, ERRSTR_UNKNOWN_HOST, name);
+	struct block *b1 = NULL;
+	for (struct addrinfo *ai = cstate->ai; ai != NULL; ai = ai->ai_next) {
+		// Pick IPv4 addresses only.
+		if (ai->ai_family != AF_INET)
+			continue;
+		/*
+		 * Generate an entry for it.
+		 */
+		struct sockaddr_in *sin =
+		    (struct sockaddr_in *)ai->ai_addr;
+		struct block *tmp = gen_host(cstate,
+		    ntohl(sin->sin_addr.s_addr),
+		    0xffffffff, proto, Q_OR, Q_HOST);
+		/*
+		 * Is it the *first* IPv4 address?
+		 */
 		if (b1 == NULL) {
 			/*
-			 * No IPv4 addresses found.
+			 * Yes, so start with it.
 			 */
-			return (NULL);
+			b1 = tmp;
+		} else {
+			/*
+			 * No, so OR it into the
+			 * existing set of
+			 * addresses.
+			 */
+			gen_or(b1, tmp);
+			b1 = tmp;
 		}
-		gen_not(b1);
-		gen_and(b0, b1);
-		return b1;
 	}
-	bpf_error(cstate, ERRSTR_INVALID_QUAL, pqkw(proto), "gateway");
-	/*NOTREACHED*/
+	freeaddrinfo(cstate->ai);
+	cstate->ai = NULL;
+
+	if (b1 == NULL) {
+		/*
+		 * No IPv4 addresses found.
+		 */
+		bpf_error(cstate, ERRSTR_UNKNOWN_HOST, name);
+	}
+	gen_not(b1);
+	gen_and(b0, b1);
+	return b1;
 }
 
 static struct block *
@@ -6889,16 +6887,7 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 		return b;
 
 	case Q_GATEWAY:
-		res = pcap_nametoaddrinfo(name);
-		cstate->ai = res;
-		if (res == NULL)
-			bpf_error(cstate, "unknown host '%s'", name);
-		b = gen_gateway(cstate, name, res, proto);
-		cstate->ai = NULL;
-		freeaddrinfo(res);
-		if (b == NULL)
-			bpf_error(cstate, "unknown host '%s'", name);
-		return b;
+		return gen_gateway(cstate, name, proto);
 
 	case Q_PROTO:
 		real_proto = lookup_proto(cstate, name, proto);

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -8776,6 +8776,8 @@ my @accept_blocks = (
 			'ip src or dst noeth-ipv4-ipv6.host123.libpcap.test',
 			'ip src or dst host noeth-ipv4-noipv6.host123.libpcap.test',
 			'ip src or dst host noeth-ipv4-ipv6.host123.libpcap.test',
+			# This does not mean "arp host" or "rarp host" because for
+			# DLT_RAW off_linktype.constant_part == OFFSET_NOT_SET.
 			'host noeth-ipv4-noipv6.host123.libpcap.test',
 			'src or dst noeth-ipv4-noipv6.host123.libpcap.test',
 			'src or dst host noeth-ipv4-noipv6.host123.libpcap.test',


### PR DESCRIPTION
This is the more difficult part of a prototype I started, but could not quickly complete earlier. The intent is simple: since `gateway X` nominally includes `not host X`, and since both `gen_gateway()` and `gen_scode()` call `pcap_addrinfo()` and process the result(s) in a very similar manner, having a slightly different code block in each function makes the code harder to maintain. However, the complexity turned out to be in the detail (including #1512), so this work-in-progress revision fails many tests. Also before this can be progressed any further, the reject filter tests must cover all code paths that go through `pcap_addrinfo()` and fail to resolve the hostname.