### PR TITLE
Free p->opt.device on close, not on cleanup.

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -4159,10 +4159,15 @@ pcapint_breakloop_common(pcap_t *p)
 void
 pcapint_cleanup_live_common(pcap_t *p)
 {
-	if (p->opt.device != NULL) {
-		free(p->opt.device);
-		p->opt.device = NULL;
-	}
+	/*
+	 * This must not free p->opt.device; that must only be done
+	 * in pcap_close(), as this might be cleaning up after a
+	 * failed pcap_activate(), in which case p->opt.device must
+	 * still be valid, in case further actions are done on the
+	 * not-yet-activated pcap_t.
+	 *
+	 * See GitHub issue #1615.
+	 */
 	if (p->buffer != NULL) {
 		free(p->buffer);
 		p->buffer = NULL;
@@ -4242,6 +4247,17 @@ void
 pcap_close(pcap_t *p)
 {
 	p->cleanup_op(p);
+
+	/*
+	 * Free information set by pcap_create() *after* calling
+	 * the module's cleanup routine; that routine might have
+	 * to use p->opt.device (see commit
+	 * e333a6044f7d2d3225a6a22205b6b7c1e389945f).
+	 */
+	if (p->opt.device != NULL) {
+		free(p->opt.device);
+		p->opt.device = NULL;
+	}
 	free(p);
 }
 

--- a/testprogs/activatetest.c
+++ b/testprogs/activatetest.c
@@ -44,6 +44,13 @@ int main(void)
 		        "FAIL: Unexpected error %d from pcap_activate().\n",
 		        err);
 	}
+
+	/*
+	 * And attempts to determine whether attributes can be set
+	 * on the pcap_t shouldn't crash after a failed activate.
+	 * See GitHub issue #1615.
+	 */
+	(void) pcap_can_set_rfmon(p);
 	pcap_close(p);
 	return ret;
 }


### PR DESCRIPTION
That way, if a failed pcap_activate() cleans up anything done by the activate by calling the module's cleanup routine, which should always call pcapint_cleanup_live_common(), p->opt.device, which is set by pcap_create() and shouldn't be freed or modified until the pcap_t is closed, will be left alone.

Commit e333a6044f7d2d3225a6a22205b6b7c1e389945f moved the freeing of p->opt.device to pcap_cleanup_live_common(), but the reason for doing that is that, before that commit, we were freeing p->opt.device *before* calling the module's cleanup routine, and pcap-npf.c's cleanup routine used p->opt.device to turn monitor mode off.

This change moves freeing of p->opt.device back, but does it *after* the module's cleanup routine is called, so it's safe for that rouine to use p->opt.device - as long as it doesn't save the value of p->opt.device and attempt to use it later. Copy the string if you need to do that.

Fix #1615.

Add a test for that crash in testprogs/activatetest.c. That won't necessarily catch *all* cases where this is a problem on *all* platforms, but it should at least catch it on Linux.