### PR TITLE
dlpi: some restructuring.

### DIFF
--- a/dlpisubs.h
+++ b/dlpisubs.h
@@ -30,6 +30,7 @@ int pcap_conf_bufmod(pcap_t *, int);
 #endif
 int pcap_alloc_databuf(pcap_t *);
 int strioctl(int, int, int, char *);
+int handle_nonexistent_dlpi_device(const char *ifname, char *errbuf);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Have a common routine to handle the "that interface doesn't have a DLPI device" error; it takes care of "device name too long to be an interface", "we have no DLPI devices because we're in a shared-IP non-global zone", and "we have no DLPI device for that interface because it's probably not a DLPI interface" (as in "the loopback device on Solaris 10 and before").

On HP-UX, where there's just one /dev/dlpi device, if we don't have permission to open that device, check whether the interface exists and, if not, report "no such interface" - see
https://github.com/the-tcpdump-group/libpcap/issues/1538.

On Solaris with libdlpi, distinguish between "that link name is invalid", in which case we know for certain that the interface doesn't exist, and "no such link", in which case we use the common routine mentioned above to find out why.

Remove "libpcap:" from messages reporting errors from libdlpi; none of our other messages announce that they come from libpcap.

Expand and clarify comments while we're at it.