### PR TITLE
fuzz: fix unused parameter compiler warning in fuzz_filter.c

### DIFF
--- a/testprogs/fuzz/fuzz_filter.c
+++ b/testprogs/fuzz/fuzz_filter.c
@@ -5,7 +5,7 @@
 #include <pcap/pcap.h>
 
 void fuzz_openFile(const char * name){
-    //do nothing
+    (void)name;//do nothing
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {

--- a/testprogs/fuzz/fuzz_filter.c
+++ b/testprogs/fuzz/fuzz_filter.c
@@ -1,11 +1,12 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "varattrs.h"
 
 #include <pcap/pcap.h>
 
-void fuzz_openFile(const char * name){
-    (void)name;//do nothing
+void fuzz_openFile(const char * name _U_){
+    //do nothing
 }
 
 int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {


### PR DESCRIPTION
When building with -Wall -Wextra a warning is triggered in the fuzzing test suite:

```
libpcap/testprogs/fuzz/fuzz_filter.c: In function ‘fuzz_openFile’:
libpcap/testprogs/fuzz/fuzz_filter.c:7:33: warning: unused parameter ‘name’ [-Wunused-parameter]
    7 | void fuzz_openFile(const char * name){
      |                    ~~~~~~~~~~~~~^~~~
```

Since the `name` parameter in `fuzz_openFile()` is intentionally unused this PR casts the unused parameter to `void` to explicitly signal to the compiler that this is intentional.

Since this is my first PR please let me know if there is something that i've got wrong!