### PR TITLE
rpcapd: free BPF instruction buffer in daemon_unpackapplyfilter()

### DIFF
--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -2385,10 +2385,12 @@ daemon_unpackapplyfilter(PCAP_SOCKET sockctrl, SSL *ctrl_ssl, struct session *se
 		    sizeof(struct rpcap_filterbpf_insn), plenp, errmsgbuf);
 		if (status == -1)
 		{
+			free(bf_prog.bf_insns);
 			return -1;
 		}
 		if (status == -2)
 		{
+			free(bf_prog.bf_insns);
 			return -2;
 		}
 
@@ -2406,15 +2408,18 @@ daemon_unpackapplyfilter(PCAP_SOCKET sockctrl, SSL *ctrl_ssl, struct session *se
 	if (bpf_validate(bf_prog.bf_insns, bf_prog.bf_len) == 0)
 	{
 		snprintf(errmsgbuf, PCAP_ERRBUF_SIZE, "The filter contains invalid instructions");
+		free(bf_prog.bf_insns);
 		return -2;
 	}
 
 	if (pcap_setfilter(session->fp, &bf_prog))
 	{
 		snprintf(errmsgbuf, PCAP_ERRBUF_SIZE, "RPCAP error: %s", pcap_geterr(session->fp));
+		free(bf_prog.bf_insns);
 		return -2;
 	}
 
+	free(bf_prog.bf_insns);
 	return 0;
 }
 


### PR DESCRIPTION
daemon_unpackapplyfilter() allocates a bpf_insn array to receive filter
instructions from the client.  pcap_setfilter() copies the filter via
install_bpf_program() and does not take ownership of the caller's buffer.

The buffer was never freed on any return path, leaking up to 64 KB per
RPCAP_MSG_UPDATEFILTER_REQ message.

Fix: free bf_prog.bf_insns before every return after the allocation.