### PR TITLE
Add the size of time_t to the version string.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -153,6 +153,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       gencode: Fix an undefined behavior in gen_mcode().
       gencode: Add a missing free() in gen_scode().
       Remove "DLT_" from the descriptions of two dlt_choices[] entries.
+      Report the size of time_t in the version string.
     Source code:
       Remove some unneeded includes.
       pcapint_find_function() changed to return "void *" to avoid

--- a/Makefile.in
+++ b/Makefile.in
@@ -368,6 +368,7 @@ EXTRA_DIST = \
 	testprogs/threadsignaltest.c \
 	testprogs/unix.h \
 	testprogs/valgrindtest.c \
+	testprogs/versiontest.c \
 	testprogs/visopts.py \
 	testprogs/writecaptest.c
 

--- a/build.sh
+++ b/build.sh
@@ -147,12 +147,14 @@ run_after_echo "$PREFIX/bin/pcap-config" --additional-libs --static-pcap-only
 # VALGRIND_CMD is meant either to collapse or to expand.
 # shellcheck disable=SC2086
 if [ "$CMAKE" = no ]; then
+    run_after_echo $VALGRIND_CMD testprogs/versiontest
     FILTERTEST_BIN="$VALGRIND_CMD testprogs/filtertest"
     export FILTERTEST_BIN
     run_after_echo "$MAKE_BIN" -s check
     run_after_echo $VALGRIND_CMD testprogs/findalldevstest
     [ "$TEST_RELEASETAR" = yes ] && run_after_echo "$MAKE_BIN" releasetar
 else
+    run_after_echo $VALGRIND_CMD run/versiontest
     FILTERTEST_BIN="$VALGRIND_CMD run/filtertest"
     export FILTERTEST_BIN
     run_after_echo "$MAKE_BIN" -s check

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -3676,18 +3676,20 @@ pcap_set_datalink_bpf(pcap_t *p _U_, int dlt _U_)
 /*
  * Platform-specific information.
  */
+#if defined(HAVE_ZEROCOPY_BPF) && defined(PCAP_SUPPORT_NETMAP)
+  #define ADDITIONAL_INFO_STRING	"with zerocopy and netmap support"
+#elif defined(HAVE_ZEROCOPY_BPF)
+  #define ADDITIONAL_INFO_STRING	"with zerocopy support"
+#elif defined(PCAP_SUPPORT_NETMAP)
+  #define ADDITIONAL_INFO_STRING	"with netmap support"
+#endif
+
 const char *
 pcap_lib_version(void)
 {
-	return (PCAP_VERSION_STRING
-#if defined(HAVE_ZEROCOPY_BPF) && defined(PCAP_SUPPORT_NETMAP)
-		" (with zerocopy and netmap support)"
-#elif defined(HAVE_ZEROCOPY_BPF)
-		" (with zerocopy support)"
-#elif defined(PCAP_SUPPORT_NETMAP)
-		" (with netmap support)"
+#ifdef ADDITIONAL_INFO_STRING
+	return (PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO(ADDITIONAL_INFO_STRING));
 #else
-		""
+	return (PCAP_VERSION_STRING);
 #endif
-	);
 }

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -1754,6 +1754,6 @@ pcapint_create_interface(const char *device _U_, char *errbuf)
 const char *
 pcap_lib_version(void)
 {
-	return (PCAP_VERSION_STRING " (DAG-only)");
+	return (PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO("DAG-only"));
 }
 #endif

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -1115,6 +1115,6 @@ pcapint_create_interface(const char *device, char *errbuf)
 const char *
 pcap_lib_version(void)
 {
-	return (PCAP_VERSION_STRING " (DPDK-only)");
+	return (PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO("DPDK-only"));
 }
 #endif

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -68,10 +68,28 @@
 #endif
 
 /*
- * Version string.
- * Uses PACKAGE_VERSION from config.h.
+ * Version string trailer.
+ * Uses SIZEOF_TIME_T from config.h.
+ * (There's no need to announce the pointer size; if it doesn't
+ * match the pointer size in code linked with libpcap, either
+ * build-time linking or run-time linking will fail.)
  */
