### PR TITLE
Neutralize rpcap_doauth_userinfo().

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -59,11 +59,9 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
         #1634, reported by FuzzAnything Organization
         (https://github.com/FuzzAnything-ORG) (fuzzanything@gmail.com).
     rpcap:
-      Support user names and passwords in rpcap:// and rpcaps:// URLs.
       Add a -t flag to rpcapd to specify the data channel port; from
         another incorporate-remote-capture project. (issue #1120)
       rpcapd: Refine SSL options in printusage().
-      Fix a possible buffer overflow (Coverity CID 1619148).
       Fix parameter name validation in the configuration file.
     Documentation:
       Add a README.hurd.md file.

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -156,6 +156,12 @@ extern int pcapint_mmap_32bit;
 #define MAXIMUM_SNAPLEN		262144
 
 /*
+ * Do not enable this feature!  rpcap_doauth_userinfo() is subject to a stack
+ * buffer overflow and must be either reimplemented or removed.
+ */
+#define RPCAP_USE_USERINFO 0
+
+/*
  * Locale-independent macros for testing character types.
  * These can be passed any integral value, without worrying about, for
  * example, sign-extending char values, unlike the C macros.

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -2241,6 +2241,7 @@ novers:
 	return -1;
 }
 
+#if RPCAP_USE_USERINFO
 /* non-alphanumeric unreserved characters plus sub-delims (RFC3986) */
 static const char userinfo_allowed_symbols[] = "-._~!&'()*+,;=";
 
@@ -2265,6 +2266,7 @@ static int rpcap_doauth_userinfo(PCAP_SOCKET sockctrl, SSL *ssl, uint8_t *ver,
 
 	if ((ptr = userinfo) != NULL)
 	{
+		// FIXME: 'pos' is not limited to the sizes of 'username' and 'password'.
 		for (int pos = -1; (buf[++pos] = *ptr) != '\0'; ++ptr)
 		{
 			/* handle %xx encoded characters */
@@ -2314,6 +2316,7 @@ static int rpcap_doauth_userinfo(PCAP_SOCKET sockctrl, SSL *ssl, uint8_t *ver,
 
 	return rpcap_doauth(sockctrl, ssl, ver, byte_swapped, NULL, errbuf);
 }
+#endif // RPCAP_USE_USERINFO
 
 
 /* We don't currently support non-blocking mode. */
@@ -2458,12 +2461,14 @@ rpcap_setup_session(const char *source, struct pcap_rmtauth *auth,
 #endif
 		}
 
+#if RPCAP_USE_USERINFO
 		if (auth == NULL && *userinfo != '\0')
 		{
 			auth_result = rpcap_doauth_userinfo(*sockctrlp, *sslp,
 			    protocol_versionp, byte_swappedp, userinfo, errbuf);
 		}
 		else
+#endif // RPCAP_USE_USERINFO
 		{
 			auth_result = rpcap_doauth(*sockctrlp, *sslp,
 			    protocol_versionp, byte_swappedp, auth, errbuf);

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -936,7 +936,7 @@ PCAP_API const char *pcap_lib_version(void);
  * - file://path_and_filename [opens a local file]
  * - rpcap://devicename [opens the selected device available on the local host, without using the RPCAP protocol]
  * - rpcap://[username:password@]host[:port]/devicename [opens the selected device available on a remote host]
- *   - username and password, if present, will be used to authenticate to the remote host
+ *   - username and password, if present, will be ignored
  *   - port, if present, will specify a port for RPCAP rather than using the default
  * - adaptername [to open a local adapter; kept for compatibility, but it is strongly discouraged]
  * - (NULL) [equivalent to "any"; kept for compatibility, but it is strongly discouraged]
@@ -945,7 +945,7 @@ PCAP_API const char *pcap_lib_version(void);
  * - file://folder/ [lists all the files in the given folder]
  * - rpcap:// [lists all local adapters]
  * - rpcap://[username:password@]host[:port]/ [lists the devices available on a remote host]
- *   - username and password, if present, will be used to authenticate to the remote host
+ *   - username and password, if present, will be ignored
  *   - port, if present, will specify a port for RPCAP rather than using the default
  *
  * In all the above, "rpcaps://" can be substituted for "rpcap://" to enable


### PR DESCRIPTION
This is a follow-up to pull request #1079.