### PR TITLE
Fix a copy-and-pasteo in utf_16le_to_utf_8_truncated().

### DIFF
--- a/fmtutils.c
+++ b/fmtutils.c
@@ -233,7 +233,7 @@ utf_16le_to_utf_8_truncated(const wchar_t *utf_16, char *utf_8,
 			*utf_8++ = ((uc >> 12) & 0x3F) | 0x80;
 			*utf_8++ = ((uc >> 6) & 0x3F) | 0x80;
 			*utf_8++ = ((uc >> 0) & 0x3F) | 0x80;
-			utf_8_len -= 3;
+			utf_8_len -= 4;
 		}
 	}
 


### PR DESCRIPTION
For the four octets of UTF-8 case, it was decrementing the remaining buffer length by 3, not 4.

Thanks to a team of developers from the Univesity of Waterloo for reporting this.