### PR TITLE
Fix resource leak on malloc failure in pcap-linux.c

### DIFF
--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -2654,6 +2654,7 @@ setup_socket(pcap_t *handle, int is_any_device)
 		if (handle->dlt_list == NULL) {
 			pcapint_fmt_errmsg_for_errno(handle->errbuf,
 			    PCAP_ERRBUF_SIZE, errno, "malloc");
+			close(sock_fd);
 			return (PCAP_ERROR);
 		}
 		handle->dlt_list[0] = DLT_LINUX_SLL;


### PR DESCRIPTION
### What this fixes

Hi,  
This PR fixes a resource leak in `pcap-linux.c`.  
If `malloc()` fails after opening a socket, the file descriptor is not closed, which can cause a resource leak.

### Fix

Added `close(sock_fd);` before returning on allocation failure.

Thank you for the review!
