### PR TITLE
netmap: set the captured length appropriately.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -134,6 +134,9 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Require SNF_VERSION_API >= 0x0003.
       Improve device descriptions and flags.
       Fill pcap_if_t in more consistently.
+    Netmap:
+      Set packet captured length based on the snapshot length and return
+        value of the capture filter.
 
 Tuesday, December 30, 2025 / The Tcpdump Group
   Summary for 1.10.6 libpcap release


### PR DESCRIPTION
If there's no capture filter, set it to the minimum of the length provided by netmap and the length specified when the device was opened.

If there is a capture filter, set it to the minimum of the length provided by netmap and the length returned by the capture filter program.

That way, "tcpdump -s", etc. will give you shorter packets, so you don't have to write all the data out or parse it.