### PR TITLE
Introduce a routine to parse decimal numbers in a string.

### DIFF
--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -150,7 +150,8 @@ bt_create(const char *device, char *ebuf, int *is_ours)
 {
 	const char *cp;
 	char *cpend;
-	long devnum;
+	int ret;
+	unsigned devnum;
 	pcap_t *p;
 
 	/* Does this look like a Bluetooth device? */
@@ -163,14 +164,9 @@ bt_create(const char *device, char *ebuf, int *is_ours)
 	}
 	/* Yes - is BT_IFACE followed by a number? */
 	cp += sizeof BT_IFACE - 1;
-	devnum = strtol(cp, &cpend, 10);
-	if (cpend == cp || *cpend != '\0') {
-		/* Not followed by a number. */
-		*is_ours = 0;
-		return NULL;
-	}
-	if (devnum < 0) {
-		/* Followed by a non-valid number. */
+	ret = pcapint_get_decuint(cp, &cpend, &devnum);
+	if (ret != 0) {
+		/* Not followed by a valid number */
 		*is_ours = 0;
 		return NULL;
 	}

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -617,6 +617,22 @@ int	pcapint_createsrcstr_ex(char *, int, const char *, const char *,
 int	pcapint_parsesrcstr_ex(const char *, int *, char *, char *,
     char *, char *, unsigned char *, char *);
 
+/*
+ * Routine to parse a string containing an unsigned decimal integer,
+ * which catches some errors that strtoul() doesn't (strtoul() appears
+ * to parse numbers according to the way a C compiler does, so it skips
+ * leading white space and will happily allow an unsigned number with
+ * a negative sign), and also can treat the string not being completely
+ * numeric as an error and will treat values that don't fit into
+ * an unsigned int as an error.
+ *
+ * On success, returns 0 and sets the value pointed to by the last
+ * argument to the integer value; on error, returns EINVAL for an
+ * invalid number or ERANGE for a value that's too large to fit in
+ * an unsigned int.
+ */
+int	pcapint_get_decuint(const char *, char **, unsigned *);
+
 #ifdef YYDEBUG
 extern int pcap_debug;
 #endif

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -24813,6 +24813,32 @@ my @translate_accept_blocks = (
 		aliases => ['rpcap://eth0', 'eth0'],
 		expect => 'rpcap://eth0',
 	},
+
+	# pcapint_get_decuint()
+	{
+		name => 'decuint_noendp_1',
+		cfunc => 'pcapint_get_decuint/noendp',
+		aliases => ['1', '01'],
+		expect => '1',
+	},
+	{
+		name => 'decuint_noendp_4294967295',
+		cfunc => 'pcapint_get_decuint/noendp',
+		aliases => ['4294967295', '04294967295'],
+		expect => '4294967295',
+	},
+	{
+		name => 'decuint_endp_4294967295',
+		cfunc => 'pcapint_get_decuint/endp',
+		aliases => ['4294967295!', '04294967295!'],
+		expect => '4294967295 "!"',
+	},
+	{
+		name => 'decuint_endp_1',
+		cfunc => 'pcapint_get_decuint/endp',
+		aliases => ['1a', '01a'],
+		expect => '1 "a"',
+	},
 );
 
 # This works similar to @filter_reject_tests.  In each array element the hash
@@ -25103,6 +25129,62 @@ my @translate_reject_tests = (
 		arg => 'rpcap://eth0',
 		errstr => 'pcapint_parsesrcstr_ex() is not supported',
 	},
+
+	# pcapint_get_decuint()
+	{
+		name => 'decuint_noendp_nullargument',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => undef,
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_emptystring',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '',
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_negative1',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '-1',
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_positive1',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '+1',
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_space1',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => ' 1',
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_tab1',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '\t1',
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_nonascii1',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '\xEF1',
+		errstr => 'EINVAL',
+	},
+	{
+		name => 'decuint_noendp_4294967296',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '4294967296',
+		errstr => 'ERANGE',
+	},
+	{
+		name => 'decuint_noendp_1111111111111111111',
+		cfunc => 'pcapint_get_decuint/noendp',
+		arg => '1111111111111111111',
+		errstr => 'ERANGE',
+	},
 );
 
 ##### more pcapint_parsesrcstr_ex() accept blocks
@@ -25326,7 +25408,43 @@ sub common_filtertest_args {
 
 sub common_translatetest_args {
 	my $test = shift;
-	my @args = ($translatetest, $test->{cfuncname});
+	#
+	# The GNU libc getopt() doesn't behave as one might expect,
+	# and, at least as I read the POSIX/SUS page on getopt(),
+	# it doesn't behave as it says it should.
+	#
+	# The POSIX/SUS page says that
+	#
+	#   If, when getopt() is called:
+	#
+	#   argv[optind]  is a null pointer
+	#  *argv[optind]  is not the character -
+	#   argv[optind]  points to the string "-"
+	#
+	#   getopt() shall return -1 without changing optind.
+	#
+	# which *I* read as indicating that an argument that
+	# doesn't begin with '-' stops option argument processing.
+	#
+	# That is *not* what GNU getopt() does by default.
+	#
+	# To get what I read as the POSIX/SUS behavior, either:
+	#
+	#   the environment variable POSIXLY_CORRECT must be set;
+	#   the option string argument must begin with '+'.
+	#
+	# Otherwise, a "--" argument must be placed before any
+	# of the non-option arguments.
+	#
+	# We choose the latter option - the POSIX/SUS getopt()
+	# page doesn't obviously seem to require that a "+" not
+	# have other undesired effects.
+	#
+	# Had the GNU folks made the standard behavior the default,
+	# and required a "+" to get the behavior they wanted, That
+	# Would Have Been Wonderful. But they didn't, so here we are.
+	#
+	my @args = ($translatetest, "--", $test->{cfuncname});
 	# The hash key exists.  For the value Perl undef means C NULL and no
 	# command-line argument in the shell command, an empty Perl string
 	# means an empty C string and a quoted empty string argument in the


### PR DESCRIPTION
This wraps strtoul() to do more error checking.

It's currently used only in one place, but there are other places where it could be useful.

Make translatetest's getopt() code do the standard "add optind to argv and subtract it frm argc" after the loop, so the first argument after the option arguments is argv[0] and there are a total of argc post-options arguments, so that it can handle a "--" argument to allow "-1" to be passed as a non-option argument, even with GNU getopt().

Add some tests, courtesy of Denis Ovsienko.