### PR TITLE
dlpi: fix an unused variable error

### DIFF
--- a/pcap-dlpi.c
+++ b/pcap-dlpi.c
@@ -956,7 +956,6 @@ static char *
 split_dname(char *device, u_int *unitp, char *ebuf)
 {
 	char *cp;
-	char *eos;
 	u_int unit;
 	int ret;
 


### PR DESCRIPTION
```
pcap-dlpi.c: In function 'split_dname':
pcap-dlpi.c:959:8: error: unused variable 'eos' [-Werror=unused-variable]
  959 |  char *eos;                                                                   
      |        ^~~

(found on cfarm210 with gcc)
```