### PR TITLE
Don't assume Linux USB headers are 64-bit aligned.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2843,6 +2843,12 @@ if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.devel OR EXISTS ${CMAKE_BINARY_DIR}/.deve
         # XXX - add /Qspectre if that is really worth doing.
         #
         check_and_add_compiler_option(-wd5045)
+        #
+        # Suppress warning C4204 from MSVC
+        # "nonstandard extension used: non-constant aggregate initializer"
+        # with code that returns a compound literal. This is allowed by C99.
+        #
+        check_and_add_compiler_option(-wd4204)
 
         #
         # Treat all (remaining) warnings as errors.

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -723,7 +723,7 @@ usb_read_linux_bin(pcap_t *handle, int max_packets _U_, pcap_handler callback, u
 		 */
 		pkth.len = sizeof(pcap_usb_header) + info.hdr->urb_len;
 	}
-	pkth.ts.tv_sec = (time_t)info.hdr->ts_sec;
+	pkth.ts.tv_sec = (time_t)pcap_4_byte_aligned_int64_val(info.hdr->ts_sec);
 	pkth.ts.tv_usec = info.hdr->ts_usec;
 
 	if (handle->fcode.bf_insns == NULL ||
@@ -911,7 +911,7 @@ usb_read_linux_mmap(pcap_t *handle, int max_packets, pcap_handler callback, u_ch
 					    hdr->urb_len);
 				}
 			}
-			pkth.ts.tv_sec = (time_t)hdr->ts_sec;
+			pkth.ts.tv_sec = (time_t)pcap_4_byte_aligned_int64_val(hdr->ts_sec);
 			pkth.ts.tv_usec = hdr->ts_usec;
 
 			if (handle->fcode.bf_insns == NULL ||

--- a/pcap-util.c
+++ b/pcap-util.c
@@ -262,7 +262,7 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 	offset += 8;			/* skip past id */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->id = SWAPLL(uhdr->id);
+	uhdr->id = swap_4_byte_aligned_uint64(uhdr->id);
 
 	offset += 4;			/* skip past various 1-byte fields */
 
@@ -276,7 +276,7 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 	offset += 8;			/* skip past ts_sec */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->ts_sec = SWAPLL(uhdr->ts_sec);
+	uhdr->ts_sec = swap_4_byte_aligned_int64(uhdr->ts_sec);
 
 	offset += 4;			/* skip past ts_usec */
 	if (hdr->caplen < offset)

--- a/pcap-util.h
+++ b/pcap-util.h
@@ -59,6 +59,22 @@
      ((u_short)(((((u_int)(y))&0xff)<<8) | \
                 ((((u_int)(y))&0xff00)>>8)))
 
+/*
+ * Byte-swap a pcap_4_byte_aligned_uint64;
+ */
+static inline pcap_4_byte_aligned_uint64 swap_4_byte_aligned_uint64(pcap_4_byte_aligned_uint64 val)
+{
+	return (pcap_4_byte_aligned_uint64){.halves[0] = SWAPLONG(val.halves[1]), .halves[1] = SWAPLONG(val.halves[0])};
+}
+
+/*
+ * Byte-swap a pcap_4_byte_aligned_int64;
+ */
+static inline pcap_4_byte_aligned_int64 swap_4_byte_aligned_int64(pcap_4_byte_aligned_int64 val)
+{
+	return (pcap_4_byte_aligned_int64){.halves[0] = SWAPLONG(val.halves[1]), .halves[1] = SWAPLONG(val.halves[0])};
+}
+
 extern void pcapint_post_process(int linktype, int swapped,
     struct pcap_pkthdr *hdr, u_char *data);
 

--- a/pcap/pcap-inttypes.h
+++ b/pcap/pcap-inttypes.h
@@ -95,4 +95,37 @@
   #include <inttypes.h>
 #endif /* defined(_MSC_VER) */
 
+#include <string.h>	/* for memcpy() */
+
+/*
+ * Some data structures have 64-bit values that are guaranteed to be
+ * on a 4-byte boundary but are not guaranteeed to be aligned on an
+ * 8-byte boundary.
+ */
+typedef struct {
+	uint32_t halves[2];
+} pcap_4_byte_aligned_uint64;
+
+static inline
+uint64_t pcap_4_byte_aligned_uint64_val(pcap_4_byte_aligned_uint64 val)
+{
+	uint64_t result;
+
+	memcpy(&result, &val, 8);
+	return result;
+}
+
+typedef struct {
+	uint32_t halves[2];
+} pcap_4_byte_aligned_int64;
+
+static inline
+int64_t pcap_4_byte_aligned_int64_val(pcap_4_byte_aligned_int64 val)
+{
+	int64_t result;
+
+	memcpy(&result, &val, 8);
+	return result;
+}
+
 #endif /* pcap/pcap-inttypes.h */

--- a/pcap/usb.h
+++ b/pcap/usb.h
@@ -77,7 +77,7 @@ typedef struct _iso_rec {
  * Appears at the front of each packet in DLT_USB_LINUX captures.
  */
 typedef struct _usb_header {
-	uint64_t id;
+	pcap_4_byte_aligned_uint64 id;
 	uint8_t event_type;
 	uint8_t transfer_type;
 	uint8_t endpoint_number;
@@ -85,7 +85,7 @@ typedef struct _usb_header {
 	uint16_t bus_id;
 	char setup_flag;/*if !=0 the urb setup header is not present*/
 	char data_flag; /*if !=0 no urb data is present*/
-	int64_t ts_sec;
+	pcap_4_byte_aligned_int64 ts_sec;
 	int32_t ts_usec;
 	int32_t status;
 	uint32_t urb_len;
@@ -102,7 +102,7 @@ typedef struct _usb_header {
  * Appears at the front of each packet in DLT_USB_LINUX_MMAPPED captures.
  */
 typedef struct _usb_header_mmapped {
-	uint64_t id;
+	pcap_4_byte_aligned_uint64 id;
 	uint8_t event_type;
 	uint8_t transfer_type;
 	uint8_t endpoint_number;
@@ -110,7 +110,7 @@ typedef struct _usb_header_mmapped {
 	uint16_t bus_id;
 	char setup_flag;/*if !=0 the urb setup header is not present*/
 	char data_flag; /*if !=0 no urb data is present*/
-	int64_t ts_sec;
+	pcap_4_byte_aligned_int64 ts_sec;
 	int32_t ts_usec;
 	int32_t status;
 	uint32_t urb_len;


### PR DESCRIPTION
They might not be, especially in pcapng capture files, which only guarantee 32-bit alignment for packet data.

Fixes GitHub issue #1634.

Discovered by FuzzAnything Organization (https://github.com/FuzzAnything-ORG) (fuzzanything@gmail.com).