### PR TITLE
Silence -Wuninitialized-const-pointer for setsockopt() in valgrindtest.c

### DIFF
--- a/diag-control.h
+++ b/diag-control.h
@@ -149,6 +149,15 @@
     PCAP_DO_PRAGMA(clang diagnostic ignored "-Wsign-compare")
   #define DIAG_ON_SIGN_COMPARE \
     PCAP_DO_PRAGMA(clang diagnostic pop)
+
+  #if PCAP_IS_AT_LEAST_CLANG_VERSION(21,1)
+    #define DIAG_OFF_UNINITIALIZED_CONST_POINTER \
+      PCAP_DO_PRAGMA(clang diagnostic push) \
+      PCAP_DO_PRAGMA(clang diagnostic ignored "-Wuninitialized-const-pointer")
+    #define and DIAG_ON_UNINITIALIZED_CONST_POINTER \
+      PCAP_DO_PRAGMA(clang diagnostic pop)
+  #endif
+
 #elif defined(_MSC_VER)
   /*
    * This is Microsoft Visual Studio; we can use __pragma(warning(disable:XXXX))
@@ -422,6 +431,12 @@
 #endif
 #ifndef DIAG_ON_SIGN_COMPARE
 #define DIAG_ON_SIGN_COMPARE
+#endif
+#ifndef DIAG_OFF_UNINITIALIZED_CONST_POINTER
+#define DIAG_OFF_UNINITIALIZED_CONST_POINTER
+#endif
+#ifndef DIAG_ON_UNINITIALIZED_CONST_POINTER
+#define DIAG_ON_UNINITIALIZED_CONST_POINTER
 #endif
 #ifndef PCAP_UNREACHABLE
 #define PCAP_UNREACHABLE

--- a/testprogs/valgrindtest.c
+++ b/testprogs/valgrindtest.c
@@ -20,6 +20,7 @@
  */
 
 #include "varattrs.h"
+#include "diag-control.h"
 
 /*
  * This doesn't actually test libpcap itself; it tests whether
@@ -404,8 +405,15 @@ main(int argc, char **argv)
 #if defined(USE_BPF)
 	ioctl(pcap_fd, BIOCSETF, &bad_fcode);
 #elif defined(USE_SOCKET_FILTERS)
+	/*
+	 * The point of this test is not to initialize bad_fcode, as we're
+	 * testing to make sure that valgrind will complain that the structure
+	 * isn't initialized.
+	 */
+DIAG_OFF_UNINITIALIZED_CONST_POINTER
 	setsockopt(pcap_fd, SOL_SOCKET, SO_ATTACH_FILTER, &bad_fcode,
 	    sizeof(bad_fcode));
+DIAG_ON_UNINITIALIZED_CONST_POINTER
 #endif
 
 	/*


### PR DESCRIPTION
Because it is the expected behavior, see #1607.

Clang >= 21.1.0.

Based on Guy diagnostic.

```
./valgrindtest.c:407:53: error: variable 'bad_fcode' is
      uninitialized when passed as a const pointer argument here
      [-Werror,-Wuninitialized-const-pointer]
  407 |         setsockopt(pcap_fd, SOL_SOCKET, SO_ATTACH_FILTER, &bad_fcode,
      |                                                            ^~~~~~~~~
1 error generated.
```
(cherry picked from commit 7a8f78b947edd7bf37ccb460df6b6594245402ba)