### PR TITLE
pcapng: Improve an error message in read_block(), printing lengths

### DIFF
--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -371,7 +371,8 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 		 * No.
 		 */
 		snprintf(errbuf, PCAP_ERRBUF_SIZE,
-		    "block total length in header and trailer don't match");
+		    "block total length in header %u and trailer %u don't match",
+		    bhdr.total_length, btrlr->total_length);
 		return (-1);
 	}
 

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -22750,7 +22750,7 @@ my @filter_reject_tests = (
 	{
 		name => 'shb_option_too_long',
 		savefile => 'shb-option-too-long.pcapng',
-		errstr => 'Failed opening: block total length in header and trailer don\'t match',
+		errstr => 'Failed opening: block total length in header 32 and trailer 808464432 don\'t match',
 	},
 
 	{


### PR DESCRIPTION
Before:
block total length in header and trailer don't match

After:
block total length in header 948 and trailer 0 don't match