### PR TITLE
Fix -Wdiscarded-qualifiers warning by retaining const qualifier

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -6861,7 +6861,7 @@ static void
 stringtoportrange(compiler_state_t *cstate, const char *string,
     bpf_u_int32 *port1, bpf_u_int32 *port2, int *proto)
 {
-	char *hyphen_off;
+	const char *hyphen_off;
 	const char *first, *second;
 	size_t first_size, second_size;
 	int save_proto;


### PR DESCRIPTION
- Fixes #1623 

Since glibc-2.43:

For ISO C23, the functions bsearch, memchr, strchr, strpbrk, strrchr, strstr, wcschr, wcspbrk, wcsrchr, wcsstr and wmemchr that return pointers into their input arrays now have definitions as macros that return a pointer to a const-qualified type when the in put argument is a pointer to a const-qualified type.

https://lists.gnu.org/archive/html/info-gnu/2026-01/msg00005.html

Fixes:
```c
../gencode.c: In function 'stringtoportrange':
../gencode.c:6999:25: warning: assignment discards 'const' qualifier from pointer target type [-Wdiscarded-qualifiers]
 6999 |         if ((hyphen_off = strchr(string, '-')) == NULL)
      |                         ^
```