### PR TITLE
pcap-filter(7): IPv4-mapped IPv6 is valid syntax.

### DIFF
--- a/pcap-filter.manmisc.in
+++ b/pcap-filter.manmisc.in
@@ -18,7 +18,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP-FILTER @MAN_MISC_INFO@ "9 October 2025"
+.TH PCAP-FILTER @MAN_MISC_INFO@ "18 October 2025"
 .SH NAME
 pcap-filter \- packet filter syntax
 .br
@@ -226,8 +226,14 @@ for Ethernet-like link-layer types is equivalent to
 .in -.5i
 .IP
 .I hostnameaddr
-may be either an address or a name.  If it is a name, the name must resolve
-to at least one IPv4 address for
+may be either an address or a name.  If it is an IPv6 address, it may use both
+the zero compression
+.RB ( :: )
+and the IPv4-mapped
+.RB ( x:x:x:x:x:x:d.d.d.d )
+notations as discussed in
+.BR inet_pton (3).
+If it is a name, the name must resolve to at least one IPv4 address for
 .BR "arp host" ,
 .B "ip host"
 and
@@ -326,7 +332,10 @@ dotted triple (e.g., 192.168.1), dotted pair (e.g, 172.16), or single
 number (e.g., 10); the netmask is 255.255.255.255 (/32) for a dotted quad
 (which means that it's really a host match), 255.255.255.0 (/24) for a dotted
 triple, 255.255.0.0 (/16) for a dotted pair, or 255.0.0.0 (/8) for a single number.
-An IPv6 network number must be written out fully; the netmask is
+.IP
+An IPv6 network number is an IPv6 address as discussed for the
+.B host
+primitive above; the implicit netmask is
 ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff (/128), so in this primitive IPv6
 "network" matches are really always host matches.  For an actual IPv6 network
 match see the `\fBnet \fInetaddr\fR/\fIlen\fR' primitive below.
@@ -398,11 +407,9 @@ is the same as the above.  For IPv6,
 .I len
 is an integer between 0 and 128 (both inclusive) and
 .I netaddr
-is an IPv6 address.  For the latter zero compression notation
-.RB ( :: )
-is valid, but IPv4-mapped notation
-.RB ( x:x:x:x:x:x:d.d.d.d )
-is not.  For both IPv4 and IPv6 the maximum value of
+is an IPv6 address as discussed for the
+.B host
+primitive above.  For both IPv4 and IPv6 the maximum value of
 .I len
 is equivalent to a host match and the 0 value (which implies an all-zeroes
 value of

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -11276,6 +11276,27 @@ my @accept_blocks = (
 			'host ::1/128',
 			'src or dst host ::1/128',
 			'src or dst ::1/128',
+			# IPv4-mapped notation of everything above
+			'ip6 host ::0.0.0.1',
+			'ip6 src or dst host ::0.0.0.1',
+			'ip6 src or dst ::0.0.0.1',
+			'host ::0.0.0.1',
+			'src or dst host ::0.0.0.1',
+			'src or dst ::0.0.0.1',
+			'ip6 net ::0.0.0.1/128',
+			'ip6 src or dst net ::0.0.0.1/128',
+			'net ::0.0.0.1/128',
+			'src or dst net ::0.0.0.1/128',
+			'ip6 net ::0.0.0.1',
+			'ip6 src or dst net ::0.0.0.1',
+			'net ::0.0.0.1',
+			'src or dst net ::0.0.0.1',
+			'ip6 host ::0.0.0.1/128',
+			'ip6 src or dst host ::0.0.0.1/128',
+			'ip6 src or dst ::0.0.0.1/128',
+			'host ::0.0.0.1/128',
+			'src or dst host ::0.0.0.1/128',
+			'src or dst ::0.0.0.1/128',
 		],
 		opt => '
 			(000) ldb      [0]
@@ -11392,6 +11413,15 @@ my @accept_blocks = (
 			'ip6 src fe80::1122:33ff:fe44:5566/128',
 			'src host fe80::1122:33ff:fe44:5566/128',
 			'src fe80::1122:33ff:fe44:5566/128',
+			# IPv4-mapped notation of everything above
+			'ip6 src host fe80::1122:33ff:254.68.85.102',
+			'ip6 src fe80::1122:33ff:254.68.85.102',
+			'src host fe80::1122:33ff:254.68.85.102',
+			'src fe80::1122:33ff:254.68.85.102',
+			'ip6 src host fe80::1122:33ff:254.68.85.102/128',
+			'ip6 src fe80::1122:33ff:254.68.85.102/128',
+			'src host fe80::1122:33ff:254.68.85.102/128',
+			'src fe80::1122:33ff:254.68.85.102/128',
 		],
 		opt => '
 			(000) ldb      [0]
@@ -11478,6 +11508,15 @@ my @accept_blocks = (
 			'ip6 dst fe80::7788:99ff:feaa:bbcc/128',
 			'dst host fe80::7788:99ff:feaa:bbcc/128',
 			'dst fe80::7788:99ff:feaa:bbcc/128',
+			# IPv4-mapped notation of everything above
+			'ip6 dst host fe80::7788:99ff:254.170.187.204',
+			'ip6 dst fe80::7788:99ff:254.170.187.204',
+			'dst host fe80::7788:99ff:254.170.187.204',
+			'dst fe80::7788:99ff:254.170.187.204',
+			'ip6 dst host fe80::7788:99ff:254.170.187.204/128',
+			'ip6 dst fe80::7788:99ff:254.170.187.204/128',
+			'dst host fe80::7788:99ff:254.170.187.204/128',
+			'dst fe80::7788:99ff:254.170.187.204/128',
 		],
 		opt => '
 			(000) ldb      [0]
@@ -11559,6 +11598,11 @@ my @accept_blocks = (
 			'net fe80::/10',
 			'src or dst net fe80::/10',
 			'ip6 src or dst net fe80::/10',
+			# IPv4-mapped notation of everything above
+			'ip6 net fe80::0.0.0.0/10',
+			'net fe80::0.0.0.0/10',
+			'src or dst net fe80::0.0.0.0/10',
+			'ip6 src or dst net fe80::0.0.0.0/10',
 		],
 		opt => '
 			(000) ldb      [0]
@@ -11580,6 +11624,9 @@ my @accept_blocks = (
 		aliases => [
 			'ip6 src net 2000::/3',
 			'src net 2000::/3',
+			# IPv4-mapped notation of everything above
+			'ip6 src net 2000::0.0.0.0/3',
+			'src net 2000::0.0.0.0/3',
 		],
 		opt => '
 			(000) ldb      [0]
@@ -11595,7 +11642,11 @@ my @accept_blocks = (
 	{
 		name => 'ip6_dst_net_0',
 		DLT => 'RAW',
-		aliases => ['ip6 dst net ::/0'],
+		aliases => [
+			'ip6 dst net ::/0',
+			# IPv4-mapped notation of everything above
+			'ip6 dst net ::0.0.0.0/0',
+		],
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
@@ -11658,7 +11709,11 @@ my @accept_blocks = (
 	{
 		name => 'ip6_dst_net_120',
 		DLT => 'RAW',
-		aliases => ['ip6 dst net ff11:2233:4455:6677:8899:aabb:ccdd:ee00/120'],
+		aliases => [
+			'ip6 dst net ff11:2233:4455:6677:8899:aabb:ccdd:ee00/120',
+			# IPv4-mapped notation of everything above
+			'ip6 dst net ff11:2233:4455:6677:8899:aabb:204.221.238.0/120',
+		],
 		unopt => '
 			(000) ldb      [0]
 			(001) and      #0xf0
@@ -14212,6 +14267,11 @@ sub errstr_invhost_ipv4 {
 	return sprintf ('invalid IPv4 address \'%s\'', shift);
 }
 
+# scanner.l
+sub errstr_invhost_ipv6 {
+	return sprintf ('bogus IPv6 address %s', shift);
+}
+
 # ERRSTR_UNKNOWN_MAC48HOST
 sub errstr_nomac48host {
 	return sprintf ('unknown Ethernet-like host \'%s\'', shift);
@@ -14388,6 +14448,30 @@ my @reject_tests = (
 		DLT => 'RAW',
 		expr => 'ip6 host fe80:0:0:0:0:0:0:0:0',
 		errstr => errstr_syntax,
+	},
+	{
+		name => 'ip6_host_mapped_octet1',
+		DLT => 'RAW',
+		expr => 'ip6 host fe80::256.20.30.40',
+		errstr => errstr_invhost_ipv6 ('fe80::256.20.30.40'),
+	},
+	{
+		name => 'ip6_host_mapped_octet2',
+		DLT => 'RAW',
+		expr => 'ip6 host fe80::10.256.30.40',
+		errstr => errstr_invhost_ipv6 ('fe80::10.256.30.40'),
+	},
+	{
+		name => 'ip6_host_mapped_octet3',
+		DLT => 'RAW',
+		expr => 'ip6 host fe80::10.20.256.40',
+		errstr => errstr_invhost_ipv6 ('fe80::10.20.256.40'),
+	},
+	{
+		name => 'ip6_host_mapped_octet4',
+		DLT => 'RAW',
+		expr => 'ip6 host fe80::10.20.30.256',
+		errstr => errstr_invhost_ipv6 ('fe80::10.20.30.256'),
 	},
 
 # This test has been flaky because it depends on an external effect (DNS


### PR DESCRIPTION
Let's see whether `inet_pton()` is as portable for IPv6 as expected.