### PR TITLE
AppVeyor: Stop building for ARM 64-bit with MSVC 2019

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -89,18 +89,6 @@ environment:
       PLATFORM: x64
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
-      # VS 2019, Npcap, 64-bit ARM, without remote
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: "Visual Studio 16 2019"
-      PLATFORM: ARM64
-      SDK: npcap-sdk
-      REMOTE: -DENABLE_REMOTE=NO
-      # VS 2019, Npcap, 64-bit ARM, with remote
-    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
-      GENERATOR: "Visual Studio 16 2019"
-      PLATFORM: ARM64
-      SDK: npcap-sdk
-      OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
       # VS 2022, WinPcap, 32-bit and 64-bit x86, without remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
@@ -167,5 +155,5 @@ build_script:
   - md build
   - cd build
   - cmake --version
-  - cmake %REMOTE% %OPENSSL_ROOT_DIR% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -G"%GENERATOR%" -A %PLATFORM% ..
+  - cmake %REMOTE% %OPENSSL_ROOT_DIR% -DPacket_ROOT=c:\projects\libpcap\Win32\%SDK% -G"%GENERATOR%" -A %PLATFORM% ..
   - msbuild /m /nologo /p:Configuration=Release pcap.sln


### PR DESCRIPTION
We continue to build for ARM 64-bit with MSVC 2022.

The problem first appeared on 2025-11-07, after the 2025-11-06 image update (Visual Studio 2019/2022).

The errors were:
C:\Program Files (x86)\Windows Kits\10\Include\10.0.26100.0\um\winnt.h
  (6343,27): warning C4013: '_CountOneBits64' undefined; assuming extern
  returning int

When it was OK:
cmake version 4.1.0
-- The C compiler identification is MSVC 19.29.30159.0

With errors:
cmake version 4.1.0
-- Selecting Windows SDK version 10.0.26100.0 to target Windows 10.0.17763.
-- The C compiler identification is MSVC 19.29.30159.0

Moreover:
Remove duplicate options in cmake command.