### PR TITLE
rpcapd: fix uint16_t truncation of packet payload length

### DIFF
--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -2727,7 +2727,7 @@ daemon_thrdatamain(void *ptr)
 
 		rpcap_createhdr((struct rpcap_header *) sendbuf,
 		    session->protocol_version, RPCAP_MSG_PACKET, 0,
-		    (uint16_t) (sizeof(struct rpcap_pkthdr) + pkt_header->caplen));
+		    (uint32_t) (sizeof(struct rpcap_pkthdr) + pkt_header->caplen));
 
 		net_pkt_header = (struct rpcap_pkthdr *) &sendbuf[sendbufidx];
 


### PR DESCRIPTION
The length passed to rpcap_createhdr() in daemon_thrdatamain() was
cast to uint16_t, truncating the plen field when caplen exceeds 65516.
This corrupts the rpcap protocol stream for any capture with large
packets (jumbo frames, TSO/GRO) and snaplen > 65516.

Fix: cast to uint32_t, matching the rpcap_createhdr parameter type.