### PR TITLE
Fix Solaris 11 64-bit SPARC CMake build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -122,12 +122,12 @@ else
 fi
 run_after_echo "$MAKE_BIN" -s clean
 if [ "$CMAKE" = no ]; then
-    run_after_echo "$MAKE_BIN" -s ${CFLAGS:+CFLAGS="$CFLAGS"}
-    run_after_echo "$MAKE_BIN" -s testprogs ${CFLAGS:+CFLAGS="$CFLAGS"}
+    run_after_echo "$MAKE_BIN" ${CFLAGS:+CFLAGS="$CFLAGS"}
+    run_after_echo "$MAKE_BIN" testprogs ${CFLAGS:+CFLAGS="$CFLAGS"}
 else
     # The "-s" flag is a no-op and CFLAGS is set using -DEXTRA_CFLAGS above.
-    run_after_echo "$MAKE_BIN"
-    run_after_echo "$MAKE_BIN" testprogs
+    run_after_echo "$MAKE_BIN" VERBOSE=1
+    run_after_echo "$MAKE_BIN" VERBOSE=1 testprogs
 fi
 run_after_echo "$MAKE_BIN" install
 

--- a/pcap.c
+++ b/pcap.c
@@ -248,7 +248,7 @@ pcap_init(unsigned int opts, char *errbuf)
 		if (initialized) {
 			if (!pcapint_utf_8_mode) {
 				snprintf(errbuf, PCAP_ERRBUF_SIZE,
-				    "Multiple pcap_init calls with different character encodings");
+				    "Multiple pcap_pinit calls with different character encodings");
 				return (PCAP_ERROR);
 			}
 		}


### PR DESCRIPTION
At this point, this is just doing verbose builds, so we can see whether the autotools and CMake builds pass different compiler arguments.

See #1511.