### PR TITLE
a few QNX-specific backports

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -15,6 +15,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
     Building and testing:
       CMake: Disable remote capture support on Windows by default.
       RDMA: Avoid valgrind errors when calling rdmasniff_findalldevs().
+      Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
 
 Tuesday, December 30, 2025 / The Tcpdump Group
   Summary for 1.10.6 libpcap release

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       CMake: Disable remote capture support on Windows by default.
       RDMA: Avoid valgrind errors when calling rdmasniff_findalldevs().
       Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
+      capturetest: Treat SA_RESTART as optional.
     QNX:
       Disable zero-copy BPF to work around portability issues.
 

--- a/CHANGES
+++ b/CHANGES
@@ -16,6 +16,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       CMake: Disable remote capture support on Windows by default.
       RDMA: Avoid valgrind errors when calling rdmasniff_findalldevs().
       Autoconf: Add QNX support to AC_LBL_LIBRARY_NET().
+    QNX:
+      Disable zero-copy BPF to work around portability issues.
 
 Tuesday, December 30, 2025 / The Tcpdump Group
   Summary for 1.10.6 libpcap release

--- a/aclocal.m4
+++ b/aclocal.m4
@@ -1049,9 +1049,24 @@ AC_DEFUN(AC_LBL_LIBRARY_NET, [
 	    ],
 	    [
 		#
-		# We didn't find it.
+		# If this is QNX 8.0, getaddrinfo() and related functions are
+		# in libsocket, but there is no libnsl, hence the check result
+		# above for getaddrinfo() in libsocket with libnsl is negative.
+		# Autoconf caches the result, but does take libnsl into account
+		# as a caching factor, so remove the cached result to prevent
+		# an erroneous "cache hit" in the check below.
 		#
-		AC_MSG_ERROR([getaddrinfo is required, but wasn't found])
+		AS_UNSET(ac_cv_lib_socket_getaddrinfo)
+		AC_CHECK_LIB(socket, getaddrinfo,
+		[
+		    LIBS="-lsocket $LIBS"
+		],
+		[
+		    #
+		    # We didn't find it.
+		    #
+		    AC_MSG_ERROR([getaddrinfo is required, but wasn't found])
+		])
 	    ])
 	], -lnsl)
 

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -119,8 +119,14 @@ static int bpf_load(char *errbuf);
 /*
  * If both BIOCROTZBUF and BPF_BUFMODE_ZBUF are defined, we have
  * zero-copy BPF.
+ *
+ * However, the current implementation of pcap_next_zbuf_shm() and
+ * pcap_ack_zbuf() is not compatible with QNX.  Both FreeBSD and QNX implement
+ * atomic operations as C11 generic functions in <stdatomic.h>, FreeBSD
+ * implements additional FreeBSDisms in <machine/atomic.h> and QNX implements
+ * additional QNXisms in <atomic.h>.  These two functions use FreeBSDisms.
  */
-#if defined(BIOCROTZBUF) && defined(BPF_BUFMODE_ZBUF)
+#if !defined(__QNX__) && defined(BIOCROTZBUF) && defined(BPF_BUFMODE_ZBUF)
   #define HAVE_ZEROCOPY_BPF
   #include <sys/mman.h>
   #include <machine/atomic.h>

--- a/testprogs/capturetest.c
+++ b/testprogs/capturetest.c
@@ -86,7 +86,14 @@ sigint_handler(int signum _U_)
  * We do have UN*X-style signals (we assume that "not Windows" means "UN*X").
  */
 #define B_OPTION	"b"
+
+#ifdef SA_RESTART
 #define R_OPTION	"r"
+#else
+// QNX 8.0 neither defines not supports SA_RESTART.
+#define R_OPTION	""
+#endif // SA_RESTART
+
 #define S_OPTION	"s"
 #endif
 
@@ -104,7 +111,9 @@ main(int argc, char **argv)
 	int immediate = 0;
 	int nonblock = 0;
 #ifndef _WIN32
+#ifdef SA_RESTART
 	int sigrestart = 0;
+#endif // SA_RESTART
 	int catchsigint = 0;
 #endif
 	pcap_if_t *devlist;
@@ -143,9 +152,11 @@ main(int argc, char **argv)
 			break;
 
 #ifndef _WIN32
+#ifdef SA_RESTART
 		case 'r':
 			sigrestart = 1;
 			break;
+#endif // SA_RESTART
 
 		case 's':
 			catchsigint = 1;
@@ -200,7 +211,11 @@ main(int argc, char **argv)
 		/*
 		 * Should SIGINT interrupt, or restart, system calls?
 		 */
+#ifdef SA_RESTART
 		action.sa_flags = sigrestart ? SA_RESTART : 0;
+#else
+		action.sa_flags = 0;
+#endif // SA_RESTART
 
 		if (sigaction(SIGINT, &action, NULL) == -1)
 			error("Can't catch SIGINT: %s\n",


### PR DESCRIPTION
This is the least amount of changes required to fix building the current libpcap-1.10 on/for QNX.