### PR TITLE
bpf: reject constant shift amounts >= 32 in validator and interpreter

### DIFF
--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -349,11 +349,17 @@ DIAG_ON_DEFAULT_ONLY_SWITCH
 			continue;
 
 		case BPF_ALU|BPF_LSH|BPF_K:
-			A <<= pc->k;
+			if (pc->k < 32)
+				A <<= pc->k;
+			else
+				A = 0;
 			continue;
 
 		case BPF_ALU|BPF_RSH|BPF_K:
-			A >>= pc->k;
+			if (pc->k < 32)
+				A >>= pc->k;
+			else
+				A = 0;
 			continue;
 
 		case BPF_ALU|BPF_NEG:
@@ -449,9 +455,12 @@ pcapint_validate_filter(const struct bpf_insn *f, int len)
 			case BPF_OR:
 			case BPF_AND:
 			case BPF_XOR:
+			case BPF_NEG:
+				break;
 			case BPF_LSH:
 			case BPF_RSH:
-			case BPF_NEG:
+				if (BPF_SRC(p->code) == BPF_K && p->k >= 32)
+					return 0;
 				break;
 			case BPF_DIV:
 			case BPF_MOD:


### PR DESCRIPTION
The BPF validator accepted LSH/RSH instructions with a constant operand
(BPF_K) of 32 or greater.  Shifting a uint32_t by >= 32 is undefined
behavior (C11 6.5.7p3).  The register-based variant (BPF_X) already
checked X < 32, but the constant variant did not.

This caused platform-dependent filter results: on x86-64 the shift
masked to 5 bits (no-op for k=32), while on ARM32 it zeroed the
accumulator.

Fix: reject k >= 32 in the validator, and add bounds checking in the
interpreter to match the existing BPF_X behavior.