### PR TITLE
Add DLT_/LINKTYPE_ values for DECT_NR_TAP

### DIFF
--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1312,7 +1312,15 @@
 // See DLT_DEBUG_ONLY
 #define LINKTYPE_DEBUG_ONLY	303
 
-#define LINKTYPE_HIGH_MATCHING_MAX	303		/* highest value in the "matching" range */
+/*
+ * DECT-2020 New Radio (NR) TAP with custom metadata header.
+ * Specification at https://github.com/DSRCorporation/dect-nr-tap
+ *
+ * Requested by Edem Khadiev <edem.khadiev@dsr-corporation.com>
+ */
+#define LINKTYPE_DECT_NR_TAP		304
+
+#define LINKTYPE_HIGH_MATCHING_MAX	304		/* highest value in the "matching" range */
 
 /*
  * The DLT_ and LINKTYPE_ values in the "matching" range should be the

--- a/pcap.c
+++ b/pcap.c
@@ -3408,6 +3408,7 @@ static struct dlt_choice dlt_choices[] = {
 	DLT_CHOICE(USER15, "Private use 15"),
 	DLT_CHOICE(EDK2_MM, "EDK II MM request serialization protocol"),
 	DLT_CHOICE(DEBUG_ONLY, "unstructured data for manual debugging only"),
+	DLT_CHOICE(DECT_NR_TAP, "DECT-2020 New Radio TAP"),
 	DLT_CHOICE_SENTINEL
 };
 

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1689,6 +1689,15 @@
 #define DLT_DEBUG_ONLY		303
 
 /*
+ * DECT-2020 New Radio (NR) TAP with custom metadata header prepended to
+ * standard DLT_DECT_NR MAC-layer frame.
+ * Specification at https://github.com/DSRCorporation/dect-nr-tap
+ *
+ * Requested by Edem Khadiev <edem.khadiev@dsr-corporation.com>
+ */
+#define DLT_DECT_NR_TAP		304
+
+/*
  * In case the code that includes this file (directly or indirectly)
  * has also included OS files that happen to define DLT_HIGH_MATCHING_MAX,
  * with a different value (perhaps because that OS hasn't picked up
@@ -1699,6 +1708,6 @@
 #undef DLT_HIGH_MATCHING_MAX
 #endif
 
-#define DLT_HIGH_MATCHING_MAX	303	/* highest value in the "matching" range */
+#define DLT_HIGH_MATCHING_MAX	304	/* highest value in the "matching" range */
 
 #endif /* !defined(lib_pcap_dlt_h) */


### PR DESCRIPTION
Add DLT_/LINKTYPE_ values for DECT_NR_TAP

**Description**
I submitted a request to tcpdump-workers@lists.tcpdump.org two weeks ago to add a new link-layer type (DLT_DECT_NR_TAP) for DECT-2020 New Radio (NR) TAP header, but haven't received a response yet.

This PR adds the necessary support DLT_DECT_NR_TAP and LINKTYPE_DECT_NR_TAP with a value of 304, as requested.
