### PR TITLE
Add SPDX license identifier tags to files

### DIFF
--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/bpf_image.c
+++ b/bpf_image.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1990, 1991, 1992, 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/charconv.c
+++ b/charconv.c
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/charconv.h
+++ b/charconv.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/diag-control.h
+++ b/diag-control.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/etherent.c
+++ b/etherent.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1990, 1993, 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/ethertype.h
+++ b/ethertype.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/extract.h
+++ b/extract.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1992, 1993, 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/fad-getad.c
+++ b/fad-getad.c
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/fad-gifc.c
+++ b/fad-gifc.c
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/fad-glifc.c
+++ b/fad-glifc.c
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/fmtutils.c
+++ b/fmtutils.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/fmtutils.h
+++ b/fmtutils.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/ftmacros.h
+++ b/ftmacros.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/gencode.c
+++ b/gencode.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/gencode.h
+++ b/gencode.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened AND BSD-4-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/ieee80211.h
+++ b/ieee80211.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause OR GPL-2.0-only
+ *
  * Copyright (c) 2001 Atsushi Onoe
  * Copyright (c) 2002-2005 Sam Leffler, Errno Consulting
  * All rights reserved.

--- a/llc.h
+++ b/llc.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/missing/getopt.c
+++ b/missing/getopt.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1987, 1993, 1994
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/missing/strlcat.c
+++ b/missing/strlcat.c
@@ -1,6 +1,8 @@
 /*	$OpenBSD: strlcat.c,v 1.15 2015/03/02 21:41:08 millert Exp $	*/
 
 /*
+ * SPDX-License-Identifier: ISC
+ *
  * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/missing/strlcpy.c
+++ b/missing/strlcpy.c
@@ -1,6 +1,8 @@
 /*	$OpenBSD: strlcpy.c,v 1.12 2015/01/15 03:54:12 millert Exp $	*/
 
 /*
+ * SPDX-License-Identifier: ISC
+ *
  * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/missing/strtok_r.c
+++ b/missing/strtok_r.c
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1998 Softweyr LLC.  All rights reserved.
  *
  * strtok_r, from Berkeley strtok

--- a/nametoaddr.c
+++ b/nametoaddr.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/nametoaddr.h
+++ b/nametoaddr.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/optimize.c
+++ b/optimize.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1988, 1989, 1990, 1991, 1993, 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/optimize.h
+++ b/optimize.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-bpf.h
+++ b/pcap-bpf.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2006 Paolo Abeni (Italy)
  * All rights reserved.
  *

--- a/pcap-bt-linux.h
+++ b/pcap-bt-linux.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2006 Paolo Abeni (Italy)
  * All rights reserved.
  *

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2014 Michal Labedzki for Tieto Corporation
  * All rights reserved.
  *

--- a/pcap-bt-monitor-linux.h
+++ b/pcap-bt-monitor-linux.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2014 Michal Labedzki for Tieto Corporation
  * All rights reserved.
  *

--- a/pcap-common.c
+++ b/pcap-common.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-common.h
+++ b/pcap-common.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-dbus.c
+++ b/pcap-dbus.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2012 Jakub Zawadzki
  * All rights reserved.
  *

--- a/pcap-dlpi.c
+++ b/pcap-dlpi.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-dpdk.c
+++ b/pcap-dpdk.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2018 jingle YANG. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/pcap-dpdk.h
+++ b/pcap-dpdk.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2018 jingle YANG. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/pcap-haiku.c
+++ b/pcap-haiku.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: MIT
+ *
  * Copyright 2006-2010, Haiku, Inc. All Rights Reserved.
  * Distributed under the terms of the MIT License.
  *

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-libdlpi.c
+++ b/pcap-libdlpi.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  *  pcap-linux.c: Packet capture interface to the Linux kernel
  *
  *  Copyright (c) 2000 Torsten Landschoff <torsten@debian.org>

--- a/pcap-namedb.h
+++ b/pcap-namedb.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2011 Jakub Zawadzki
  * All rights reserved.
  *

--- a/pcap-netfilter-linux.h
+++ b/pcap-netfilter-linux.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2011 Jakub Zawadzki
  * All rights reserved.
  *

--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (C) 2014 Luigi Rizzo. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/pcap-new.c
+++ b/pcap-new.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2008 CACE Technologies, Davis (California)
  * All rights reserved.

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1999 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2010 CACE Technologies, Davis (California)
  * All rights reserved.

--- a/pcap-null.c
+++ b/pcap-null.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-options.c
+++ b/pcap-options.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-rdmasniff.c
+++ b/pcap-rdmasniff.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2017 Pure Storage, Inc.
  * All rights reserved.
  *

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2008 CACE Technologies, Davis (California)
  * All rights reserved.

--- a/pcap-rpcap.h
+++ b/pcap-rpcap.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-types.h
+++ b/pcap-types.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier:  BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2009 CACE Technologies, Inc. Davis (California)
  * All rights reserved.

--- a/pcap-usb-linux-common.h
+++ b/pcap-usb-linux-common.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-usb-linux.c
+++ b/pcap-usb-linux.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2006 Paolo Abeni (Italy)
  * All rights reserved.
  *

--- a/pcap-usb-linux.h
+++ b/pcap-usb-linux.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2006 Paolo Abeni (Italy)
  * All rights reserved.
  *

--- a/pcap-util.c
+++ b/pcap-util.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap-util.h
+++ b/pcap-util.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap.c
+++ b/pcap.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap.h
+++ b/pcap.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/bluetooth.h
+++ b/pcap/bluetooth.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2006 Paolo Abeni (Italy)
  * All rights reserved.
  *

--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/can_socketcan.h
+++ b/pcap/can_socketcan.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/compiler-tests.h
+++ b/pcap/compiler-tests.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/dlt.h
+++ b/pcap/dlt.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/funcattrs.h
+++ b/pcap/funcattrs.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/ipnet.h
+++ b/pcap/ipnet.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/namedb.h
+++ b/pcap/namedb.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/nflog.h
+++ b/pcap/nflog.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
  * Copyright (c) 2013, Petar Alilovic,
  * Faculty of Electrical Engineering and Computing, University of Zagreb
  * All rights reserved

--- a/pcap/pcap-inttypes.h
+++ b/pcap/pcap-inttypes.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2009 CACE Technologies, Inc. Davis (California)
  * All rights reserved.

--- a/pcap/pcap.h
+++ b/pcap/pcap.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/sll.h
+++ b/pcap/sll.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/socket.h
+++ b/pcap/socket.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pcap/usb.h
+++ b/pcap/usb.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2006 Paolo Abeni (Italy)
  * All rights reserved.
  *

--- a/pcap/vlan.h
+++ b/pcap/vlan.h
@@ -1,4 +1,6 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 1990, 1991, 1992, 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/pflog.h
+++ b/pflog.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1982, 1986, 1993
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/portability.h
+++ b/portability.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/ppp.h
+++ b/ppp.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: CMU-Mach
+ *
  * Point to Point Protocol (PPP) RFC1331
  *
  * Copyright 1989 by Carnegie Mellon.

--- a/rpcap-protocol.c
+++ b/rpcap-protocol.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2008 CACE Technologies, Davis (California)
  * All rights reserved.

--- a/rpcap-protocol.h
+++ b/rpcap-protocol.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2005 NetGroup, Politecnico di Torino (Italy)
  * Copyright (c) 2005 - 2008 CACE Technologies, Davis (California)
  * All rights reserved.

--- a/rpcapd/config_params.h
+++ b/rpcapd/config_params.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/daemon.c
+++ b/rpcapd/daemon.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/daemon.h
+++ b/rpcapd/daemon.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/fileconf.c
+++ b/rpcapd/fileconf.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1987, 1993, 1994
  *      The Regents of the University of California.  All rights reserved.
  *

--- a/rpcapd/fileconf.h
+++ b/rpcapd/fileconf.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/log.c
+++ b/rpcapd/log.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/rpcapd/log.h
+++ b/rpcapd/log.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1998
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/rpcapd/rpcapd.c
+++ b/rpcapd/rpcapd.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/rpcapd.h
+++ b/rpcapd/rpcapd.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/win32-svc.c
+++ b/rpcapd/win32-svc.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/rpcapd/win32-svc.h
+++ b/rpcapd/win32-svc.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/savefile.c
+++ b/savefile.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/sf-pcap.h
+++ b/sf-pcap.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/sf-pcapng.h
+++ b/sf-pcapng.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-Shortened
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/sockutils.c
+++ b/sockutils.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/sockutils.h
+++ b/sockutils.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/sslutils.c
+++ b/sslutils.c
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/sslutils.h
+++ b/sslutils.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
  * Copyright (c) 2002 - 2003
  * NetGroup, Politecnico di Torino (Italy)
  * All rights reserved.

--- a/thread-local.h
+++ b/thread-local.h
@@ -1,4 +1,6 @@
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1994, 1995, 1996
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/varattrs.h
+++ b/varattrs.h
@@ -1,5 +1,7 @@
 /* -*- Mode: c; tab-width: 8; indent-tabs-mode: 1; c-basic-offset: 8; -*- */
 /*
+ * SPDX-License-Identifier: BSD-4-Clause-UC
+ *
  * Copyright (c) 1993, 1994, 1995, 1996, 1997
  *	The Regents of the University of California.  All rights reserved.
  *


### PR DESCRIPTION
Add SPDX license identifier tags to files. Each SPDX license identifier is in own commit to make easier to review this.