### PR TITLE
CMake: Disable remote capture support on Windows by default

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -35,96 +35,96 @@ environment:
       PLATFORM: Win32
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=YES
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
       PLATFORM: x64
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=YES
       # VS 2017, Npcap, 32-bit and 64-bit x86, without AirPcap, with remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
       PLATFORM: Win32
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=YES
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
       GENERATOR: "Visual Studio 15 2017"
       PLATFORM: x64
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
+      REMOTE: -DENABLE_REMOTE=YES
       # VS 2019, WinPcap, 32-bit and 64-bit x86, without AirPcap, without remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: Win32
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: x64
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
       # VS 2019, Npcap, 32-bit and 64-bit x86, without AirPcap, without remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: Win32
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: x64
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
       # VS 2019, Npcap, 32-bit and 64-bit x86, with AirPcap, with remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: Win32
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win32\bin
+      REMOTE: -DENABLE_REMOTE=YES
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2019
       GENERATOR: "Visual Studio 16 2019"
       PLATFORM: x64
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
+      REMOTE: -DENABLE_REMOTE=YES
       # VS 2022, WinPcap, 32-bit and 64-bit x86, without AirPcap, without remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: x64
       SDK: WpdPack
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
       # VS 2022, Npcap, 32-bit and 64-bit x86, without AirPcap, without remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: x64
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
-      REMOTE: -DENABLE_REMOTE=NO
       # VS 2022, Npcap, 32-bit and 64-bit x86, with AirPcap and remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: Win32
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win32\bin
+      REMOTE: -DENABLE_REMOTE=YES
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
       PLATFORM: x64
       SDK: npcap-sdk
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
+      REMOTE: -DENABLE_REMOTE=YES
       # VS 2022, Npcap, 64-bit ARM, without AirPcap, with remote
     - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
       GENERATOR: "Visual Studio 17 2022"
@@ -132,6 +132,7 @@ environment:
       SDK: npcap-sdk
       AIRPCAP: -DDISABLE_AIRPCAP=YES
       OPENSSL_ROOT_DIR: -DOPENSSL_ROOT_DIR=C:\OpenSSL-v33-Win64\bin
+      REMOTE: -DENABLE_REMOTE=YES
 
 build_script:
   #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,14 +492,10 @@ option(NO_PROTOCHAIN "Disable protochain instruction" OFF)
 set(PCAP_TYPE "" CACHE STRING "Packet capture type")
 
 #
-# Default to having remote capture support on Windows and, for now, to
-# not having it on UN*X.
+# Disable remote capture support by default.
+# This feature is experimental and is not ready for production use.
 #
-if(WIN32)
-    option(ENABLE_REMOTE "Enable remote capture" ON)
-else()
-    option(ENABLE_REMOTE "Enable remote capture" OFF)
-endif(WIN32)
+option(ENABLE_REMOTE "Enable remote capture" OFF)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
     option(BUILD_WITH_LIBNL "Build with libnl" ON)
@@ -3637,3 +3633,12 @@ configure_file(
 
 add_custom_target(uninstall
     COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+
+if(ENABLE_REMOTE)
+  message(WARNING "
+  ***  REMOTE PACKET CAPTURE IS ENABLED  ***
+  The ENABLE_REMOTE feature is experimental and is not ready for
+  production use. Remote packet capture may expose libpcap-based
+  applications to attacks by malicious remote capture servers!"
+  )
+endif()


### PR DESCRIPTION
This feature is experimental and is not ready for production use.

Add a warning when enabling remote capture, as with Autoconf.

(backported from commit 5b2265c2ccbb27036dc47657f1c14e980c0e6be6)

Accordingly:

AppVeyor: Update the remote capture build configuration

The default is now: ENABLE_REMOTE=NO (OFF).

Thus add when needed:
REMOTE: -DENABLE_REMOTE=YES
and remove:
REMOTE: -DENABLE_REMOTE=NO

[skip ci]