### PR TITLE
Hardening: Fix memory leak in pcapng fail path and secure realloc logic

### DIFF
--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -343,6 +343,7 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 			return (-1);
 		}
 		p->buffer = bigger_buffer;
+		p->bufsize = bhdr.total_length;
 	}
 
 	/*
@@ -902,9 +903,7 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 	default:
 		snprintf(errbuf, PCAP_ERRBUF_SIZE,
 		    "unknown time stamp resolution %u", precision);
-		free(p);
-		*err = 1;
-		return (NULL);
+		goto fail;
 	}
 
 	p->opt.tstamp_precision = precision;
@@ -931,9 +930,7 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 	p->buffer = malloc(p->bufsize);
 	if (p->buffer == NULL) {
 		snprintf(errbuf, PCAP_ERRBUF_SIZE, "out of memory");
-		free(p);
-		*err = 1;
-		return (NULL);
+		goto fail;
 	}
 	ps->max_blocksize = INITIAL_MAX_BLOCKSIZE;
 


### PR DESCRIPTION
This is a pure C99 follow-up to the discussions in PR #1664, isolating the parser hardening and memory leak fixes as recommended by @guyharris and @mcr.

### What this PR changes:
* **Fixes Memory Leaks in `pcap_ng_check_header`:** Reroutes early error returns (such as unknown timestamp precision or `p->buffer` allocation failures) through the `goto fail` path. This ensures that `ps->ifaces` and `p->buffer` are properly freed before returning `NULL`.
* **Hardens `realloc` state in `read_block`:** Ensures that when `p->buffer` is successfully expanded via `realloc` into a temporary pointer, the metadata (`p->bufsize`) is correctly updated to track the new capacity. This prevents stale size tracking and repeated, unnecessary reallocation attempts.

This patch strictly adheres to the project's C99 requirements and introduces no changes to the build systems.