### PR TITLE
Add DLT and linktype for OASIS.

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1300,7 +1300,16 @@
  */
 #define LINKTYPE_DECT_NR	301
 
-#define LINKTYPE_HIGH_MATCHING_MAX	301		/* highest value in the "matching" range */
+/*
+ * OASIS Send / Receive Protocol
+ *
+ * https://cpm80.com/oasis-send-recv-protocol.html
+ *
+ * Requested by Howard M. Harte <hharte@magicandroidapps.com>.
+ */
+#define LINKTYPE_OASIS		302
+
+#define LINKTYPE_HIGH_MATCHING_MAX	302		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3324,6 +3324,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(FIRA_UCI, "Ultra-wideband controller interface protocol"),
 	DLT_CHOICE(MDB, "Multi-Drop Bus"),
 	DLT_CHOICE(DECT_NR, "DECT New Radio"),
+	DLT_CHOICE(OASIS, "OASIS Send/Receive"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1665,6 +1665,15 @@
 #define DLT_DECT_NR		301
 
 /*
+ * OASIS Send / Receive Protocol
+ *
+ * https://cpm80.com/oasis-send-recv-protocol.html
+ *
+ * Requested by Howard M. Harte <hharte@magicandroidapps.com>.
+ */
+#define DLT_OASIS		302
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_HIGH_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1675,6 +1684,6 @@
 #undef DLT_HIGH_MATCHING_MAX
 #endif
 
-#define DLT_HIGH_MATCHING_MAX	301	/* highest value in the "matching" range */
+#define DLT_HIGH_MATCHING_MAX	302	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
Add a link-layer header type for the OASIS Send/Receive protocol:

Protocol documentation:
https://cpm80.com/oasis-send-recv-protocol.html

Original Protocol reference document:
http://www.bitsavers.org/pdf/phaseOneSystems/oasis/Communications_Reference_Manual_2ed.pdf

Corresponding PR for the web page: https://github.com/the-tcpdump-group/tcpdump-htdocs/pull/44

Link to GitHub project with more details:
https://github.com/hharte/oasis-utils/blob/main/wireshark/OASIS-send-recv-protocol.md

Thank you for your consideration.
-Howard
