### PR TITLE
plugin: add runtime plugin loader for external capture backends including dpdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2509,6 +2509,25 @@ if(NOT DISABLE_DPDK)
     endif()
 endif()
 
+#
+# Plugin loader — always compiled, discovers pcap-*.so at runtime.
+#
+set(PROJECT_SOURCE_LIST_C ${PROJECT_SOURCE_LIST_C} pcap-plugin.c)
+set(PCAP_LINK_LIBRARIES ${PCAP_LINK_LIBRARIES} ${CMAKE_DL_LIBS})
+
+#
+# Plugin directory (build-time default).
+# Exposed as plugindir in libpcap.pc so external projects can
+# query it with: pkg-config --variable=plugindir libpcap
+#
+set(PLUGIN_DIR "${CMAKE_INSTALL_PREFIX}/lib/pcap/plugins" CACHE STRING
+    "Plugin directory for pcap-*.so modules")
+add_definitions(-DPCAP_PLUGIN_DIR="${PLUGIN_DIR}")
+
+check_function_exists(secure_getenv HAVE_SECURE_GETENV)
+check_function_exists(issetugid HAVE_ISSETUGID)
+check_function_exists(getauxval HAVE_GETAUXVAL)
+
 # Check for Bluetooth sniffing support
 if(NOT DISABLE_BLUETOOTH)
     if(CMAKE_SYSTEM_NAME STREQUAL "Linux")
@@ -3574,6 +3593,7 @@ if(NOT MSVC)
             set(RPATH "")
         endif()
     endif()
+    set(plugindir "${PLUGIN_DIR}")
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pcap-config.in ${CMAKE_CURRENT_BINARY_DIR}/pcap-config @ONLY)
     configure_file(${CMAKE_CURRENT_SOURCE_DIR}/libpcap.pc.in ${CMAKE_CURRENT_BINARY_DIR}/libpcap.pc @ONLY)
     install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/pcap-config DESTINATION bin)

--- a/Makefile.in
+++ b/Makefile.in
@@ -33,6 +33,8 @@ sbindir = @sbindir@
 includedir = @includedir@
 # Pathname of directory to install the library
 libdir =  @libdir@
+# Pathname of directory to install plugin modules
+plugindir = @plugindir@
 # Pathname of directory to install the man pages
 mandir = @mandir@
 
@@ -53,7 +55,7 @@ MKDEP = @MKDEP@
 CCOPT = @V_CCOPT@
 SHLIB_CCOPT = @V_SHLIB_CCOPT@
 INCLS = -I. @V_INCLS@
-DEFS = -DBUILDING_PCAP -Dpcap_EXPORTS @DEFS@ @V_DEFS@
+DEFS = -DBUILDING_PCAP -Dpcap_EXPORTS -DPCAP_PLUGIN_DIR='"$(plugindir)"' @DEFS@ @V_DEFS@
 ADDLOBJS = @ADDLOBJS@
 ADDLARCHIVEOBJS = @ADDLARCHIVEOBJS@
 LIBS = @LIBS@
@@ -114,6 +116,7 @@ PUBHDR = \
 	pcap/nflog.h \
 	pcap/pcap-inttypes.h \
 	pcap/pcap.h \
+	pcap/pcap-plugin.h \
 	pcap/sll.h \
 	pcap/socket.h \
 	pcap/usb.h \
@@ -132,6 +135,7 @@ HDR = $(PUBHDR) \
 	optimize.h \
 	pcap-common.h \
 	pcap-int.h \
+	pcap-plugin.h \
 	pcap-rpcap.h \
 	pcap-types.h \
 	pcap-usb-linux-common.h \
@@ -316,6 +320,8 @@ EXTRA_DIST = \
 	pcap-netmap.h \
 	pcap-npf.c \
 	pcap-null.c \
+	pcap-plugin.c \
+	pcap-plugin.h \
 	pcap-rdmasniff.c \
 	pcap-rdmasniff.h \
 	pcap-rpcap.c \

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -42,6 +42,15 @@
 /* Define to 1 if fseeko (and presumably ftello) exists and is declared. */
 #cmakedefine HAVE_FSEEKO 1
 
+/* Define to 1 if you have the `secure_getenv' function. */
+#cmakedefine HAVE_SECURE_GETENV 1
+
+/* Define to 1 if you have the `issetugid' function. */
+#cmakedefine HAVE_ISSETUGID 1
+
+/* Define to 1 if you have the `getauxval' function. */
+#cmakedefine HAVE_GETAUXVAL 1
+
 /* Define to 1 if you have the `getspnam' function. */
 #cmakedefine HAVE_GETSPNAM 1
 

--- a/configure.ac
+++ b/configure.ac
@@ -3000,6 +3000,30 @@ if test "x$enable_rdma" != "xno"; then
 fi
 
 #
