### PR TITLE
Autoconf: Move the --enable-remote warning at the end of configure sc…

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1636,8 +1636,6 @@ AC_ARG_ENABLE([remote],
    [enableval=no])
 case "$enableval" in
 yes)	AC_MSG_RESULT(yes)
-	AC_MSG_WARN(Remote packet capture may expose libpcap-based applications)
-	AC_MSG_WARN(to attacks by malicious remote capture servers!)
 	#
 	# rpcapd requires pthreads on UN*X.
 	#
@@ -3092,4 +3090,13 @@ AC_CONFIG_FILES([Makefile grammar.y pcap-filter.manmisc pcap-linktype.manmisc
 	rpcapd/Makefile rpcapd/rpcapd.manadmin rpcapd/rpcapd-config.manfile
 	testprogs/Makefile])
 AC_OUTPUT
+AS_IF([test "x$enable_remote" = xyes],
+  [AC_MSG_WARN([
+
+	***  REMOTE PACKET CAPTURE IS ENABLED  ***
+
+	The --enable-remote feature is experimental and is not ready for
+	production use. Remote packet capture may expose libpcap-based
+	applications to attacks by malicious remote capture servers!
+  ])])
 exit 0


### PR DESCRIPTION
…ript

It will be better seen at the end of the output.
Update the warning text.