### PR TITLE
Draft: fix Solaris 11 64-bit SPARC CMake build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,12 +122,12 @@ else
 fi
 run_after_echo "$MAKE_BIN" -s clean
 if [ "$CMAKE" = no ]; then
-    run_after_echo "$MAKE_BIN" -s ${CFLAGS:+CFLAGS="$CFLAGS"}
-    run_after_echo "$MAKE_BIN" -s testprogs ${CFLAGS:+CFLAGS="$CFLAGS"}
+    run_after_echo "$MAKE_BIN" ${CFLAGS:+CFLAGS="$CFLAGS"}
+    run_after_echo "$MAKE_BIN" testprogs ${CFLAGS:+CFLAGS="$CFLAGS"}
 else
     # The "-s" flag is a no-op and CFLAGS is set using -DEXTRA_CFLAGS above.
-    run_after_echo "$MAKE_BIN"
-    run_after_echo "$MAKE_BIN" testprogs
+    run_after_echo "$MAKE_BIN" VERBOSE=1
+    run_after_echo "$MAKE_BIN" VERBOSE=1 testprogs
 fi
 run_after_echo "$MAKE_BIN" install
 

--- a/pcap.c
+++ b/pcap.c
@@ -1,4 +1,4 @@
-/*
+/* 
  * Copyright (c) 1993, 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *


### PR DESCRIPTION
At this point, this is just doing verbose builds, so we can see whether the autotools and CMake builds pass different compiler arguments.

See #1511.