### PR TITLE
linux: don't trash the "no permission" or "no packet sockets" error.

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -2464,9 +2464,9 @@ setup_socket(pcap_t *handle, int is_any_device)
 			 * Other error.
 			 */
 			status = PCAP_ERROR;
+			pcapint_fmt_errmsg_for_errno(handle->errbuf,
+			    PCAP_ERRBUF_SIZE, errno, "socket");
 		}
-		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
-		    errno, "socket");
 		return status;
 	}
 


### PR DESCRIPTION
If we've already put an error message in handle->errbuf for the "you don't have permission to open a packet socket" or "this kernel (or simulacrum of one, such as WSL1) doesn't support packet sockets" errors, don't trash it with a generic "we got some error trying to create the packet socket, here's the error message for that error code" message.