### PR TITLE
QNX improvements

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -146,6 +146,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
         value of the capture filter.
     QNX:
       Disable zero-copy BPF to work around portability issues.
+      Use "unix.h" instead of the missing <sysexits.h>.
 
 Tuesday, December 30, 2025 / The Tcpdump Group
   Summary for 1.10.6 libpcap release

--- a/CHANGES
+++ b/CHANGES
@@ -74,6 +74,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       man: Document devices, interfaces and "any" better.
       Remove list of OSes that support "ipv6-icmp"; all the ones we
         support appear to do so.
+      Add a README.qnx.md file.
     Building and testing:
       Apply GNU Hurd support patch from the Debian package.
       CI: Introduce and use LIBPCAP_CMAKE_TAINTED.

--- a/CHANGES
+++ b/CHANGES
@@ -105,6 +105,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Remove the "disable IPv6" build option.
       translatetest: Add a test program for various translation functions.
       Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
+      capturetest: Treat SA_RESTART as optional.
     Hurd:
       Support network capture devices too.
       Fix a few device activation bugs.

--- a/CHANGES
+++ b/CHANGES
@@ -144,6 +144,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
     Netmap:
       Set packet captured length based on the snapshot length and return
         value of the capture filter.
+    QNX:
+      Disable zero-copy BPF to work around portability issues.
 
 Tuesday, December 30, 2025 / The Tcpdump Group
   Summary for 1.10.6 libpcap release

--- a/CHANGES
+++ b/CHANGES
@@ -104,6 +104,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Rename CMake option to ENABLE_PROTOCHAIN to match Autoconf.
       Remove the "disable IPv6" build option.
       translatetest: Add a test program for various translation functions.
+      Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
     Hurd:
       Support network capture devices too.
       Fix a few device activation bugs.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -7,6 +7,7 @@ Platform-specific notes:
 * [GNU/Hurd](doc/README.hurd.md)
 * [GNU/Linux](doc/README.linux)
 * [macOS](doc/README.macos)
+* [QNX](doc/README.qnx.md)
 * [Solaris and related OSes](doc/README.solaris.md)
 * [Windows](doc/README.windows.md)
 
@@ -141,6 +142,7 @@ You can get around this by installing GCC.
 	doc/README.hurd.md  - notes on using libpcap on GNU/Hurd
 	doc/README.linux    - notes on using libpcap on Linux
 	doc/README.macos    - notes on using libpcap on macOS
+	doc/README.qnx.md   - notes on using libpcap on QNX
 	doc/README.snf.md   - notes on using libpcap to capture on Myricom SNF devices
 	doc/README.solaris.md - notes on using libpcap on Solaris
 	doc/README.windows.md - notes on using libpcap on Windows systems (with Npcap)

--- a/Makefile.in
+++ b/Makefile.in
@@ -248,6 +248,7 @@ EXTRA_DIST = \
 	doc/README.hurd.md \
 	doc/README.linux \
 	doc/README.macos \
+	doc/README.qnx.md \
 	doc/README.snf.md \
 	doc/README.solaris.md \
 	doc/README.windows.md \

