### PR TITLE
socketcan: add CAN XL Remote Request Substitution CANXL_RRS bit

### DIFF
--- a/pcap/can_socketcan.h
+++ b/pcap/can_socketcan.h
@@ -72,7 +72,8 @@ typedef struct {
 } pcap_can_socketcan_xl_hdr;
 
 /* Bits in the flags field */
-#define CANXL_SEC   0x01 /* Simple Extended Context */
-#define CANXL_XLF   0x80 /* mark to distinguish CAN XL from CAN/CAN FD frames */
+#define CANXL_SEC 0x01 /* Simple Extended Content (security/segmentation) */
+#define CANXL_RRS 0x02 /* Remote Request Substitution */
+#define CANXL_XLF 0x80 /* mark to distinguish CAN XL from CAN/CAN FD frames */
 
 #endif


### PR DESCRIPTION
The Remote Request Substitution bit is a dominant bit ("0") in the CAN XL frame. As some CAN XL controllers support to access this bit a new CANXL_RRS value has been defined for the canxl_frame.flags element.

Defined in Linux mainline since Linux 6.15

Additionally fixed a typo 'Context' -> 'Content'