### PR TITLE
fuzz: make fuzz_rclient reach the rpcap packet-read path

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1145,6 +1145,10 @@ static int pcap_startcapture_remote(pcap_t *fp)
 	 * so I would have to call getpeername() anyway
 	 */
 	saddrlen = sizeof(struct sockaddr_storage);
+#ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+	ai_family = AF_INET;
+	pcapint_strlcpy(host, "127.0.0.1", sizeof(host));
+#else
 	if (getpeername(pr->rmt_sockctrl, (struct sockaddr *) &saddr, &saddrlen) == -1)
 	{
 		sock_geterrmsg(fp->errbuf, PCAP_ERRBUF_SIZE,
@@ -1161,6 +1165,7 @@ static int pcap_startcapture_remote(pcap_t *fp)
 		    "getnameinfo() failed");
 		goto error_nodiscard;
 	}
+#endif
 
 	/*
 	 * Data connection is opened by the server toward the client if:

--- a/sockutils.c
+++ b/sockutils.c
@@ -655,6 +655,8 @@ PCAP_SOCKET sock_open(const char *host, struct addrinfo *addrinfo,
 		{
 			tempaddrinfo = addrs_to_try[i].info;
 #ifdef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
+			sock = sock_create_socket(tempaddrinfo, errbuf,
+			    errbuflen);
 			break;
 #endif
 			/*

--- a/testprogs/fuzz/fuzz_rclient.c
+++ b/testprogs/fuzz/fuzz_rclient.c
@@ -43,7 +43,11 @@ int LLVMFuzzerTestOneInput(const uint8_t *Data, size_t Size) {
     //loop over packets
     r = pcap_next_ex(pkts, &header, &pkt);
     while (r > 0) {
+        unsigned int i, sum = 0;
         fprintf(outfile, "packet length=%d/%d\n",header->caplen, header->len);
+        for (i = 0; i < header->caplen; i++)
+            sum += pkt[i];
+        fprintf(outfile, "checksum=%u\n", sum);
         r = pcap_next_ex(pkts, &header, &pkt);
     }
     if (pcap_stats(pkts, &stats) == 0) {


### PR DESCRIPTION
The fuzz_rclient target never reached the rpcap packet-reading code because the fuzzing sock_open() stub returned INVALID_SOCKET and getpeername()/getnameinfo() failed on the unconnected fuzzing socket; this gives the stub a usable socket, skips those connection-dependent calls under the fuzzing macro, and has the harness read the captured bytes so sanitizers can catch over-reads.