### PR TITLE
rpcap: validate caplen against payload size in pcap_read_nocb_remote

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -576,7 +576,22 @@ static int pcap_read_nocb_remote(pcap_t *p, struct pcap_pkthdr *pkt_header, u_ch
 		return 0;	/* Return 'no packets received' */
 	}
 
-	if (ntohl(net_pkt_header->caplen) > plen)
+	/*
+	 * The payload holds the packet header followed by the captured
+	 * data, so it must be at least as large as the packet header.
+	 */
+	if (plen < sizeof(struct rpcap_pkthdr))
+	{
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		    "Packet message payload is shorter than a packet header");
+		return -1;
+	}
+
+	/*
+	 * The captured data follows the packet header, so caplen bytes
+	 * must fit in what's left of the payload after the header.
+	 */
+	if (ntohl(net_pkt_header->caplen) > plen - sizeof(struct rpcap_pkthdr))
 	{
 		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 		    "Packet's captured data goes past the end of the received packet message.");


### PR DESCRIPTION
pcap_read_nocb_remote checks a packet message's caplen against the full payload length plen, but plen also covers the 20-byte struct rpcap_pkthdr that precedes the captured data, so a malicious server can report a caplen up to sizeof(struct rpcap_pkthdr) bytes larger than the data actually received. The packet-data pointer is buffer + sizeof(rpcap_header) + sizeof(rpcap_pkthdr) and plen may be as large as bufsize minus the rpcap header, so the caplen-byte packet handed to the caller reads past the end of p->buffer. Reject payloads shorter than a packet header and bound caplen by plen minus sizeof(struct rpcap_pkthdr).