### PR TITLE
Add pcap_setwritefilter() and pcap_lockfilter()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3627,6 +3627,8 @@ if(NOT MSVC)
         install_manpage_symlink(pcap_open_offline.3pcap pcap_fopen_offline_with_tstamp_precision.3pcap ${CMAKE_INSTALL_MANDIR}/man3)
         install_manpage_symlink(pcap_tstamp_type_val_to_name.3pcap pcap_tstamp_type_val_to_description.3pcap ${CMAKE_INSTALL_MANDIR}/man3)
         install_manpage_symlink(pcap_setnonblock.3pcap pcap_getnonblock.3pcap ${CMAKE_INSTALL_MANDIR}/man3)
+        install_manpage_symlink(pcap_setfilter.3pcap pcap_setwritefilter.3pcap ${CMAKE_INSTALL_MANDIR}/man3)
+        install_manpage_symlink(pcap_setfilter.3pcap pcap_lockfilter.3pcap ${CMAKE_INSTALL_MANDIR}/man3)
 
         set(MANFILE "")
         foreach(TEMPLATE_MANPAGE ${MANFILE_EXPAND})

--- a/Makefile.in
+++ b/Makefile.in
@@ -634,7 +634,11 @@ install: install-shared install-archive libpcap.pc pcap-config @INSTALL_RPCAPD@
 	rm -f pcap_tstamp_type_val_to_description.3pcap && \
 	$(LN_S) pcap_tstamp_type_val_to_name.3pcap pcap_tstamp_type_val_to_description.3pcap && \
 	rm -f pcap_getnonblock.3pcap && \
-	$(LN_S) pcap_setnonblock.3pcap pcap_getnonblock.3pcap)
+	$(LN_S) pcap_setnonblock.3pcap pcap_getnonblock.3pcap && \
+	rm -f pcap_setwritefilter.3pcap && \
+	$(LN_S) pcap_setfilter.3pcap pcap_setwritefilter.3pcap && \
+	rm -f pcap_lockfilter.3pcap && \
+	$(LN_S) pcap_setfilter.3pcap pcap_lockfilter.3pcap)
 	for i in $(MANFILE); do \
 		$(INSTALL_DATA) `echo $$i | sed 's/.manfile.in/.manfile/'` \
 		    $(DESTDIR)$(mandir)/man@MAN_FILE_FORMATS@/`echo $$i | sed 's/.manfile.in/.@MAN_FILE_FORMATS@/'`; done

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -251,6 +251,8 @@ static void remove_802_11(pcap_t *);
 static int pcap_can_set_rfmon_bpf(pcap_t *p);
 static int pcap_activate_bpf(pcap_t *p);
 static int pcap_setfilter_bpf(pcap_t *p, struct bpf_program *fp);
+static int pcap_setwritefilter_bpf(pcap_t *p, struct bpf_program *fp);
+static int pcap_lockfilter_bpf(pcap_t *p);
 static int pcap_setdirection_bpf(pcap_t *, pcap_direction_t);
 static int pcap_set_datalink_bpf(pcap_t *p, int dlt);
 
@@ -2767,6 +2769,8 @@ pcap_activate_bpf(pcap_t *p)
 	p->read_op = pcap_read_bpf;
 	p->inject_op = pcap_inject_bpf;
 	p->setfilter_op = pcap_setfilter_bpf;
+	p->setwritefilter_op = pcap_setwritefilter_bpf;
+	p->lockfilter_op = pcap_lockfilter_bpf;
 	p->setdirection_op = pcap_setdirection_bpf;
 	p->set_datalink_op = pcap_set_datalink_bpf;
 	p->getnonblock_op = pcap_getnonblock_bpf;
@@ -3558,6 +3562,42 @@ pcap_setfilter_bpf(pcap_t *p, struct bpf_program *fp)
 		return (-1);
 	pb->filtering_in_kernel = 0;	/* filtering in userland */
 	return (0);