+# Plugin loader — always compiled, discovers pcap-*.so at runtime.
+# Needs -ldl on systems where dlopen is in libdl (not needed on
+# FreeBSD, musl, etc. where it is in libc).
+#
+MODULE_C_SRC="$MODULE_C_SRC pcap-plugin.c"
+AC_SEARCH_LIBS([dlopen], [dl])
+
+AC_CHECK_FUNCS([secure_getenv issetugid getauxval])
+
+# Plugin directory (build-time default).
+# Exposed as plugindir in libpcap.pc so external projects can
+# query it with: pkg-config --variable=plugindir libpcap
+plugindir='${libdir}/pcap/plugins'
+AC_ARG_WITH([plugin-dir],
+    AS_HELP_STRING([--with-plugin-dir=DIR],
+	[plugin directory @<:@LIBDIR/pcap/plugins@:>@]),
+    [
+	if test "$withval" != no && test "$withval" != yes; then
+		plugindir="$withval"
+	fi
+    ])
+AC_SUBST(plugindir)
+
+#
 # If this is a platform where we need to have the .pc file and
 # pcap-config script supply an rpath option to specify the directory
 # in which the libpcap shared library is installed, and the install

--- a/libpcap.pc.in
+++ b/libpcap.pc.in
@@ -9,6 +9,7 @@ prefix="@prefix@"
 exec_prefix="@exec_prefix@"
 includedir="@includedir@"
 libdir="@libdir@"
+plugindir="@plugindir@"
 
 Name: libpcap
 Description: Platform-independent network traffic capture library

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -564,10 +564,14 @@ FILE	*pcapint_charset_fopen(const char *path, const char *mode);
  */
 #ifdef _WIN32
 #define pcap_code_handle_t	HMODULE
+#else
+#define pcap_code_handle_t	void *
+#endif
 
 pcap_code_handle_t	pcapint_load_code(const char *);
 void			*pcapint_find_function(pcap_code_handle_t, const char *);
