### PR TITLE
Fix some const warnings from GCC 16.

### DIFF
--- a/pcap.c
+++ b/pcap.c
@@ -1713,7 +1713,7 @@ static int
 pcap_parse_source(const char *source, char **schemep, char **userinfop,
     char **hostp, char **portp, char **pathp, char *ebuf)
 {
-	char *colonp;
+	const char *colonp;
 	size_t scheme_len;
 	char *scheme;
 	const char *endp;
@@ -1762,7 +1762,7 @@ pcap_parse_source(const char *source, char **schemep, char **userinfop,
 	 * include colons (e.g., I think some Solaris interfaces
 	 * might).
 	 */
-	colonp = strchr(source, ':');
+	colonp = (const char *)strchr(source, ':');
 	if (colonp == NULL) {
 		/*
 		 * The source is the device to open.

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -3098,7 +3098,7 @@ static void session_close(struct session *session)
 static int
 is_url(const char *source)
 {
-	char *colonp;
+	const char *colonp;
 
 	/*
 	 * RFC 3986 says:
@@ -3120,7 +3120,7 @@ is_url(const char *source)
 	 * include colons (e.g., I think some Solaris interfaces
 	 * might).
 	 */
-	colonp = strchr(source, ':');
+	colonp = (const char *)strchr(source, ':');
 	if (colonp == NULL)
 	{
 		/*


### PR DESCRIPTION
Constify some pointers to substrings that we don't modify.

Cast the result of strchr() to const before assigning it to those pointers.