### PR TITLE
Remove definition of ETHERTYPE_PUP

### DIFF
--- a/ethertype.h
+++ b/ethertype.h
@@ -31,9 +31,6 @@
  * <netinet/if_ether.h> if all it needs are ETHERTYPE_ values.
  */
 
-#ifndef ETHERTYPE_PUP
-#define ETHERTYPE_PUP		0x0200	/* PUP protocol */
-#endif
 #ifndef ETHERTYPE_IP
 #define ETHERTYPE_IP		0x0800	/* IP protocol */
 #endif


### PR DESCRIPTION
1. Unused.
2. IANA states: Formerly XEROX PUP. Invalid as an Ethertype since 1983.
(https://www.iana.org/assignments/ieee-802-numbers/ieee-802-numbers.xhtml)

[skip ci]