### PR TITLE
WIP/RFC possible use of va_list in gencode.c

### DIFF
--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -2444,7 +2444,7 @@ my @accept_blocks = (
 		name => 'atm_connectmsg',
 		DLT => 'SUNATM',
 		aliases => ['connectmsg'],
-		opt => '
+		unopt => '
 			(000) ldb      [1]
 			(001) jeq      #0x0             jt 2	jf 12
 			(002) ldh      [2]
@@ -2464,7 +2464,7 @@ my @accept_blocks = (
 		name => 'atm_metaconnect',
 		DLT => 'SUNATM',
 		aliases => ['metaconnect'],
-		opt => '
+		unopt => '
 			(000) ldb      [1]
 			(001) jeq      #0x0             jt 2	jf 11
 			(002) ldh      [2]
@@ -3920,7 +3920,7 @@ my @accept_blocks = (
 		name => 'link_proto_ip_PPP_BSDOS',
 		DLT => 'PPP_BSDOS',
 		aliases => ['link proto \ip'],
-		opt => '
+		unopt => '
 			(000) ldh      [5]
 			(001) jeq      #0x21            jt 4	jf 2
 			(002) jeq      #0x2d            jt 4	jf 3
@@ -5567,6 +5567,16 @@ my @accept_blocks = (
 			(003) jeq      #0x9100          jt 4	jf 5
 			(004) ret      #262144
 			(005) ret      #0
+			',
+		unopt => '
+			(000) ldh      [12]
+			(001) jeq      #0x8100          jt 6	jf 2
+			(002) ldh      [12]
+			(003) jeq      #0x88a8          jt 6	jf 4
+			(004) ldh      [12]
+			(005) jeq      #0x9100          jt 6	jf 7
+			(006) ret      #262144
+			(007) ret      #0
 			',
 	}, # vlan_eth_nullary
 	{


### PR DESCRIPTION
This is another unfinished piece that didn't quite work out the way I originally expected, but took some time to produce anyway. Potentially this could be developed further, please have a look when you have time.

This is one of the optimizations that avoid generating duplicate instructions in the first place. On this occasion it is the code produced by a series of ORed `gen_cmp()` calls, all of which load the same exact packet data, in which case, obviously, only the first load is required. The draft demonstrates how this can be done for PPP, ATM and ARCnet (the tests pass), all of which hard-code the values.