+}
+
+static int
+pcap_setwritefilter_bpf(pcap_t *p, struct bpf_program *fp)
+{
+#ifdef BIOCSETWF
+	/*
+	 * Try to install the kernel filter.
+	 */
+	if (ioctl(p->fd, BIOCSETWF, (caddr_t)fp) == 0)
+		return (0);
+#else
+	(void)fp;
+	errno = ENOSYS;
+#endif
+	pcapint_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+	    errno, "BIOCSETWF");
+	return (-1);
+}
+
+static int
+pcap_lockfilter_bpf(pcap_t *p)
+{
+#ifdef BIOCLOCK
+	struct pcap_bpf *pb = p->priv;
+
+	if (pb->filtering_in_kernel == 0)
+		errno = EINVAL;
+	else if (ioctl(p->fd, BIOCLOCK) == 0)
+		return (0);
+#else
+	errno = ENOSYS;
+#endif
+	pcapint_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+	    errno, "BIOCLOCK");
+	return (-1);
 }
 
 /*

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -210,6 +210,7 @@ typedef int	(*next_packet_op_t)(pcap_t *, struct pcap_pkthdr *, u_char **);
 typedef int	(*inject_op_t)(pcap_t *, const void *, int);
 typedef void	(*save_current_filter_op_t)(pcap_t *, const char *);
 typedef int	(*setfilter_op_t)(pcap_t *, struct bpf_program *);
+typedef int	(*lockfilter_op_t)(pcap_t *);
 typedef int	(*setdirection_op_t)(pcap_t *, pcap_direction_t);
 typedef int	(*set_datalink_op_t)(pcap_t *, int);
 typedef int	(*getnonblock_op_t)(pcap_t *);
@@ -351,6 +352,8 @@ struct pcap {
 	inject_op_t inject_op;
 	save_current_filter_op_t save_current_filter_op;
 	setfilter_op_t setfilter_op;
+	setfilter_op_t setwritefilter_op;
+	lockfilter_op_t lockfilter_op;
 	setdirection_op_t setdirection_op;
 	set_datalink_op_t set_datalink_op;
 	getnonblock_op_t getnonblock_op;

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -259,6 +259,7 @@ static int pcap_can_set_rfmon_linux(pcap_t *);
 static int pcap_inject_linux(pcap_t *, const void *, int);
 static int pcap_stats_linux(pcap_t *, struct pcap_stat *);
 static int pcap_setfilter_linux(pcap_t *, struct bpf_program *);
+static int pcap_lockfilter_linux(pcap_t *);
 static int pcap_setdirection_linux(pcap_t *, pcap_direction_t);
 static int pcap_set_datalink_linux(pcap_t *, int);
 
@@ -1327,6 +1328,7 @@ pcap_activate_linux(pcap_t *handle)
 
 	handle->inject_op = pcap_inject_linux;
 	handle->setfilter_op = pcap_setfilter_linux;
+	handle->lockfilter_op = pcap_lockfilter_linux;
 	handle->setdirection_op = pcap_setdirection_linux;
 	handle->set_datalink_op = pcap_set_datalink_linux;
 	handle->setnonblock_op = pcap_setnonblock_linux;
@@ -4823,6 +4825,26 @@ pcap_setfilter_linux(pcap_t *handle, struct bpf_program *filter)
 	handlep->filter_in_userland = 1;
 
 	return 0;
+}
+
+static int
+pcap_lockfilter_linux(pcap_t *handle)
+{
+#ifdef SO_LOCK_FILTER
+	struct pcap_linux *handlep = handle->priv;
+	int fd = handle->fd, on = 1;
+
+	if (handlep->filter_in_userland)
+		errno = EINVAL;
+	else if (setsockopt(fd, SOL_SOCKET, SO_LOCK_FILTER, &on, sizeof(on)) == 0)
+		return (0);
+#else
+	errno = ENOSYS;
+#endif
+
+	pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
+	    errno, "SO_LOCK_FILTER");
+	return (-1);
 }
 
 /*

--- a/pcap.c
+++ b/pcap.c
@@ -342,6 +342,22 @@ pcap_setfilter_not_initialized(pcap_t *pcap, struct bpf_program *fp _U_)
 }
 
 static int
+pcap_setwritefilter_not_initialized(pcap_t *pcap, struct bpf_program *fp _U_)
+{
+	pcap_set_not_initialized_message(pcap);
+	/* this means 'not initialized' */
+	return (PCAP_ERROR_NOT_ACTIVATED);
+}
+
+static int
+pcap_lockfilter_not_initialized(pcap_t *pcap)
+{
+	pcap_set_not_initialized_message(pcap);
+	/* this means 'not initialized' */
+	return (PCAP_ERROR_NOT_ACTIVATED);
+}
+
+static int
 pcap_setdirection_not_initialized(pcap_t *pcap, pcap_direction_t d _U_)
 {
 	pcap_set_not_initialized_message(pcap);
@@ -2448,6 +2464,8 @@ initialize_ops(pcap_t *p)
 	p->read_op = pcap_read_not_initialized;
 	p->inject_op = pcap_inject_not_initialized;
 	p->setfilter_op = pcap_setfilter_not_initialized;
+	p->setwritefilter_op = pcap_setwritefilter_not_initialized;
+	p->lockfilter_op = pcap_lockfilter_not_initialized;
 	p->setdirection_op = pcap_setdirection_not_initialized;
 	p->set_datalink_op = pcap_set_datalink_not_initialized;
 	p->getnonblock_op = pcap_getnonblock_not_initialized;
@@ -3950,6 +3968,18 @@ pcap_setfilter(pcap_t *p, struct bpf_program *fp)
 	return (p->setfilter_op(p, fp));
 }
 