-#endif
+void			pcapint_unload_code(pcap_code_handle_t);
+
 
 /*
  * Internal interfaces for doing user-mode filtering of packets and

--- a/pcap-plugin.c
+++ b/pcap-plugin.c
@@ -426,6 +426,30 @@ pcap_plugin_get_tstamp_type(pcap_t *p)
 }
 
 int
+pcap_plugin_get_tstamp_precision(pcap_t *p)
+{
+	return p->opt.tstamp_precision;
+}
+
+int
+pcap_plugin_get_promisc(pcap_t *p)
+{
+	return p->opt.promisc;
+}
+
+int
+pcap_plugin_get_buffer_size(pcap_t *p)
+{
+	return (int)p->opt.buffer_size;
+}
+
+int
+pcap_plugin_get_immediate(pcap_t *p)
+{
+	return p->opt.immediate;
+}
+
+int
 pcap_plugin_set_tstamp_type_list(pcap_t *p, const int *types, int count)
 {
 	u_int *list;
@@ -439,6 +463,47 @@ pcap_plugin_set_tstamp_type_list(pcap_t *p, const int *types, int count)
 	p->tstamp_type_list = list;
 	p->tstamp_type_count = count;
 	return 0;
+}
+
+int
+pcap_plugin_set_tstamp_precision_list(pcap_t *p, const int *precisions,
+    int count)
+{
+	u_int *list;
+
+	list = malloc(count * sizeof(u_int));
+	if (list == NULL)
+		return -1;
+	for (int i = 0; i < count; i++)
+		list[i] = (u_int)precisions[i];
+	free(p->tstamp_precision_list);
+	p->tstamp_precision_list = list;
+	p->tstamp_precision_count = count;
+	return 0;
+}
+
+int
+pcap_plugin_set_datalink_list(pcap_t *p, const int *dlts, int count)
+{
+	u_int *list;
+
+	list = malloc(count * sizeof(u_int));
+	if (list == NULL)
+		return -1;
+	for (int i = 0; i < count; i++)
+		list[i] = (u_int)dlts[i];
+	free(p->dlt_list);
+	p->dlt_list = list;
+	p->dlt_count = count;
+	return 0;
+}
+
+void
+pcap_plugin_set_selectable_fd(pcap_t *p, int fd)
+{
+#ifndef _WIN32
+	p->selectable_fd = fd;
+#endif
 }
 
 pcap_if_t *

--- a/pcap-plugin.c
+++ b/pcap-plugin.c
@@ -419,6 +419,28 @@ pcap_plugin_filter(const struct bpf_insn *pc, const unsigned char *pkt,
 	return pcapint_filter(pc, pkt, wirelen, caplen);
 }
 
+int
+pcap_plugin_get_tstamp_type(pcap_t *p)
+{
+	return p->opt.tstamp_type;
+}
+
+int
+pcap_plugin_set_tstamp_type_list(pcap_t *p, const int *types, int count)
+{
+	u_int *list;
+
+	list = malloc(count * sizeof(u_int));
+	if (list == NULL)
+		return -1;
+	for (int i = 0; i < count; i++)
+		list[i] = (u_int)types[i];
+	free(p->tstamp_type_list);
+	p->tstamp_type_list = list;
+	p->tstamp_type_count = count;
+	return 0;
+}
+
 pcap_if_t *
 pcap_plugin_add_dev(pcap_if_list_t *devlistp, const char *name,
     unsigned int flags, const char *description, char *errbuf)

--- a/pcap-plugin.c
+++ b/pcap-plugin.c
@@ -1,0 +1,428 @@
+/*
+ * Copyright (c) 2026 Vincent Jardin, Free Mobile, Iliad
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+/*
+ * pcap-plugin: generic plugin loader for libpcap capture backends.
+ *
+ * Scans plugin directories for pcap-*.so shared modules, loads each
+ * via pcapint_load_code(), and dispatches findalldevs/create calls to
+ * loaded plugins.
+ *
+ * Security model (modeled after OpenSSL provider loading):
+ *   - $PCAP_PLUGIN_DIR is read through secure_getenv() (or equivalent),
+ *     so it is automatically ignored under elevated privileges (setuid,
+ *     setgid, file capabilities, LSM transitions).
+ *   - The hardcoded plugin directory (PCAP_PLUGIN_DIR) is always scanned.
+ *   - Filesystem permissions on the plugin directory are the security
+ *     boundary, same as PAM, NSS, OpenSSL, and Mesa.
+ *   - libpcap does NOT drop privileges itself; that is the app's job.
+ *
+ * Plugin search order:
+ *   1. $PCAP_PLUGIN_DIR (colon-separated, skipped under privilege)
+ *   2. PCAP_PLUGIN_DIR (compile-time default, e.g. /usr/lib/pcap/plugins)
+ */
+
+#include <config.h>
+
+#ifdef HAVE_SECURE_GETENV
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE	/* for secure_getenv() */
+#endif
+#endif
+
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifndef _WIN32
+#include <dirent.h>
+#include <dlfcn.h>
+#include <unistd.h>
+
+#ifdef HAVE_GETAUXVAL
+#include <sys/auxv.h>
+#endif
+#endif /* _WIN32 */
+
+#include "pcap-int.h"
+#include "pcap-plugin.h"
+#include <pcap/pcap-plugin.h>
+
+/*
+ * Default plugin directory if not set by the build system.
+ */
+#ifndef PCAP_PLUGIN_DIR
+#define PCAP_PLUGIN_DIR	"/usr/local/lib/pcap/plugins"
+#endif
+
+#define MAX_PLUGINS	16
+
+static struct pcap_plugin *plugins[MAX_PLUGINS];
+static int n_plugins;
+static int plugins_loaded;
+
+#ifndef _WIN32
+/*
+ * Get the value of an environment variable, but only when the process
+ * is NOT running with elevated privileges. Returns NULL if privileged.
+ *
+ * This follows the OpenSSL provider model: secure_getenv() on glibc,
+ * with fallbacks for BSD (issetugid) and other systems (getauxval,
+ * uid/euid comparison).
+ */
+static const char *
+pcap_secure_getenv(const char *name)
+{
+#ifdef HAVE_SECURE_GETENV
+	return (secure_getenv(name));
+#elif defined(HAVE_ISSETUGID)
+	if (issetugid())
+		return (NULL);
+	return (getenv(name));
+#elif defined(HAVE_GETAUXVAL)
+	if (getauxval(AT_SECURE))
+		return (NULL);
+	return (getenv(name));
+#else
+	if (getuid() != geteuid() || getgid() != getegid())
+		return (NULL);
+	return (getenv(name));
+#endif
+}
+
+static void
+load_plugin(const char *path)
+{
+	pcap_code_handle_t handle;
+	struct pcap_plugin *p;
+
+	if (n_plugins >= MAX_PLUGINS) {
+		fprintf(stderr,
+		    "libpcap: too many plugins (max %d), skipping \"%s\"\n",
+		    MAX_PLUGINS, path);
+		return;
+	}
+
+	handle = pcapint_load_code(path);
+	if (handle == NULL) {
+		fprintf(stderr,
+		    "libpcap: cannot load plugin \"%s\": %s\n",
+		    path, dlerror());
+		return;
+	}
+
+	p = pcapint_find_function(handle, "pcap_plugin_entry");
+	if (p == NULL) {
+		fprintf(stderr,
+		    "libpcap: plugin \"%s\" has no pcap_plugin_entry "
+		    "symbol\n", path);
+		pcapint_unload_code(handle);
+		return;
+	}
+	if (p->abi_version != PCAP_PLUGIN_ABI_VERSION) {
+		fprintf(stderr,
+		    "libpcap: plugin \"%s\" ABI version %d != expected %d\n",
+		    path, p->abi_version, PCAP_PLUGIN_ABI_VERSION);
+		pcapint_unload_code(handle);
+		return;
+	}
+	if (p->name == NULL || p->create == NULL) {
+		fprintf(stderr,
+		    "libpcap: plugin \"%s\" has NULL name or create\n",
+		    path);
+		pcapint_unload_code(handle);
+		return;
+	}
+
+	plugins[n_plugins++] = p;
+	/*
+	 * Intentionally leak the dlopen handle: the plugin stays loaded
+	 * for the lifetime of the process.
+	 */
+}
+
+static void
+scan_dir(const char *dirpath)
+{
+	DIR *d;
+	struct dirent *ent;
+
+	d = opendir(dirpath);
+	if (d == NULL)
+		return;
+
+	while ((ent = readdir(d)) != NULL) {
+		const char *name = ent->d_name;
+		size_t len = strlen(name);
+		char path[4096];
+
+		/* match pcap-*.so */
+		if (len < 8)	/* strlen("pcap-.so") */
+			continue;
+		if (strncmp(name, "pcap-", 5) != 0)
+			continue;
+		if (strcmp(name + len - 3, ".so") != 0)
+			continue;
+
+		snprintf(path, sizeof(path), "%s/%s", dirpath, name);
+		load_plugin(path);
+	}
+	closedir(d);
+}
+
+static void
+load_plugins(void)
+{
+	const char *env;
+
+	if (plugins_loaded)
+		return;
+	plugins_loaded = 1;
+
+	/*
+	 * $PCAP_PLUGIN_DIR is read through pcap_secure_getenv():
+	 * automatically returns NULL under elevated privileges
+	 * (setuid, setgid, file capabilities, LSM transitions),
+	 * matching how OpenSSL handles OPENSSL_MODULES and how
+	 * ld-linux.so handles LD_LIBRARY_PATH.
+	 */
+	env = pcap_secure_getenv("PCAP_PLUGIN_DIR");
+	if (env != NULL && env[0] != '\0') {
+		char *dirs, *dir, *saveptr;
+
+		dirs = strdup(env);
+		if (dirs != NULL) {
+			for (dir = strtok_r(dirs, ":", &saveptr);
+			     dir != NULL;
+			     dir = strtok_r(NULL, ":", &saveptr)) {
+				scan_dir(dir);
+			}
+			free(dirs);
+		}
+	}
+
+	scan_dir(PCAP_PLUGIN_DIR);
+}
+#else /* _WIN32 */
+static void
+load_plugins(void)
+{
+	/*
+	 * Windows plugin loading: not yet implemented.
+	 *
+	 * When implemented, this would use FindFirstFileA/FindNextFileA
+	 * to scan a plugin directory for pcap-*.dll files, then call
+	 * pcapint_load_code() and pcapint_find_function() for each.
+	 *
+	 * Note: the existing pcapint_load_code() on Windows prepends
+	 * GetSystemDirectoryA(), which is not suitable for plugins in
+	 * custom directories. A future implementation would need a
+	 * variant that takes an absolute path.
+	 */
+}
+#endif /* _WIN32 */
+
+pcap_t *
+pcap_plugin_dispatch_create(const char *device, char *errbuf, int *is_ours)
+{
+	int i;
+
+	load_plugins();
+
+	for (i = 0; i < n_plugins; i++) {
+		pcap_t *p = plugins[i]->create(device, errbuf, is_ours);
+		if (*is_ours)
+			return p;
+	}
+
+	*is_ours = 0;
+	return NULL;
+}
+
+int
+pcap_plugin_dispatch_findalldevs(pcap_if_list_t *devlistp, char *errbuf)
+{
+	int i;
+
+	load_plugins();
+
+	for (i = 0; i < n_plugins; i++) {
+		if (plugins[i]->findalldevs == NULL)
+			continue;
+		if (plugins[i]->findalldevs(devlistp, errbuf) == -1)
+			return -1;
+	}
+	return 0;
+}
+
+/*
+ * Plugin helper functions — exported wrappers around internal
+ * libpcap functions and struct pcap accessors. These have PCAP_API
+ * (default visibility) so plugins can call them from dlopen'd .so
+ * modules without needing pcap-int.h.
+ */
+
+pcap_t *
+pcap_plugin_create_handle(char *errbuf, size_t priv_size)
+{
+	return pcapint_create_common(errbuf,
+	    sizeof(pcap_t) + priv_size, sizeof(pcap_t));
+}
+
+void *
+pcap_plugin_priv(pcap_t *p)
+{
+	return p->priv;
+}
+
+void
+pcap_plugin_set_activate(pcap_t *p, int (*activate_op)(pcap_t *))
+{
+	p->activate_op = activate_op;
+}
+
+void
+pcap_plugin_set_ops(pcap_t *p, const struct pcap_plugin_ops *ops)
+{
+	if (ops->read != NULL)
+		p->read_op = ops->read;
+	if (ops->inject != NULL)
+		p->inject_op = ops->inject;
+	if (ops->setfilter != NULL)
+		p->setfilter_op = ops->setfilter;
+	if (ops->setdirection != NULL)
+		p->setdirection_op = ops->setdirection;
+	if (ops->set_datalink != NULL)
+		p->set_datalink_op = ops->set_datalink;
+	if (ops->getnonblock != NULL)
+		p->getnonblock_op = ops->getnonblock;
+	if (ops->setnonblock != NULL)
+		p->setnonblock_op = ops->setnonblock;
+	if (ops->stats != NULL)
+		p->stats_op = ops->stats;
+	if (ops->cleanup != NULL)
+		p->cleanup_op = ops->cleanup;
+	if (ops->breakloop_func != NULL)
+		p->breakloop_op = ops->breakloop_func;
+}
+
+void
+pcap_plugin_set_linktype(pcap_t *p, int linktype)
+{
+	p->linktype = linktype;
+}
+
+void
+pcap_plugin_set_snapshot(pcap_t *p, int snaplen)
+{
+	p->snapshot = snaplen;
+}
+
+void
+pcap_plugin_set_select_timeout(pcap_t *p, struct timeval *tv)
+{
+#ifndef _WIN32
+	p->required_select_timeout = tv;
+#endif
+}
+
+const char *
+pcap_plugin_get_device(pcap_t *p)
+{
+	return p->opt.device;
+}
+
+int
+pcap_plugin_get_snapshot(pcap_t *p)
+{
+	return p->snapshot;
+}
+
+int
+pcap_plugin_get_timeout(pcap_t *p)
+{
+	return p->opt.timeout;
+}
+
+int
+pcap_plugin_check_break_loop(pcap_t *p)
+{
+	if (p->break_loop) {
+		p->break_loop = 0;
+		return 1;
+	}
+	return 0;
+}
+
+struct bpf_insn *
+pcap_plugin_get_filter(pcap_t *p)
+{
+	return p->fcode.bf_insns;
+}
+
+void
+pcap_plugin_set_errbuf(pcap_t *p, const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	vsnprintf(p->errbuf, PCAP_ERRBUF_SIZE, fmt, ap);
+	va_end(ap);
+}
+
+void
+pcap_plugin_cleanup_live(pcap_t *p)
+{
+	pcapint_cleanup_live_common(p);
+}
+
+void
+pcap_plugin_breakloop(pcap_t *p)
+{
+	pcapint_breakloop_common(p);
+}
+
+int
+pcap_plugin_install_bpf(pcap_t *p, struct bpf_program *fp)
+{
+	return pcapint_install_bpf_program(p, fp);
+}
+
+unsigned int
+pcap_plugin_filter(const struct bpf_insn *pc, const unsigned char *pkt,
+    unsigned int wirelen, unsigned int caplen)
+{
+	return pcapint_filter(pc, pkt, wirelen, caplen);
+}
+
+pcap_if_t *
+pcap_plugin_add_dev(pcap_if_list_t *devlistp, const char *name,
+    unsigned int flags, const char *description, char *errbuf)
+{
+	return pcapint_add_dev(devlistp, name, (bpf_u_int32)flags,
+	    description, errbuf);
+}

