### PR TITLE
FreeBSD USB: remove interface creation for FreeBSD 16.0

### DIFF
--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -43,7 +43,7 @@
 #endif
 #include <sys/utsname.h>
 
-#if defined(__FreeBSD__) && defined(SIOCIFCREATE2)
+#if defined(__FreeBSD__) && __FreeBSD_version < 1600006
 /*
  * Add support for capturing on FreeBSD usbusN interfaces.
  */
@@ -1736,7 +1736,7 @@ pcap_cleanup_bpf(pcap_t *p)
 		}
 #endif /* HAVE_BSD_IEEE80211 */
 
-#if defined(__FreeBSD__) && defined(SIOCIFCREATE2)
+#if defined(__FreeBSD__) && __FreeBSD_version < 1600006
 		/*
 		 * Attempt to destroy the usbusN interface that we created.
 		 */
@@ -1753,7 +1753,7 @@ pcap_cleanup_bpf(pcap_t *p)
 				}
 			}
 		}
-#endif /* defined(__FreeBSD__) && defined(SIOCIFCREATE2) */
+#endif /* defined(__FreeBSD__) && __FreeBSD_version < 1600006 */
 		/*
 		 * Take this pcap out of the list of pcaps for which we
 		 * have to take the interface out of some mode.
@@ -2049,11 +2049,11 @@ pcap_activate_bpf(pcap_t *p)
 	}
 #endif /* __APPLE__ */
 
+#if defined(__FreeBSD__) && __FreeBSD_version < 1600006
 	/*
-	 * If this is FreeBSD, and the device name begins with "usbus",
+	 * If this is legacy FreeBSD, and the device name begins with "usbus",
 	 * try to create the interface if it's not available.
 	 */
-#if defined(__FreeBSD__) && defined(SIOCIFCREATE2)
 	if (strncmp(p->opt.device, usbus_prefix, USBUS_PREFIX_LEN) == 0) {
 		/*
 		 * Do we already have an interface with that name?
@@ -2126,7 +2126,7 @@ pcap_activate_bpf(pcap_t *p)
 			pcapint_add_to_pcaps_to_close(p);
 		}
 	}
-#endif /* defined(__FreeBSD__) && defined(SIOCIFCREATE2) */
+#endif /* defined(__FreeBSD__) && __FreeBSD_version < 1600006 */
 
 #ifdef HAVE_ZEROCOPY_BPF
 	/*
@@ -2857,18 +2857,50 @@ check_bpf_bindable(const char *name)
 	return (1);
 }
 
-#if defined(__FreeBSD__) && defined(SIOCIFCREATE2)
+#if defined(__FreeBSD__)
 static int
-get_usb_if_flags(const char *name _U_, bpf_u_int32 *flags _U_, char *errbuf _U_)
+get_flags_stub(const char *name _U_, bpf_u_int32 *flags _U_, char *errbuf _U_)
 {
-	/*
-	 * XXX - if there's a way to determine whether there's something
-	 * plugged into a given USB bus, use that to determine whether
-	 * this device is "connected" or not.
-	 */
 	return (0);
 }
 
+#if __FreeBSD_version >= 1600006
+static int
+finddevs_bpf(pcap_if_list_t *devlistp, char *errbuf)
+{
+	struct bpf_iflist bi;
+	const char *name;
+	int fd;
+
+	if ((fd = bpf_open(errbuf)) < 0)
+		return (-1);
+
+	memset(&bi, 0, sizeof(bi));
+	if (ioctl(fd, BIOCGETIFLIST, (caddr_t)&bi) != 0 || bi.bi_size == 0)
+		return (-1);
+
+	if ((bi.bi_ubuf = malloc(bi.bi_size)) == NULL)
+		return (-1);
+
+	if (ioctl(fd, BIOCGETIFLIST, (caddr_t)&bi) != 0)
+		return (-1);
+
+	for (name = bi.bi_ubuf; bi.bi_count > 0;
+	    bi.bi_count--, name += strlen(name) + 1)
+		/*
+		 * Add only those devices that were not added via the
+		 * getifaddrs() loop in pcapint_findalldevs_interfaces().
+		 */
+		if (pcapint_find_or_add_dev(devlistp, name, PCAP_IF_UP,
+		    get_flags_stub, NULL, errbuf) == NULL) {
+			free(bi.bi_ubuf);
+			return (-1);
+		}
+
+	free(bi.bi_ubuf);
+	return (0);
+}
+#else
 static int
 finddevs_usb(pcap_if_list_t *devlistp, char *errbuf)
 {
@@ -2933,7 +2965,7 @@ finddevs_usb(pcap_if_list_t *devlistp, char *errbuf)
 		 * for each bus.
 		 */
 		if (pcapint_find_or_add_dev(devlistp, name, PCAP_IF_UP,
-		    get_usb_if_flags, NULL, errbuf) == NULL) {
+		    get_flags_stub, NULL, errbuf) == NULL) {
 			free(name);
 			closedir(usbdir);
 			return (PCAP_ERROR);
@@ -2944,6 +2976,7 @@ finddevs_usb(pcap_if_list_t *devlistp, char *errbuf)
 	return (0);
 }
 #endif
+#endif	/* FreeBSD */
 
 /*
  * Get additional flags for a device, using SIOCGIFMEDIA.
@@ -3086,9 +3119,14 @@ pcapint_platform_finddevs(pcap_if_list_t *devlistp, char *errbuf)
 		return (-1);
 #endif
 
-#if defined(__FreeBSD__) && defined(SIOCIFCREATE2)
+#if defined(__FreeBSD__)
+#if __FreeBSD_version >= 1600006
+	if (finddevs_bpf(devlistp, errbuf) == -1)
+		return (-1);
+#else
 	if (finddevs_usb(devlistp, errbuf) == -1)
 		return (-1);
+#endif
 #endif
 
 	return (0);


### PR DESCRIPTION
In FreeBSD 16.0 the USB bpf(4) taps are always available and the creation of pseudo-interfaces, that used to exist merely for a bpf(4) tap, is neither required nor is possible.  The list of all tap points can be obtained with BIOCGETIFLIST.  Note that we still use pcapint_findalldevs_interfaces() as the main method of collecting bpf taps, and we use BIOCGETIFLIST only to fill the gaps there - get those bpf taps, that are not a network interface.