+int
+pcap_setwritefilter(pcap_t *p, struct bpf_program *fp)
+{
+	return (p->setwritefilter_op(p, fp));
+}
+
+int
+pcap_lockfilter(pcap_t *p)
+{
+	return (p->lockfilter_op(p));
+}
+
 /*
  * Set direction flag, which controls whether we accept only incoming
  * packets, only outgoing packets, or both.
@@ -4491,6 +4521,22 @@ pcap_setfilter_dead(pcap_t *p, struct bpf_program *fp _U_)
 }
 
 static int
+pcap_setwritefilter_dead(pcap_t *p, struct bpf_program *fp _U_)
+{
+	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+	    "A filter cannot be set on a pcap_open_dead pcap_t");
+	return (-1);
+}
+
+static int
+pcap_lockfilter_dead(pcap_t *p)
+{
+	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+	    "A filter cannot be locked on a pcap_open_dead pcap_t");
+	return (-1);
+}
+
+static int
 pcap_setdirection_dead(pcap_t *p, pcap_direction_t d _U_)
 {
 	snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
@@ -4662,6 +4708,8 @@ pcap_open_dead_with_tstamp_precision(int linktype, int snaplen, u_int precision)
 	p->read_op = pcap_read_dead;
 	p->inject_op = pcap_inject_dead;
 	p->setfilter_op = pcap_setfilter_dead;
+	p->setwritefilter_op = pcap_setwritefilter_dead;
+	p->lockfilter_op = pcap_lockfilter_dead;
 	p->setdirection_op = pcap_setdirection_dead;
 	p->set_datalink_op = pcap_set_datalink_dead;
 	p->getnonblock_op = pcap_getnonblock_dead;

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -616,6 +616,14 @@ PCAP_AVAILABLE_0_4
 PCAP_API int	pcap_setfilter(pcap_t *, struct bpf_program *)
 	     PCAP_WARN_UNUSED_RESULT;
 
+PCAP_AVAILABLE_1_11
+PCAP_API int	pcap_setwritefilter(pcap_t *, struct bpf_program *)
+	     PCAP_WARN_UNUSED_RESULT;
+
+PCAP_AVAILABLE_1_11
+PCAP_API int	pcap_lockfilter(pcap_t *)
+	     PCAP_WARN_UNUSED_RESULT;
+
 PCAP_AVAILABLE_0_9
 PCAP_API int	pcap_setdirection(pcap_t *, pcap_direction_t)
 	     PCAP_WARN_UNUSED_RESULT;

--- a/pcap_setfilter.3pcap
+++ b/pcap_setfilter.3pcap
@@ -28,6 +28,8 @@ pcap_setfilter \- set the filter
 .LP
 .ft B
 int pcap_setfilter(pcap_t *p, struct bpf_program *fp);
+int pcap_setwritefilter(pcap_t *p, struct bpf_program *fp);
+int pcap_lockfilter(pcap_t *p);
 .ft
 .fi
 .SH DESCRIPTION
@@ -57,9 +59,23 @@ but if it stands for a live packet capture, the filter program may use the
 extensions if necessary.  See
 .BR pcap_compile ()
 for more information.
+.PP
+.BR \%pcap_setwritefilter ()
+functions the same as
+.BR pcap_setfilter () ,
+except it filters packets written to the network rather than read from.
+This can only be a kernel filter.
+.PP
+.BR \%pcap_lockfilter ()
+will lock the in kernel read and write filters and stop them from being
+changed or removed.
+Once locked, they cannot be unlocked.
 .SH RETURN VALUE
-.BR pcap_setfilter ()
-returns
+.BR pcap_setfilter () ,
+.BR pcap_setwritefilter ()
+and
+.BR pcap_lockfilter ()
+return
 .B 0
 on success,
 .B PCAP_ERROR_NOT_ACTIVATED


### PR DESCRIPTION
When using libpcap in a public facing application, such as a DHCP client or ARP proxy, the application is vulnerable to malicious attacks.

If exploited, an attacker could use libpcap to write arbitary packets to the network.

To mitigate this potential exploit, applications can call pcap_setwritefilter() to ensure injected packets match how the application expects outbound packets to look, or just drop all outbound packets if it's not using libpcap to inject packets. Once set, the application should call pcap_lockfilter() to ensure the in kernel read and write filters cannot be changed or removed.

Note that this mechanism only works for kernel filtering.