### PR TITLE
Fix IPv4 multicast upper bound

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -62,6 +62,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Require "(ip|ip6) proto" value to be within range.
       Require "protochain" value to be within range.
       Always enable the "gateway" primitive.
+      Fix IPv4 multicast filtering to only include 224.0.0.0/4.
     rpcap:
       Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from

--- a/gencode.c
+++ b/gencode.c
@@ -8095,7 +8095,12 @@ gen_multicast(compiler_state_t *cstate, int proto)
 
 	case Q_IP:
 		b0 = gen_linktype(cstate, ETHERTYPE_IP);
-		b1 = gen_cmp_ge(cstate, OR_LINKPL, 16, BPF_B, 224);
+
+		/*
+		 * Compare address with 224.0.0.0/4
+		 */
+		b1 = gen_mcmp(cstate, OR_LINKPL, 16, BPF_B, 0xe0, 0xf0);
+
 		gen_and(b0, b1);
 		return b1;
 

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -8435,9 +8435,19 @@ my @accept_blocks = (
 		opt => '
 			(000) ld       #0x0
 			(001) ldb      [16]
-			(002) jge      #0xe0            jt 3	jf 4
-			(003) ret      #1000
-			(004) ret      #0
+			(002) and      #0xf0
+			(003) jeq      #0xe0            jt 4	jf 5
+			(004) ret      #1000
+			(005) ret      #0
+			',
+		unopt => '
+			(000) ld       #0x0
+			(001) jeq      #0x0             jt 2	jf 6
+			(002) ldb      [16]
+			(003) and      #0xf0
+			(004) jeq      #0xe0            jt 5	jf 6
+			(005) ret      #1000
+			(006) ret      #0
 			',
 	}, # ip_multicast
 	{


### PR DESCRIPTION
IPv4 multicast addresses are defined to be in 224.0.0.0/4.

While the generated code for multicast checked the lower bound, it
failed to verify the upper bound, mistakenly including the reserved
range (240.0.0.0/4) and broadcast (255.255.255.255).

Fix this by explicitly comparing the first four bits of the address to
the multicast ones.