### PR TITLE
rpcap: fix an out-of-bounds read in pcap_read_nocb_remote()

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -576,7 +576,8 @@ static int pcap_read_nocb_remote(pcap_t *p, struct pcap_pkthdr *pkt_header, u_ch
 		return 0;	/* Return 'no packets received' */
 	}
 
-	if (ntohl(net_pkt_header->caplen) > plen)
+	if (plen < sizeof(struct rpcap_pkthdr) ||
+	    ntohl(net_pkt_header->caplen) > plen - sizeof(struct rpcap_pkthdr))
 	{
 		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 		    "Packet's captured data goes past the end of the received packet message.");


### PR DESCRIPTION
The captured length in an rpcap packet message was validated against the full payload length instead of the payload length minus the rpcap packet header, letting a malicious or compromised server make a consumer read past the end of the capture buffer.