### PR TITLE
Autoconf: Set the MKDEP default value

### DIFF
--- a/aclocal.m4
+++ b/aclocal.m4
@@ -589,6 +589,11 @@ dnl	os-proto.h (symlinked)
 dnl
 AC_DEFUN(AC_LBL_DEVEL,
     [rm -f os-proto.h
+    #
+    # MKDEP defaults to no-op (":") if we don't test whether the compiler
+    # supports generating dependencies
+    #
+    MKDEP=:
     if test "${LBL_CFLAGS+set}" = set; then
 	    $1="$$1 ${LBL_CFLAGS}"
     fi


### PR DESCRIPTION
MKDEP defaults to no-op (":") if we don't test whether the compiler supports generating dependencies.

This avoids:

$ make depend
[...]
/bin/sh: 1: c: not found