### PR TITLE
pcap: Use the same error message for all unsupported savefile versions

### DIFF
--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -279,13 +279,6 @@ pcap_check_header(const uint8_t *magic, FILE *fp, u_int precision, char *errbuf,
 		hdr.linktype = SWAPLONG(hdr.linktype);
 	}
 
-	if (hdr.version_major < PCAP_VERSION_MAJOR) {
-		snprintf(errbuf, PCAP_ERRBUF_SIZE,
-		    "archaic pcap savefile format");
-		*err = 1;
-		return (NULL);
-	}
-
 	/*
 	 * currently only versions 2.[0-4] are supported with
 	 * the exception of 543.0 for DG/UX tcpdump.

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -17767,7 +17767,7 @@ my @reject_tests = (
 	{
 		name => 'pcap_invalid_version_1',
 		savefile => 'pcap-invalid-version-1.pcap',
-		errstr => 'Failed opening: archaic pcap savefile format',
+		errstr => 'Failed opening: unsupported pcap savefile version 1.4',
 	},
 	{
 		name => 'pcap_invalid_version_2',


### PR DESCRIPTION
Before:
archaic pcap savefile format
Now:
unsupported pcap savefile version X.Y