--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@ User-level Packet Capture''
 [gzipped PostScript](https://www.tcpdump.org/papers/bpf-usenix93.ps.gz),
 [PDF](https://www.tcpdump.org/papers/bpf-usenix93.pdf)).
 
-Although most packet capture interfaces support in-kernel filtering,
-libpcap utilizes in-kernel filtering only for the BPF interface.
-On systems that don't have BPF, all packets are read into user-space
-and the BPF filters are evaluated in the libpcap library, incurring
+Although most packet capture interfaces support some in-kernel filtering,
+libpcap utilizes in-kernel filtering only for the use cases that support
+BPF programs, namely, the BPF packet capture interface, the Linux packet
+socket and the GNU/Hurd interface.
+
+In all other cases libpcap reads every packet into user-space and
+evaluates it using the filter program, which incurs
 added overhead (especially, for selective filters).  Ideally, libpcap
 would translate BPF filters into a filter program that is compatible
-with the underlying kernel subsystem, but this is not yet implemented.
+with the underlying kernel subsystem, but this is not implemented.
 
-BPF is standard in NetBSD, FreeBSD, OpenBSD, DragonFly BSD, macOS, and
+BPF is standard in NetBSD, FreeBSD, OpenBSD, DragonFly BSD, macOS, QNX and
 Solaris 11; an older, modified and undocumented version is standard
 in AIX.
 

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -747,9 +747,24 @@ AC_DEFUN(AC_LBL_LIBRARY_NET, [
 	    ],
 	    [
 		#
-		# We didn't find it.
+		# If this is QNX 8.0, getaddrinfo() and related functions are
+		# in libsocket, but there is no libnsl, hence the check result
+		# above for getaddrinfo() in libsocket with libnsl is negative.
+		# Autoconf caches the result, but does take libnsl into account
+		# as a caching factor, so remove the cached result to prevent
+		# an erroneous "cache hit" in the check below.
 		#
-		AC_MSG_ERROR([getaddrinfo is required, but wasn't found])
+		AS_UNSET(ac_cv_lib_socket_getaddrinfo)
+		AC_CHECK_LIB(socket, getaddrinfo,
+		[
+		    LIBS="-lsocket $LIBS"
+		],
+		[
+		    #
+		    # We didn't find it.
+		    #
+		    AC_MSG_ERROR([getaddrinfo is required, but wasn't found])
+		])
 	    ])
 	], -lnsl)
 

--- a/doc/README.qnx.md
+++ b/doc/README.qnx.md
@@ -1,0 +1,17 @@
+# Compiling libpcap for QNX
+
+It is possible to cross-compile libpcap from this source tree on a Linux host
+for a QNX 8.0 target as follows:
+1. Obtain a licence, download and install QNX Software Center.
+2. Using QNX Software Center, install a suitable version of QNX SDP (for
+   example, 8.0.3 works) and note the SDP installation directory (for example,
+   `~/qnx800`).  There is no need to install the Momentics IDE.
+3. Initialize environment variables and cross-compile libpcap for the required
+   target.  For example, for AArch64:
+   ```
+   . ~/qnx800/qnxsdp-env.sh
+   ./configure --host=aarch64-unknown-nto-qnx8.0.0
+   make
+   ```
+4. Cross-compile the required software using `libpcap.a` and the headers from
+   the libpcap source tree.

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -119,8 +119,14 @@ static int bpf_load(char *errbuf);
 /*
  * If both BIOCROTZBUF and BPF_BUFMODE_ZBUF are defined, we have
  * zero-copy BPF.
+ *
+ * However, the current implementation of pcap_next_zbuf_shm() and
+ * pcap_ack_zbuf() is not compatible with QNX.  Both FreeBSD and QNX implement
+ * atomic operations as C11 generic functions in <stdatomic.h>, FreeBSD
+ * implements additional FreeBSDisms in <machine/atomic.h> and QNX implements
+ * additional QNXisms in <atomic.h>.  These two functions use FreeBSDisms.
  */
-#if defined(BIOCROTZBUF) && defined(BPF_BUFMODE_ZBUF)
+#if !defined(__QNX__) && defined(BIOCROTZBUF) && defined(BPF_BUFMODE_ZBUF)
   #define HAVE_ZEROCOPY_BPF
   #include <sys/mman.h>
   #include <machine/atomic.h>

--- a/testprogs/capturetest.c
+++ b/testprogs/capturetest.c
@@ -86,7 +86,14 @@ sigint_handler(int signum _U_)
  * We do have UN*X-style signals (we assume that "not Windows" means "UN*X").
  */
 #define B_OPTION	"b"
+
+#ifdef SA_RESTART
 #define R_OPTION	"r"
+#else
+// QNX 8.0 neither defines not supports SA_RESTART.
+#define R_OPTION	""
+#endif // SA_RESTART
+
 #define S_OPTION	"s"
 #endif
 
@@ -104,7 +111,9 @@ main(int argc, char **argv)
 	int immediate = 0;
 	int nonblock = 0;
 #ifndef _WIN32
+#ifdef SA_RESTART
 	int sigrestart = 0;
+#endif // SA_RESTART
 	int catchsigint = 0;
 #endif
 	pcap_if_t *devlist;
@@ -143,9 +152,11 @@ main(int argc, char **argv)
 			break;
 
 #ifndef _WIN32
+#ifdef SA_RESTART
 		case 'r':
 			sigrestart = 1;
 			break;
+#endif // SA_RESTART
 
 		case 's':
 			catchsigint = 1;
@@ -200,7 +211,11 @@ main(int argc, char **argv)
 		/*
 		 * Should SIGINT interrupt, or restart, system calls?
 		 */
+#ifdef SA_RESTART
 		action.sa_flags = sigrestart ? SA_RESTART : 0;
+#else
+		action.sa_flags = 0;
+#endif // SA_RESTART
 
 		if (sigaction(SIGINT, &action, NULL) == -1)
 			error("Can't catch SIGINT: %s\n",

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -35,13 +35,19 @@ The Regents of the University of California.  All rights reserved.\n";
 #include <string.h>
 #include <stdarg.h>
 #include <limits.h>
+
 #ifdef _WIN32
   #include "getopt.h"
-  #include "unix.h"
 #else
   #include <unistd.h>
+#endif
+
+#if defined(_WIN32) || defined(__QNX__)
+  #include "unix.h"
+#else
   #include <sysexits.h>
 #endif
+
 #include <fcntl.h>
 #include <errno.h>
 #ifdef _WIN32

--- a/testprogs/translatetest.c
+++ b/testprogs/translatetest.c
@@ -8,9 +8,13 @@
 
 #ifdef _WIN32
   #include "getopt.h"
-  #include "unix.h"
 #else
   #include <unistd.h>
+#endif
+
+#if defined(_WIN32) || defined(__QNX__)
+  #include "unix.h"
+#else
   #include <sysexits.h>
 #endif
 

--- a/testprogs/unix.h
+++ b/testprogs/unix.h
@@ -55,7 +55,7 @@
   #define close		_close
 #endif
 
-// No <sysexits.h> on Windows.
+// No <sysexits.h> on Windows and QNX.
 #define EX_OK		0
 #define EX_USAGE	64
 #define EX_DATAERR	65


### PR DESCRIPTION
These changes address assorted failures to compile and unblock building of tcpdump, which seems to work as expected in my short tests, but I did not do any thorough testing. Zero-copy BPF is available, but disabled (see the comment).