--- a/pcap-plugin.h
+++ b/pcap-plugin.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026 Vincent Jardin, Free Mobile, Iliad
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+pcap_t *pcap_plugin_dispatch_create(const char *, char *, int *);
+int pcap_plugin_dispatch_findalldevs(pcap_if_list_t *, char *);

--- a/pcap.c
+++ b/pcap.c
@@ -124,6 +124,8 @@
 #include "pcap-dpdk.h"
 #endif
 
+#include "pcap-plugin.h"
+
 #ifdef ENABLE_REMOTE
 #include "pcap-rpcap.h"
 #endif
@@ -657,6 +659,7 @@ static struct capture_source_type {
 #ifdef PCAP_SUPPORT_RDMASNIFF
 	{ rdmasniff_findalldevs, rdmasniff_create },
 #endif
+	{ pcap_plugin_dispatch_findalldevs, pcap_plugin_dispatch_create },
 #ifdef PCAP_SUPPORT_DPDK
 	{ pcap_dpdk_findalldevs, pcap_dpdk_create },
 #endif
@@ -4336,7 +4339,6 @@ pcap_close(pcap_t *p)
 
 /*
  * Helpers for safely loading code at run time.
- * Currently Windows-only.
  */
 #ifdef _WIN32
 //
@@ -4420,7 +4422,33 @@ pcapint_find_function(pcap_code_handle_t code, const char *func)
 {
 	return ((void *)GetProcAddress(code, func));
 }
-#endif
+
+void
+pcapint_unload_code(pcap_code_handle_t code)
+{
+	FreeLibrary(code);
+}
+#else /* _WIN32 */
+#include <dlfcn.h>
+
+pcap_code_handle_t
+pcapint_load_code(const char *path)
+{
+	return (dlopen(path, RTLD_NOW));
+}
+
+void *
+pcapint_find_function(pcap_code_handle_t code, const char *func)
+{
+	return (dlsym(code, func));
+}
+
+void
+pcapint_unload_code(pcap_code_handle_t code)
+{
+	dlclose(code);
+}
+#endif /* _WIN32 */
 
 /*
  * Given a BPF program, a pcap_pkthdr structure for a packet, and the raw

--- a/pcap/pcap-plugin.h
+++ b/pcap/pcap-plugin.h
@@ -195,10 +195,36 @@ PCAP_API void pcap_plugin_set_errbuf(pcap_t *p,
 
 /*
  * Get the timestamp type requested by the user (e.g. PCAP_TSTAMP_ADAPTER).
- * Returns PCAP_TSTAMP_HOST if none was explicitly set.
+ * Returns -1 (not set) if none was explicitly requested.
  * Call during activate to decide which clock source to use.
  */
 PCAP_API int pcap_plugin_get_tstamp_type(pcap_t *p);
+
+/*
+ * Get the timestamp precision requested by the user.
+ * Returns PCAP_TSTAMP_PRECISION_MICRO (default) or
+ * PCAP_TSTAMP_PRECISION_NANO. Call during activate to decide
+ * whether to provide nanosecond timestamps.
+ */
+PCAP_API int pcap_plugin_get_tstamp_precision(pcap_t *p);
+
+/*
+ * Get the promiscuous mode flag (nonzero = user requested promisc).
+ * Call during activate.
+ */
+PCAP_API int pcap_plugin_get_promisc(pcap_t *p);
+
+/*
+ * Get the buffer size requested by the user (0 = platform default).
+ * Call during activate to size ring buffers or mempools.
+ */
+PCAP_API int pcap_plugin_get_buffer_size(pcap_t *p);
+
+/*
+ * Get the immediate mode flag (nonzero = deliver packets ASAP,
+ * don't wait to fill a buffer). Call during activate.
+ */
+PCAP_API int pcap_plugin_get_immediate(pcap_t *p);
 
 /*
  * Advertise supported timestamp types to libpcap. Call during create
@@ -207,6 +233,31 @@ PCAP_API int pcap_plugin_get_tstamp_type(pcap_t *p);
  */
 PCAP_API int pcap_plugin_set_tstamp_type_list(pcap_t *p,
     const int *types, int count);
+
+/*
+ * Advertise supported timestamp precisions. Call during create
+ * so pcap_list_tstamp_precisions() works. The array is copied.
+ * Returns 0 on success, -1 on allocation failure.
+ */
+PCAP_API int pcap_plugin_set_tstamp_precision_list(pcap_t *p,
+    const int *precisions, int count);
+
+/*
+ * Advertise supported data link types. Call during activate
+ * so pcap_list_datalinks() works. The array is copied.
+ * Returns 0 on success, -1 on allocation failure.
+ */
+PCAP_API int pcap_plugin_set_datalink_list(pcap_t *p,
+    const int *dlts, int count);
+
+/*
+ * Set the selectable file descriptor for poll/select/epoll.
+ * Plugins that can provide a pollable fd (e.g. eventfd, unix socket)
+ * should call this during activate. Set to -1 if not pollable
+ * (then also set a required_select_timeout via
+ * pcap_plugin_set_select_timeout).
+ */
+PCAP_API void pcap_plugin_set_selectable_fd(pcap_t *p, int fd);
 
 /* ---- Helper functions ---- */
 

--- a/pcap/pcap-plugin.h
+++ b/pcap/pcap-plugin.h
@@ -193,6 +193,21 @@ PCAP_API struct bpf_insn *pcap_plugin_get_filter(pcap_t *p);
 PCAP_API void pcap_plugin_set_errbuf(pcap_t *p,
     PCAP_FORMAT_STRING(const char *fmt), ...) PCAP_PRINTFLIKE(2, 3);
 
+/*
+ * Get the timestamp type requested by the user (e.g. PCAP_TSTAMP_ADAPTER).
+ * Returns PCAP_TSTAMP_HOST if none was explicitly set.
+ * Call during activate to decide which clock source to use.
+ */
+PCAP_API int pcap_plugin_get_tstamp_type(pcap_t *p);
+
+/*
+ * Advertise supported timestamp types to libpcap. Call during create
+ * (before activate) so pcap_list_tstamp_types() works. The types
+ * array is copied. Returns 0 on success, -1 on allocation failure.
+ */
+PCAP_API int pcap_plugin_set_tstamp_type_list(pcap_t *p,
+    const int *types, int count);
+
 /* ---- Helper functions ---- */
 
 /*

--- a/pcap/pcap-plugin.h
+++ b/pcap/pcap-plugin.h
@@ -1,0 +1,228 @@
+/*
+ * Copyright (c) 2026 Vincent Jardin, Free Mobile, Iliad
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ *   1. Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *   2. Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS''AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef pcap_plugin_h
+#define pcap_plugin_h
+
+/*
+ * Public plugin ABI for libpcap capture backends.
+ *
+ * External projects can build shared modules (pcap-*.so) that libpcap
+ * discovers and loads at runtime via dlopen(). This avoids compiling
+ * backend-specific code into libpcap itself.
+ *
+ * Each plugin .so exports a single symbol "pcap_plugin_entry" of type
+ * struct pcap_plugin. The loader (pcap-plugin.c) scans plugin directories,
+ * dlopen's each pcap-*.so, and dispatches findalldevs/create calls.
+ *
+ * Plugins link against libpcap (-lpcap) and use the pcap_plugin_*
+ * accessor/helper functions declared below instead of accessing the
+ * pcap_t struct directly (which would require pcap-int.h). All
+ * pcap_plugin_* functions have default visibility and are safe to call
+ * from dlopen'd modules.
+ */
+
+#include <pcap/pcap.h>
+
+/*
+ * pcap_if_list_t is defined in pcap-int.h (not public).
+ * Forward-declare it here so plugins can use the findalldevs callback
+ * and pcap_plugin_add_dev() without including pcap-int.h.
+ *
+ * Guard against duplicate typedef when pcap-int.h is already included
+ * (C99 does not allow duplicate typedefs; C11 does, but some compilers
+ * reject it with -Werror,-Wtypedef-redefinition).
+ */
+#ifndef pcap_int_h
+struct pcap_if_list;
+typedef struct pcap_if_list pcap_if_list_t;
+#endif
+
+#define PCAP_PLUGIN_ABI_VERSION	1
+
+/*
+ * Maximum snapshot length. Same value as MAXIMUM_SNAPLEN in pcap-int.h.
+ * Plugins should clamp snapshots to this value.
+ */
+#define PCAP_PLUGIN_SNAPLEN_MAX	262144
+
+/*
+ * Each plugin .so exports one instance of this struct as the symbol
+ * "pcap_plugin_entry".
+ */
+struct pcap_plugin {
+	int abi_version;	/* must be PCAP_PLUGIN_ABI_VERSION */
+	const char *name;	/* short name, e.g. "grout" */
+	int (*findalldevs)(pcap_if_list_t *, char *);
+	pcap_t *(*create)(const char *device, char *errbuf, int *is_ours);
+};
+
+/*
+ * Function pointer types for pcap operations.
+ * These match the types used internally by libpcap.
+ */
+typedef int	(*pcap_plugin_read_op)(pcap_t *, int, pcap_handler, u_char *);
+typedef int	(*pcap_plugin_inject_op)(pcap_t *, const void *, int);
+typedef int	(*pcap_plugin_setfilter_op)(pcap_t *, struct bpf_program *);
+typedef int	(*pcap_plugin_setdirection_op)(pcap_t *, pcap_direction_t);
+typedef int	(*pcap_plugin_set_datalink_op)(pcap_t *, int);
+typedef int	(*pcap_plugin_getnonblock_op)(pcap_t *);
+typedef int	(*pcap_plugin_setnonblock_op)(pcap_t *, int);
+typedef int	(*pcap_plugin_stats_op)(pcap_t *, struct pcap_stat *);
+typedef void	(*pcap_plugin_cleanup_op)(pcap_t *);
+typedef void	(*pcap_plugin_breakloop_op)(pcap_t *);
+
+/*
+ * Capture backend operations. Set all applicable fields, then call
+ * pcap_plugin_set_ops() during activate.
+ */
+struct pcap_plugin_ops {
+	pcap_plugin_read_op read;
+	pcap_plugin_inject_op inject;
+	pcap_plugin_setfilter_op setfilter;
+	pcap_plugin_setdirection_op setdirection;
+	pcap_plugin_set_datalink_op set_datalink;
+	pcap_plugin_getnonblock_op getnonblock;
+	pcap_plugin_setnonblock_op setnonblock;
+	pcap_plugin_stats_op stats;
+	pcap_plugin_cleanup_op cleanup;
+	pcap_plugin_breakloop_op breakloop_func;
+};
+
+/* ---- Handle allocation ---- */
+
+/*
+ * Allocate a pcap_t with space for priv_size bytes of private data.
+ * Returns NULL on failure (errbuf filled in).
+ */
+PCAP_API pcap_t *pcap_plugin_create_handle(char *errbuf, size_t priv_size);
+
+/*
+ * Get the private data pointer from a pcap_t.
+ */
+PCAP_API void *pcap_plugin_priv(pcap_t *p);
+
+/* ---- Handle configuration (call during create/activate) ---- */
+
+/*
+ * Set the activate callback. Call from your create function.
+ */
+PCAP_API void pcap_plugin_set_activate(pcap_t *p,
+    int (*activate_op)(pcap_t *));
+
+/*
+ * Install all capture operations at once. Call from your activate
+ * function. NULL entries are left unchanged (libpcap defaults).
+ */
+PCAP_API void pcap_plugin_set_ops(pcap_t *p,
+    const struct pcap_plugin_ops *ops);
+
+/*
+ * Set the link-layer type (e.g. DLT_EN10MB). Call from activate.
+ */
+PCAP_API void pcap_plugin_set_linktype(pcap_t *p, int linktype);
+
+/*
+ * Set the snapshot length. Call from activate if you need to override
+ * the user-requested value.
+ */
+PCAP_API void pcap_plugin_set_snapshot(pcap_t *p, int snaplen);
+
+/*
+ * Set the required select timeout for poll-based plugins.
+ * The pointer must remain valid for the lifetime of the pcap_t.
+ */
+PCAP_API void pcap_plugin_set_select_timeout(pcap_t *p, struct timeval *tv);
+
+/* ---- Handle accessors (call during dispatch/activate) ---- */
+
+/*
+ * Get the device name string (e.g. "grout:p0").
+ */
+PCAP_API const char *pcap_plugin_get_device(pcap_t *p);
+
+/*
+ * Get the current snapshot length.
+ */
+PCAP_API int pcap_plugin_get_snapshot(pcap_t *p);
+
+/*
+ * Get the read timeout in milliseconds (0 = no timeout).
+ */
+PCAP_API int pcap_plugin_get_timeout(pcap_t *p);
+
+/*
+ * Check and clear the break_loop flag. Returns nonzero if a break
+ * was requested. Plugins should call this in their dispatch loop.
+ */
+PCAP_API int pcap_plugin_check_break_loop(pcap_t *p);
+
+/*
+ * Get the compiled BPF filter instructions, or NULL if no filter
+ * is installed. For plugins that do in-kernel/hardware filtering,
+ * this is the fallback software filter.
+ */
+PCAP_API struct bpf_insn *pcap_plugin_get_filter(pcap_t *p);
+
+/*
+ * Format an error message into the pcap_t's error buffer.
+ */
+PCAP_API void pcap_plugin_set_errbuf(pcap_t *p,
+    PCAP_FORMAT_STRING(const char *fmt), ...) PCAP_PRINTFLIKE(2, 3);
+
+/* ---- Helper functions ---- */
+
+/*
+ * Common cleanup for live captures. Call from your cleanup_op.
+ */
+PCAP_API void pcap_plugin_cleanup_live(pcap_t *p);
+
+/*
+ * Standard breakloop implementation. Use as breakloop_func in ops,
+ * or call from your own breakloop.
+ */
+PCAP_API void pcap_plugin_breakloop(pcap_t *p);
+
+/*
+ * Install a BPF filter program (deep copy). Call from your setfilter_op
+ * to install the filter locally for pcap_plugin_filter() fallback.
+ */
+PCAP_API int pcap_plugin_install_bpf(pcap_t *p, struct bpf_program *fp);
+
+/*
+ * Run a BPF filter on a packet. Returns nonzero if the packet matches.
+ */
+PCAP_API unsigned int pcap_plugin_filter(const struct bpf_insn *pc,
+    const unsigned char *pkt, unsigned int wirelen, unsigned int caplen);
+
+/*
+ * Add a device entry to a device list (for findalldevs).
+ */
+PCAP_API pcap_if_t *pcap_plugin_add_dev(pcap_if_list_t *devlistp,
+    const char *name, unsigned int flags, const char *description,
+    char *errbuf);
+
+#endif /* pcap_plugin_h */


### PR DESCRIPTION
Dataplanes like DPDK expose unstable APIs that change across releases. Compiling backends for these dataplanes directly into libpcap ties the two release cycles together: a DPDK API change breaks the libpcap build, and fixing it requires a coordinated update of both projects. The same problem applies to any fast-moving dataplane (grout, VPP, etc.) whose capture interface evolves independently from libpcap.

Add a generic plugin loader (pcap-plugin.c) that discovers external capture backends at runtime. Each backend ships as a pcap-*.so shared module in a well-known directory. The loader dlopen's every matching file, looks up a "pcap_plugin_entry" symbol, validates the ABI version, and dispatches findalldevs/create calls through it. Backends are found in $PCAP_PLUGIN_DIR (colon-separated), /usr/lib/pcap/plugins, and /usr/local/lib/pcap/plugins.

Because pcap-int.h is not installed, plugins cannot access the pcap_t struct directly. A set of pcap_plugin_* accessor functions is exported with default visibility: handle allocation, ops registration, field getters/setters, BPF helpers, and device enumeration. This gives plugins a stable ABI (versioned via PCAP_PLUGIN_ABI_VERSION) without exposing libpcap internals.

With this mechanism, a dataplane project builds its own pcap-*.so against its own headers and ships it alongside its packages. Upgrading the dataplane only requires rebuilding the plugin, not libpcap. If the plugin is absent or fails to load, libpcap keeps working — no compile time dependency, no conditional #ifdefs.