### PR TITLE
Linux netfilter: Fix a Y2K38_SAFETY Coverity warning

### DIFF
--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -31,7 +31,6 @@
 #include <config.h>
 
 #include "pcap-int.h"
-#include "diag-control.h"
 
 #include <errno.h>
 #include <stdlib.h>
@@ -351,10 +350,6 @@ netfilter_send_config_msg(const pcap_t *handle, uint16_t msg_type, int ack, u_in
 	struct sockaddr_nl snl;
 	static unsigned int seq_id;
 
-	if (!seq_id)
-DIAG_OFF_NARROWING
-		seq_id = time(NULL);
-DIAG_ON_NARROWING
 	++seq_id;
 
 	nlh->nlmsg_len = NLMSG_LENGTH(sizeof(struct nfgenmsg));


### PR DESCRIPTION
```
This concerns the 'Sequence number' in Netlink messages.

The Linux Documentation/userspace-api/netlink/intro.rst states:
:c:member:`nlmsghdr.nlmsg_seq` should be a set to a monotonically
increasing value. The value gets echoed back in responses and doesn't
matter in practice, but setting it to an increasing value for each
message sent is considered good hygiene. The purpose of the field is
matching responses to requests.

Thus seq_id, used to set it, has no need to be initialized to
time(NULL). It can start at 1.

The Coverity warning was:
CID 1508935: Use of 32-bit time_t (Y2K38_SAFETY)
A time_t value is stored in an integer with too few bits to accommodate
  it. The expression time(NULL) is cast to unsigned int.
  356                seq_id = time(NULL);

There was also an old clang warning on 64-bit build:
pcap-netfilter-linux.c:356:12: warning: implicit conversion loses
  integer precision: 'time_t' (aka 'long') to 'unsigned int'
  [-Wshorten-64-to-32]
  356 |                 seq_id = time(NULL);
      |                        ~ ^~~~~~~~~~

It was silenced by 16782c7e7811c2bc821c1f58ae948af7bccf81fe.
This commit is no longer useful.

The "To be look at before 2038..." in the previous commit message is no
longer relevant.
```