### PR TITLE
AppVeyor: Add workaround for build with Visual Studio 2019 on ARM64

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -95,12 +95,14 @@ environment:
       PLATFORM: ARM64
       SDK: npcap-sdk
       REMOTE: -DENABLE_REMOTE=NO
+      WINDOWS_TARGET_PLATFORM_VERSION: -p:WindowsTargetPlatformVersion=10.0.22621.0
       # VS 2019, Npcap, 64-bit ARM, with remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: ARM64
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
+      WINDOWS_TARGET_PLATFORM_VERSION: -p:WindowsTargetPlatformVersion=10.0.22621.0
       # VS 2022, WinPcap, 32-bit and 64-bit x86, without remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
@@ -168,4 +170,4 @@ build_script:
   - cd build
   - cmake --version
   - cmake %REMOTE% %OPENSSL_ROOT_DIR% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -G"%GENERATOR%" -A %PLATFORM% ..
-  - msbuild /m /nologo /p:Configuration=Release pcap.sln
+  - msbuild /m /nologo /p:Configuration=Release pcap.sln %WINDOWS_TARGET_PLATFORM_VERSION%


### PR DESCRIPTION
Avoid the SDK 10.0.26100.0. Use an older SDK: 10.0.22621.0.

The problem first appeared on 2025-11-07, after the 2025-11-06
image update (Visual Studio 2019/2022).

The errors were:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\winnt.h
(6343,27): warning C4013: '_CountOneBits64' undefined; assuming extern
returning int

When it was OK:
cmake version 4.1.0
-- The C compiler identification is MSVC 19.29.30159.0

Current:
cmake version 4.1.0
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.17763.
-- The C compiler identification is MSVC 19.29.30159.0
