### PR TITLE
Add support for install-strip target

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -76,6 +76,7 @@ INSTALL = @INSTALL@
 INSTALL_PROGRAM = @INSTALL_PROGRAM@
 INSTALL_DATA = @INSTALL_DATA@
 RANLIB = @RANLIB@
+STRIP = @STRIP@
 
 LEX = @LEX@
 BISON_BYACC = @BISON_BYACC@
@@ -641,6 +642,13 @@ install: install-shared install-archive libpcap.pc pcap-config @INSTALL_RPCAPD@
 	for i in $(MANMISC); do \
 		$(INSTALL_DATA) `echo $$i | sed 's/.manmisc.in/.manmisc/'` \
 		    $(DESTDIR)$(mandir)/man@MAN_MISC_INFO@/`echo $$i | sed 's/.manmisc.in/.@MAN_MISC_INFO@/'`; done
+
+install-strip: install
+	VER=`cat $(srcdir)/VERSION`; \
+	MAJOR_VER=`sed 's/\([0-9][0-9]*\)\..*/\1/' $(srcdir)/VERSION`; \
+	$(STRIP) $(DESTDIR)$(libdir)/libpcap.so.$$VER 2>/dev/null || :; \
+	$(STRIP) $(DESTDIR)$(libdir)/libpcap.$$VER.dylib 2>/dev/null || :; \
+	$(STRIP) $(DESTDIR)$(libdir)/libpcap.$$MAJOR_VER 2>/dev/null || :
 
 install-shared: install-shared-$(DYEXT)
 install-shared-so: libpcap.so

--- a/configure.ac
+++ b/configure.ac
@@ -2350,6 +2350,7 @@ test "x$enable_shared" = "xno" && DYEXT="none"
 
 AC_PROG_RANLIB
 AC_CHECK_TOOL([AR], [ar])
+AC_CHECK_TOOL([STRIP], [strip], [:])
 
 AC_PROG_LN_S
 AC_SUBST(LN_S)


### PR DESCRIPTION
Hello!

The [GNU standard targets](https://www.gnu.org/software/make/manual/html_node/Standard-Targets.html) point to `install-strip` as a known target, where it invokes `strip` in order to remove symbols from binaries. 

As the `libpcap` is heavily used in memory-constrained embedded environments, allowing an immediate stripped install helps the creation of lightweight root filesystems, like when using Buildroot or Yocto. For a regular Desktop application, it can still remove debug symbols.

I built locally on Linux to validate this new target: [libpcap-1.11.0-linux-amd64-gcc13-release-shared-stripped.log](https://github.com/user-attachments/files/26747600/libpcap-1.11.0-linux-amd64-gcc13-release-shared-stripped.log)

#### Steps to Reproduce

```
mkdir build && cd build/
autoreconf --install --force --verbose .. 
../configure --prefix=/tmp/install --enable-shared
make
make install-strip
file /tmp/install/lib/libpcap.so.1.11.0-PRE-GIT
```

Regards! 