-#define PCAP_VERSION_STRING "libpcap version " PACKAGE_VERSION
+#if SIZEOF_TIME_T == 8
+  #define PCAP_SIZEOF_TIME_T_BITS_STRING "64"
+#elif SIZEOF_TIME_T == 4
+  #define PCAP_SIZEOF_TIME_T_BITS_STRING "32"
+#else
+  #error Unknown time_t size
+#endif
+
+/*
+ * Version string.
+ * Uses PACKAGE_VERSION from config.h and PCAP_SIZEOF_TIME_T_BITS_STRING.
+ */
+#define PCAP_VERSION_STRING \
+	"libpcap version " PACKAGE_VERSION " (" PCAP_SIZEOF_TIME_T_BITS_STRING "-bit time_t)"
+#define PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO(additional_info) \
+	"libpcap version " PACKAGE_VERSION " (" PCAP_SIZEOF_TIME_T_BITS_STRING "-bit time_t, " additional_info ")"
 
 #ifdef __cplusplus
 extern "C" {

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -6209,18 +6209,18 @@ pcap_set_protocol_linux(pcap_t *p, int protocol)
 /*
  * Libpcap version string.
  */
+#if defined(HAVE_TPACKET3) && defined(PCAP_SUPPORT_NETMAP)
+  #define ADDITIONAL_INFO_STRING	"with TPACKET_V3 and netmap"
+#elif defined(HAVE_TPACKET3)
+  #define ADDITIONAL_INFO_STRING	"with TPACKET_V3"
+#elif defined(PCAP_SUPPORT_NETMAP)
+  #define ADDITIONAL_INFO_STRING	"with TPACKET_V2 and netmap"
+#else
+  #define ADDITIONAL_INFO_STRING	"with TPACKET_V2"
+#endif
+
 const char *
 pcap_lib_version(void)
 {
-	return (PCAP_VERSION_STRING
-#if defined(HAVE_TPACKET3) && defined(PCAP_SUPPORT_NETMAP)
-		" (with TPACKET_V3 and netmap)"
-#elif defined(HAVE_TPACKET3)
-		" (with TPACKET_V3)"
-#elif defined(PCAP_SUPPORT_NETMAP)
-		" (with TPACKET_V2 and netmap)"
-#else
-		" (with TPACKET_V2)"
-#endif
-	);
+	return (PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO(ADDITIONAL_INFO_STRING));
 }

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -2516,7 +2516,7 @@ pcap_lib_version(void)
 		char *full_pcap_version_string;
 
 		if (pcapint_asprintf(&full_pcap_version_string,
-		    PCAP_VERSION_STRING " (packet.dll version %s)",
+		    PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO("packet.dll version %s"),
 		    PacketGetVersion()) != -1) {
 			/* Success */
 			pcap_lib_version_string = full_pcap_version_string;

--- a/pcap-snf.c
+++ b/pcap-snf.c
@@ -678,6 +678,6 @@ pcapint_create_interface(const char *device _U_, char *errbuf)
 const char *
 pcap_lib_version(void)
 {
-	return (PCAP_VERSION_STRING " (SNF-only)");
+	return (PCAP_VERSION_STRING_WITH_ADDITIONAL_INFO("SNF-only"));
 }
 #endif

--- a/testprogs/CMakeLists.txt
+++ b/testprogs/CMakeLists.txt
@@ -34,6 +34,7 @@ add_test_executable(findalldevstest)
 add_test_executable(findalldevstest-perf)
 add_test_executable(opentest)
 add_test_executable(reactivatetest)
+add_test_executable(versiontest)
 add_test_executable(writecaptest)
 
 if(NOT WIN32)

--- a/testprogs/Makefile.in
+++ b/testprogs/Makefile.in
@@ -86,6 +86,7 @@ SRC = @VALGRINDTEST_SRC@ \
 	reactivatetest.c \
 	selpolltest.c \
 	threadsignaltest.c \
+	versiontest.c \
 	writecaptest.c
 
 TESTS = $(SRC:.c=)
@@ -150,6 +151,10 @@ threadsignaltest: $(srcdir)/threadsignaltest.c ../libpcap.a
 
 valgrindtest: $(srcdir)/valgrindtest.c ../libpcap.a
 	$(CC) $(FULL_CFLAGS) -I. -L. -o $@ $(srcdir)/valgrindtest.c \
+	    ../libpcap.a $(LIBS)
+
+versiontest: $(srcdir)/versiontest.c ../libpcap.a
+	$(CC) $(FULL_CFLAGS) -I. -L. -o $@ $(srcdir)/versiontest.c \
 	    ../libpcap.a $(LIBS)
 
 writecaptest: $(srcdir)/writecaptest.c ../libpcap.a

--- a/testprogs/versiontest.c
+++ b/testprogs/versiontest.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 1988, 1989, 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 2000
+ *	The Regents of the University of California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that: (1) source code distributions
+ * retain the above copyright notice and this paragraph in its entirety, (2)
+ * distributions including binary code include the above copyright notice and
+ * this paragraph in its entirety in the documentation or other materials
+ * provided with the distribution, and (3) all advertising materials mentioning
+ * features or use of this software display the following acknowledgement:
+ * ``This product includes software developed by the University of California,
+ * Lawrence Berkeley Laboratory and its contributors.'' Neither the name of
+ * the University nor the names of its contributors may be used to endorse
+ * or promote products derived from this software without specific prior
+ * written permission.
+ * THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR IMPLIED
+ * WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+ */
+
+#include <pcap.h>
+#include <stdio.h>
+
+int
+main(void)
+{
+	printf("%s\n", pcap_lib_version());
+}


### PR DESCRIPTION
This makes it easier to detect time_t size mismatches between libpcap and code that uses libpcap, at least with code that reports the version.