### PR TITLE
Rename SWAPSHORT(), SWAPLONG(), SWAPLL() to PCAP_BSWAP_({16,32,64})

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -21,6 +21,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Deprecate pcap_compile_nopcap().
       Remove unmaintained DPDK capture backend (was disabled by default).
       Return more useful strings from pcap_statustostr().
+      Rename SWAPSHORT(), SWAPLONG(), SWAPLL() to PCAP_BSWAP_({16,32,64}).
     Link-layer types:
       Add LINKTYPE_DECT_NR_TAP/DLT_DECT_NR_TAP.
     Packet filtering:

--- a/CHANGES
+++ b/CHANGES
@@ -22,6 +22,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Remove unmaintained DPDK capture backend (was disabled by default).
       Return more useful strings from pcap_statustostr().
       Rename SWAPSHORT(), SWAPLONG(), SWAPLL() to PCAP_BSWAP_({16,32,64}).
+      Replace EXTRACT_SHORT by EXTRACT_BE_U_2, EXTRACT_LONG by EXTRACT_BE_U_4.
     Link-layer types:
       Add LINKTYPE_DECT_NR_TAP/DLT_DECT_NR_TAP.
     Packet filtering:

--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -45,9 +45,6 @@
 #include "extract.h"
 #include "diag-control.h"
 
-#define EXTRACT_SHORT	EXTRACT_BE_U_2
-#define EXTRACT_LONG	EXTRACT_BE_U_4
-
 #ifndef _WIN32
 #include <sys/param.h>
 #include <sys/types.h>
@@ -115,7 +112,7 @@ pcapint_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			if (k > buflen || sizeof(int32_t) > buflen - k) {
 				return 0;
 			}
-			A = EXTRACT_LONG(&p[k]);
+			A = EXTRACT_BE_U_4(&p[k]);
 			continue;
 
 		case BPF_LD|BPF_H|BPF_ABS:
@@ -123,7 +120,7 @@ pcapint_filter_with_aux_data(const struct bpf_insn *pc, const u_char *p,
 			if (k > buflen || sizeof(int16_t) > buflen - k) {
 				return 0;
 			}
-			A = EXTRACT_SHORT(&p[k]);
+			A = EXTRACT_BE_U_2(&p[k]);
 			continue;
 
 		case BPF_LD|BPF_B|BPF_ABS:
@@ -174,7 +171,7 @@ DIAG_ON_DEFAULT_ONLY_SWITCH
 			    sizeof(int32_t) > buflen - k) {
 				return 0;
 			}
-			A = EXTRACT_LONG(&p[k]);
+			A = EXTRACT_BE_U_4(&p[k]);
 			continue;
 
 		case BPF_LD|BPF_H|BPF_IND:
@@ -183,7 +180,7 @@ DIAG_ON_DEFAULT_ONLY_SWITCH
 			    sizeof(int16_t) > buflen - k) {
 				return 0;
 			}
-			A = EXTRACT_SHORT(&p[k]);
+			A = EXTRACT_BE_U_2(&p[k]);
 			continue;
 
 		case BPF_LD|BPF_B|BPF_IND:

--- a/gencode.c
+++ b/gencode.c
@@ -1587,7 +1587,7 @@ finish_parse(compiler_state_t *cstate, struct block *p_arg)
 	 */
 	if (cstate->linktype == DLT_PPI) {
 		struct block *ppi_dlt_check = gen_cmp(cstate, OR_PACKET,
-			4, BPF_W, SWAPLONG(DLT_IEEE802_11));
+			4, BPF_W, PCAPINT_BSWAP_32(DLT_IEEE802_11));
 		p = gen_and(ppi_dlt_check, p);
 	}
 
@@ -2945,7 +2945,7 @@ gen_endian_linktype(compiler_state_t *cstate, u_int offset, u_int size,
     bpf_u_int32 ll_proto, int swapped)
 {
 	return (gen_cmp(cstate, OR_LINKHDR, offset, size,
-	    swapped ? SWAPLONG(ll_proto) : ll_proto));
+	    swapped ? PCAPINT_BSWAP_32(ll_proto) : ll_proto));
 }
 
 static struct block *
@@ -3846,7 +3846,7 @@ gen_load_802_11_header_len(compiler_state_t *cstate, struct slist *s, struct sli
 		sappend(s, s2);
 
 		sjset_radiotap_flags_present = new_stmt(cstate, JMP(BPF_JSET, BPF_K));
-		sjset_radiotap_flags_present->s.k = SWAPLONG(0x00000002);
+		sjset_radiotap_flags_present->s.k = PCAPINT_BSWAP_32(0x00000002);
 		sappend(s, sjset_radiotap_flags_present);
 
 		/*
@@ -3858,7 +3858,7 @@ gen_load_802_11_header_len(compiler_state_t *cstate, struct slist *s, struct sli
 		 * Otherwise, is the "extension" bit set in that word?
 		 */
 		sjset_radiotap_ext_present = new_stmt(cstate, JMP(BPF_JSET, BPF_K));
-		sjset_radiotap_ext_present->s.k = SWAPLONG(0x80000000);
+		sjset_radiotap_ext_present->s.k = PCAPINT_BSWAP_32(0x80000000);
 		sappend(s, sjset_radiotap_ext_present);
 		sjset_radiotap_flags_present->s.jt = sjset_radiotap_ext_present;
 
@@ -3871,7 +3871,7 @@ gen_load_802_11_header_len(compiler_state_t *cstate, struct slist *s, struct sli
 		 * Otherwise, is the IEEE80211_RADIOTAP_TSFT bit set?
 		 */
 		sjset_radiotap_tsft_present = new_stmt(cstate, JMP(BPF_JSET, BPF_K));
-		sjset_radiotap_tsft_present->s.k = SWAPLONG(0x00000001);
+		sjset_radiotap_tsft_present->s.k = PCAPINT_BSWAP_32(0x00000001);
 		sappend(s, sjset_radiotap_tsft_present);
 		sjset_radiotap_ext_present->s.jf = sjset_radiotap_tsft_present;
 
@@ -5417,7 +5417,7 @@ gen_dnhostop(compiler_state_t *cstate, bpf_u_int32 addr, int dir)
 	 * To test PLENGTH and FLAGS, use multiple-byte constants with the
 	 * values and the masks, this maps to the required single bytes of
 	 * the message correctly on both big-endian and little-endian hosts.
-	 * For the DECnet address use SWAPSHORT(), which always swaps bytes,
+	 * For the DECnet address use PCAPINT_BSWAP_16(), which always swaps bytes,
 	 * because the wire encoding is little-endian and BPF multiple-byte
 	 * loads are big-endian.  When the destination address is near enough
 	 * to PLENGTH and FLAGS, generate one 32-bit comparison instead of two
@@ -5426,35 +5426,35 @@ gen_dnhostop(compiler_state_t *cstate, bpf_u_int32 addr, int dir)
 	/* Check for pad = 1, long header case */
 	tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_H, 0x8106U, 0xFF07U);
 	b1 = gen_cmp(cstate, OR_LINKPL, 2 + 1 + offset_lh,
-	    BPF_H, SWAPSHORT(addr));
+	    BPF_H, PCAPINT_BSWAP_16(addr));
 	b1 = gen_and(tmp, b1);
 	/* Check for pad = 0, long header case */
 	tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_B, 0x06U, 0x07U);
 	b2 = gen_cmp(cstate, OR_LINKPL, 2 + offset_lh, BPF_H,
-	    SWAPSHORT(addr));
+	    PCAPINT_BSWAP_16(addr));
 	b2 = gen_and(tmp, b2);
 	b1 = gen_or(b2, b1);
 	/* Check for pad = 1, short header case */
 	if (dir == Q_DST) {
 		b2 = gen_mcmp(cstate, OR_LINKPL, 2, BPF_W,
-		    0x81020000U | SWAPSHORT(addr),
+		    0x81020000U | PCAPINT_BSWAP_16(addr),
 		    0xFF07FFFFU);
 	} else {
 		tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_H, 0x8102U, 0xFF07U);
 		b2 = gen_cmp(cstate, OR_LINKPL, 2 + 1 + offset_sh, BPF_H,
-		    SWAPSHORT(addr));
+		    PCAPINT_BSWAP_16(addr));
 		b2 = gen_and(tmp, b2);
 	}
 	b1 = gen_or(b2, b1);
 	/* Check for pad = 0, short header case */
 	if (dir == Q_DST) {
 		b2 = gen_mcmp(cstate, OR_LINKPL, 2, BPF_W,
-		    0x02000000U | SWAPSHORT(addr) << 8,
+		    0x02000000U | PCAPINT_BSWAP_16(addr) << 8,
 		    0x07FFFF00U);
 	} else {
 		tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_B, 0x02U, 0x07U);
 		b2 = gen_cmp(cstate, OR_LINKPL, 2 + offset_sh, BPF_H,
-		    SWAPSHORT(addr));
+		    PCAPINT_BSWAP_16(addr));
 		b2 = gen_and(tmp, b2);
 	}
 
@@ -10057,8 +10057,8 @@ gen_mtp3field_code_internal(compiler_state_t *cstate, int mtp3field,
 	case M_OPC:
 		assert_maxval(cstate, ss7kw(mtp3field), jvalue, MTP3_PC_MAXVAL);
 		return gen_ncmp(cstate, OR_PACKET, newoff_opc, BPF_W,
-		    SWAPLONG(MTP3_PC_MAXVAL << 14), jtype, reverse,
-		    SWAPLONG(jvalue << 14));
+		    PCAPINT_BSWAP_32(MTP3_PC_MAXVAL << 14), jtype, reverse,
+		    PCAPINT_BSWAP_32(jvalue << 14));
 
 	case MH_DPC:
 		newoff_dpc += 3;
@@ -10067,8 +10067,8 @@ gen_mtp3field_code_internal(compiler_state_t *cstate, int mtp3field,
 	case M_DPC:
 		assert_maxval(cstate, ss7kw(mtp3field), jvalue, MTP3_PC_MAXVAL);
 		return gen_ncmp(cstate, OR_PACKET, newoff_dpc, BPF_H,
-		    SWAPSHORT(MTP3_PC_MAXVAL), jtype, reverse,
-		    SWAPSHORT(jvalue));
+		    PCAPINT_BSWAP_16(MTP3_PC_MAXVAL), jtype, reverse,
+		    PCAPINT_BSWAP_16(jvalue));
 
 	case MH_SLS:
 		newoff_sls += 3;

--- a/gencode.c
+++ b/gencode.c
@@ -1587,7 +1587,7 @@ finish_parse(compiler_state_t *cstate, struct block *p_arg)
 	 */
 	if (cstate->linktype == DLT_PPI) {
 		struct block *ppi_dlt_check = gen_cmp(cstate, OR_PACKET,
-			4, BPF_W, SWAPLONG(DLT_IEEE802_11));
+			4, BPF_W, PCAP_BSWAP_32(DLT_IEEE802_11));
 		p = gen_and(ppi_dlt_check, p);
 	}
 
@@ -2945,7 +2945,7 @@ gen_endian_linktype(compiler_state_t *cstate, u_int offset, u_int size,
     bpf_u_int32 ll_proto, int swapped)
 {
 	return (gen_cmp(cstate, OR_LINKHDR, offset, size,
-	    swapped ? SWAPLONG(ll_proto) : ll_proto));
+	    swapped ? PCAP_BSWAP_32(ll_proto) : ll_proto));
 }
 
 static struct block *
@@ -3846,7 +3846,7 @@ gen_load_802_11_header_len(compiler_state_t *cstate, struct slist *s, struct sli
 		sappend(s, s2);
 
 		sjset_radiotap_flags_present = new_stmt(cstate, JMP(BPF_JSET, BPF_K));
-		sjset_radiotap_flags_present->s.k = SWAPLONG(0x00000002);
+		sjset_radiotap_flags_present->s.k = PCAP_BSWAP_32(0x00000002);
 		sappend(s, sjset_radiotap_flags_present);
 
 		/*
@@ -3858,7 +3858,7 @@ gen_load_802_11_header_len(compiler_state_t *cstate, struct slist *s, struct sli
 		 * Otherwise, is the "extension" bit set in that word?
 		 */
 		sjset_radiotap_ext_present = new_stmt(cstate, JMP(BPF_JSET, BPF_K));
-		sjset_radiotap_ext_present->s.k = SWAPLONG(0x80000000);
+		sjset_radiotap_ext_present->s.k = PCAP_BSWAP_32(0x80000000);
 		sappend(s, sjset_radiotap_ext_present);
 		sjset_radiotap_flags_present->s.jt = sjset_radiotap_ext_present;
 
@@ -3871,7 +3871,7 @@ gen_load_802_11_header_len(compiler_state_t *cstate, struct slist *s, struct sli
 		 * Otherwise, is the IEEE80211_RADIOTAP_TSFT bit set?
 		 */
 		sjset_radiotap_tsft_present = new_stmt(cstate, JMP(BPF_JSET, BPF_K));
-		sjset_radiotap_tsft_present->s.k = SWAPLONG(0x00000001);
+		sjset_radiotap_tsft_present->s.k = PCAP_BSWAP_32(0x00000001);
 		sappend(s, sjset_radiotap_tsft_present);
 		sjset_radiotap_ext_present->s.jf = sjset_radiotap_tsft_present;
 
@@ -5417,7 +5417,7 @@ gen_dnhostop(compiler_state_t *cstate, bpf_u_int32 addr, int dir)
 	 * To test PLENGTH and FLAGS, use multiple-byte constants with the
 	 * values and the masks, this maps to the required single bytes of
 	 * the message correctly on both big-endian and little-endian hosts.
-	 * For the DECnet address use SWAPSHORT(), which always swaps bytes,
+	 * For the DECnet address use PCAP_BSWAP_16(), which always swaps bytes,
 	 * because the wire encoding is little-endian and BPF multiple-byte
 	 * loads are big-endian.  When the destination address is near enough
 	 * to PLENGTH and FLAGS, generate one 32-bit comparison instead of two
@@ -5426,35 +5426,35 @@ gen_dnhostop(compiler_state_t *cstate, bpf_u_int32 addr, int dir)
 	/* Check for pad = 1, long header case */
 	tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_H, 0x8106U, 0xFF07U);
 	b1 = gen_cmp(cstate, OR_LINKPL, 2 + 1 + offset_lh,
-	    BPF_H, SWAPSHORT(addr));
+	    BPF_H, PCAP_BSWAP_16(addr));
 	b1 = gen_and(tmp, b1);
 	/* Check for pad = 0, long header case */
 	tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_B, 0x06U, 0x07U);
 	b2 = gen_cmp(cstate, OR_LINKPL, 2 + offset_lh, BPF_H,
-	    SWAPSHORT(addr));
+	    PCAP_BSWAP_16(addr));
 	b2 = gen_and(tmp, b2);
 	b1 = gen_or(b2, b1);
 	/* Check for pad = 1, short header case */
 	if (dir == Q_DST) {
 		b2 = gen_mcmp(cstate, OR_LINKPL, 2, BPF_W,
-		    0x81020000U | SWAPSHORT(addr),
+		    0x81020000U | PCAP_BSWAP_16(addr),
 		    0xFF07FFFFU);
 	} else {
 		tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_H, 0x8102U, 0xFF07U);
 		b2 = gen_cmp(cstate, OR_LINKPL, 2 + 1 + offset_sh, BPF_H,
-		    SWAPSHORT(addr));
+		    PCAP_BSWAP_16(addr));
 		b2 = gen_and(tmp, b2);
 	}
 	b1 = gen_or(b2, b1);
 	/* Check for pad = 0, short header case */
 	if (dir == Q_DST) {
 		b2 = gen_mcmp(cstate, OR_LINKPL, 2, BPF_W,
-		    0x02000000U | SWAPSHORT(addr) << 8,
+		    0x02000000U | PCAP_BSWAP_16(addr) << 8,
 		    0x07FFFF00U);
 	} else {
 		tmp = gen_mcmp(cstate, OR_LINKPL, 2, BPF_B, 0x02U, 0x07U);
 		b2 = gen_cmp(cstate, OR_LINKPL, 2 + offset_sh, BPF_H,
-		    SWAPSHORT(addr));
+		    PCAP_BSWAP_16(addr));
 		b2 = gen_and(tmp, b2);
 	}
 
@@ -10057,8 +10057,8 @@ gen_mtp3field_code_internal(compiler_state_t *cstate, int mtp3field,
 	case M_OPC:
 		assert_maxval(cstate, ss7kw(mtp3field), jvalue, MTP3_PC_MAXVAL);
 		return gen_ncmp(cstate, OR_PACKET, newoff_opc, BPF_W,
-		    SWAPLONG(MTP3_PC_MAXVAL << 14), jtype, reverse,
-		    SWAPLONG(jvalue << 14));
+		    PCAP_BSWAP_32(MTP3_PC_MAXVAL << 14), jtype, reverse,
+		    PCAP_BSWAP_32(jvalue << 14));
 
 	case MH_DPC:
 		newoff_dpc += 3;
@@ -10067,8 +10067,8 @@ gen_mtp3field_code_internal(compiler_state_t *cstate, int mtp3field,
 	case M_DPC:
 		assert_maxval(cstate, ss7kw(mtp3field), jvalue, MTP3_PC_MAXVAL);
 		return gen_ncmp(cstate, OR_PACKET, newoff_dpc, BPF_H,
-		    SWAPSHORT(MTP3_PC_MAXVAL), jtype, reverse,
-		    SWAPSHORT(jvalue));
+		    PCAP_BSWAP_16(MTP3_PC_MAXVAL), jtype, reverse,
+		    PCAP_BSWAP_16(jvalue));
 
 	case MH_SLS:
 		newoff_sls += 3;

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -19,7 +19,7 @@
 #include "pcap-int.h"
 
 #if __BYTE_ORDER == __BIG_ENDIAN
-// Will need SWAPLL().
+// Will need PCAPINT_BSWAP_64().
 #include "pcap-util.h"
 #endif
 
@@ -695,7 +695,7 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			unsigned long long ts;
 
 #if __BYTE_ORDER == __BIG_ENDIAN
-			ts = SWAPLL(header->ts);
+			ts = PCAPINT_BSWAP_64(header->ts);
 #else
 			ts = header->ts;
 #endif // __BYTE_ORDER

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -19,7 +19,7 @@
 #include "pcap-int.h"
 
 #if __BYTE_ORDER == __BIG_ENDIAN
-// Will need SWAPLL().
+// Will need PCAP_BSWAP_64().
 #include "pcap-util.h"
 #endif
 
@@ -695,7 +695,7 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 			unsigned long long ts;
 
 #if __BYTE_ORDER == __BIG_ENDIAN
-			ts = SWAPLL(header->ts);
+			ts = PCAP_BSWAP_64(header->ts);
 #else
 			ts = header->ts;
 #endif // __BYTE_ORDER

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -4204,7 +4204,7 @@ static int pcap_handle_packet_mmap(
 				 * field in little-endian byte order.
 				 */
 				/* Byte-swap priority/VCID. */
-				canxl_hdr->priority_vcid = SWAPLONG(canxl_hdr->priority_vcid);
+				canxl_hdr->priority_vcid = PCAPINT_BSWAP_32(canxl_hdr->priority_vcid);
 #elif __BYTE_ORDER == __BIG_ENDIAN
 				/*
 				 * We're capturing on a big-endian
@@ -4214,7 +4214,7 @@ static int pcap_handle_packet_mmap(
 				 * fields to little-endian.
 				 */
 				/* Byte-swap the payload length */
-				canxl_hdr->payload_length = SWAPSHORT(canxl_hdr->payload_length);
+				canxl_hdr->payload_length = PCAPINT_BSWAP_16(canxl_hdr->payload_length);
 
 				/*
 				 * Byte-swap the acceptance field.
@@ -4222,7 +4222,7 @@ static int pcap_handle_packet_mmap(
 				 * XXX - is it just a 4-octet string,
 				 * not in any byte order?
 				 */
-				canxl_hdr->acceptance_field = SWAPLONG(canxl_hdr->acceptance_field);
+				canxl_hdr->acceptance_field = PCAPINT_BSWAP_32(canxl_hdr->acceptance_field);
 #else
 #error "Unknown byte order"
 #endif

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -4204,7 +4204,7 @@ static int pcap_handle_packet_mmap(
 				 * field in little-endian byte order.
 				 */
 				/* Byte-swap priority/VCID. */
-				canxl_hdr->priority_vcid = SWAPLONG(canxl_hdr->priority_vcid);
+				canxl_hdr->priority_vcid = PCAP_BSWAP_32(canxl_hdr->priority_vcid);
 #elif __BYTE_ORDER == __BIG_ENDIAN
 				/*
 				 * We're capturing on a big-endian
@@ -4214,7 +4214,7 @@ static int pcap_handle_packet_mmap(
 				 * fields to little-endian.
 				 */
 				/* Byte-swap the payload length */
-				canxl_hdr->payload_length = SWAPSHORT(canxl_hdr->payload_length);
+				canxl_hdr->payload_length = PCAP_BSWAP_16(canxl_hdr->payload_length);
 
 				/*
 				 * Byte-swap the acceptance field.
@@ -4222,7 +4222,7 @@ static int pcap_handle_packet_mmap(
 				 * XXX - is it just a 4-octet string,
 				 * not in any byte order?
 				 */
-				canxl_hdr->acceptance_field = SWAPLONG(canxl_hdr->acceptance_field);
+				canxl_hdr->acceptance_field = PCAP_BSWAP_32(canxl_hdr->acceptance_field);
 #else
 #error "Unknown byte order"
 #endif

--- a/pcap-util.c
+++ b/pcap-util.c
@@ -67,7 +67,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include uid field */
 		return;
 	}
-	pflhdr->uid = SWAPLONG(pflhdr->uid);
+	pflhdr->uid = PCAPINT_BSWAP_32(pflhdr->uid);
 
 	if (caplen < (u_int) (offsetof(struct pfloghdr, pid) + sizeof pflhdr->pid) ||
 	    length < (u_int) (offsetof(struct pfloghdr, pid) + sizeof pflhdr->pid)) {
@@ -78,7 +78,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include pid field */
 		return;
 	}
-	pflhdr->pid = SWAPLONG(pflhdr->pid);
+	pflhdr->pid = PCAPINT_BSWAP_32(pflhdr->pid);
 
 	if (caplen < (u_int) (offsetof(struct pfloghdr, rule_uid) + sizeof pflhdr->rule_uid) ||
 	    length < (u_int) (offsetof(struct pfloghdr, rule_uid) + sizeof pflhdr->rule_uid)) {
@@ -89,7 +89,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include rule_uid field */
 		return;
 	}
-	pflhdr->rule_uid = SWAPLONG(pflhdr->rule_uid);
+	pflhdr->rule_uid = PCAPINT_BSWAP_32(pflhdr->rule_uid);
 
 	if (caplen < (u_int) (offsetof(struct pfloghdr, rule_pid) + sizeof pflhdr->rule_pid) ||
 	    length < (u_int) (offsetof(struct pfloghdr, rule_pid) + sizeof pflhdr->rule_pid)) {
@@ -100,7 +100,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include rule_pid field */
 		return;
 	}
-	pflhdr->rule_pid = SWAPLONG(pflhdr->rule_pid);
+	pflhdr->rule_pid = PCAPINT_BSWAP_32(pflhdr->rule_pid);
 }
 
 /*
@@ -139,7 +139,7 @@ swap_socketcan_header(uint16_t protocol, u_int caplen, u_int length,
 			/* Not enough data to have the can_id field */
 			return;
 		}
-		hdrp->can_id = SWAPLONG(hdrp->can_id);
+		hdrp->can_id = PCAPINT_BSWAP_32(hdrp->can_id);
 		break;
 
 	case LINUX_SLL_P_CANXL:
@@ -154,19 +154,19 @@ swap_socketcan_header(uint16_t protocol, u_int caplen, u_int length,
 			/* Not enough data to have the priority_vcid field */
 			return;
 		}
-		xl_hdrp->priority_vcid = SWAPLONG(xl_hdrp->priority_vcid);
+		xl_hdrp->priority_vcid = PCAPINT_BSWAP_32(xl_hdrp->priority_vcid);
 		if (caplen < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, payload_length) + sizeof xl_hdrp->payload_length) ||
 		    length < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, payload_length) + sizeof xl_hdrp->payload_length)) {
 			/* Not enough data to have the payload_length field */
 			return;
 		}
-		xl_hdrp->payload_length = SWAPSHORT(xl_hdrp->payload_length);
+		xl_hdrp->payload_length = PCAPINT_BSWAP_16(xl_hdrp->payload_length);
 		if (caplen < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, acceptance_field) + sizeof xl_hdrp->acceptance_field) ||
 		    length < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, acceptance_field) + sizeof xl_hdrp->acceptance_field)) {
 			/* Not enough data to have the acceptance_field field */
 			return;
 		}
-		xl_hdrp->acceptance_field = SWAPLONG(xl_hdrp->acceptance_field);
+		xl_hdrp->acceptance_field = PCAPINT_BSWAP_32(xl_hdrp->acceptance_field);
 		break;
 
 	default:
@@ -269,7 +269,7 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 	offset += 2;			/* skip past bus_id */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->bus_id = SWAPSHORT(uhdr->bus_id);
+	uhdr->bus_id = PCAPINT_BSWAP_16(uhdr->bus_id);
 
 	offset += 2;			/* skip past various 1-byte fields */
 
@@ -281,33 +281,33 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 	offset += 4;			/* skip past ts_usec */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->ts_usec = SWAPLONG(uhdr->ts_usec);
+	uhdr->ts_usec = PCAPINT_BSWAP_32(uhdr->ts_usec);
 
 	offset += 4;			/* skip past status */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->status = SWAPLONG(uhdr->status);
+	uhdr->status = PCAPINT_BSWAP_32(uhdr->status);
 
 	offset += 4;			/* skip past urb_len */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->urb_len = SWAPLONG(uhdr->urb_len);
+	uhdr->urb_len = PCAPINT_BSWAP_32(uhdr->urb_len);
 
 	offset += 4;			/* skip past data_len */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->data_len = SWAPLONG(uhdr->data_len);
+	uhdr->data_len = PCAPINT_BSWAP_32(uhdr->data_len);
 
 	if (uhdr->transfer_type == URB_ISOCHRONOUS) {
 		offset += 4;			/* skip past s.iso.error_count */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->s.iso.error_count = SWAPLONG(uhdr->s.iso.error_count);
+		uhdr->s.iso.error_count = PCAPINT_BSWAP_32(uhdr->s.iso.error_count);
 
 		offset += 4;			/* skip past s.iso.numdesc */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->s.iso.numdesc = SWAPLONG(uhdr->s.iso.numdesc);
+		uhdr->s.iso.numdesc = PCAPINT_BSWAP_32(uhdr->s.iso.numdesc);
 	} else
 		offset += 8;			/* skip USB setup header */
 
@@ -334,22 +334,22 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 		offset += 4;			/* skip past interval */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->interval = SWAPLONG(uhdr->interval);
+		uhdr->interval = PCAPINT_BSWAP_32(uhdr->interval);
 
 		offset += 4;			/* skip past start_frame */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->start_frame = SWAPLONG(uhdr->start_frame);
+		uhdr->start_frame = PCAPINT_BSWAP_32(uhdr->start_frame);
 
 		offset += 4;			/* skip past xfer_flags */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->xfer_flags = SWAPLONG(uhdr->xfer_flags);
+		uhdr->xfer_flags = PCAPINT_BSWAP_32(uhdr->xfer_flags);
 
 		offset += 4;			/* skip past ndesc */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->ndesc = SWAPLONG(uhdr->ndesc);
+		uhdr->ndesc = PCAPINT_BSWAP_32(uhdr->ndesc);
 
 		if (uhdr->transfer_type == URB_ISOCHRONOUS) {
 			/* swap the values in struct linux_usb_isodesc */
@@ -361,17 +361,17 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 				offset += 4;		/* skip past status */
 				if (hdr->caplen < offset)
 					return;
-				pisodesc->status = SWAPLONG(pisodesc->status);
+				pisodesc->status = PCAPINT_BSWAP_32(pisodesc->status);
 
 				offset += 4;		/* skip past offset */
 				if (hdr->caplen < offset)
 					return;
-				pisodesc->offset = SWAPLONG(pisodesc->offset);
+				pisodesc->offset = PCAPINT_BSWAP_32(pisodesc->offset);
 
 				offset += 4;		/* skip past len */
 				if (hdr->caplen < offset)
 					return;
-				pisodesc->len = SWAPLONG(pisodesc->len);
+				pisodesc->len = PCAPINT_BSWAP_32(pisodesc->len);
 
 				offset += 4;		/* skip past padding */
 
@@ -421,8 +421,8 @@ swap_nflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		tlv = (nflog_tlv_t *) p;
 
 		/* Swap the type and length. */
-		tlv->tlv_type = SWAPSHORT(tlv->tlv_type);
-		tlv->tlv_length = SWAPSHORT(tlv->tlv_length);
+		tlv->tlv_type = PCAPINT_BSWAP_16(tlv->tlv_type);
+		tlv->tlv_length = PCAPINT_BSWAP_16(tlv->tlv_length);
 
 		/* Get the length of the TLV. */
 		size = tlv->tlv_length;

--- a/pcap-util.c
+++ b/pcap-util.c
@@ -67,7 +67,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include uid field */
 		return;
 	}
-	pflhdr->uid = SWAPLONG(pflhdr->uid);
+	pflhdr->uid = PCAP_BSWAP_32(pflhdr->uid);
 
 	if (caplen < (u_int) (offsetof(struct pfloghdr, pid) + sizeof pflhdr->pid) ||
 	    length < (u_int) (offsetof(struct pfloghdr, pid) + sizeof pflhdr->pid)) {
@@ -78,7 +78,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include pid field */
 		return;
 	}
-	pflhdr->pid = SWAPLONG(pflhdr->pid);
+	pflhdr->pid = PCAP_BSWAP_32(pflhdr->pid);
 
 	if (caplen < (u_int) (offsetof(struct pfloghdr, rule_uid) + sizeof pflhdr->rule_uid) ||
 	    length < (u_int) (offsetof(struct pfloghdr, rule_uid) + sizeof pflhdr->rule_uid)) {
@@ -89,7 +89,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include rule_uid field */
 		return;
 	}
-	pflhdr->rule_uid = SWAPLONG(pflhdr->rule_uid);
+	pflhdr->rule_uid = PCAP_BSWAP_32(pflhdr->rule_uid);
 
 	if (caplen < (u_int) (offsetof(struct pfloghdr, rule_pid) + sizeof pflhdr->rule_pid) ||
 	    length < (u_int) (offsetof(struct pfloghdr, rule_pid) + sizeof pflhdr->rule_pid)) {
@@ -100,7 +100,7 @@ swap_pflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		/* Header doesn't include rule_pid field */
 		return;
 	}
-	pflhdr->rule_pid = SWAPLONG(pflhdr->rule_pid);
+	pflhdr->rule_pid = PCAP_BSWAP_32(pflhdr->rule_pid);
 }
 
 /*
@@ -139,7 +139,7 @@ swap_socketcan_header(uint16_t protocol, u_int caplen, u_int length,
 			/* Not enough data to have the can_id field */
 			return;
 		}
-		hdrp->can_id = SWAPLONG(hdrp->can_id);
+		hdrp->can_id = PCAP_BSWAP_32(hdrp->can_id);
 		break;
 
 	case LINUX_SLL_P_CANXL:
@@ -154,19 +154,19 @@ swap_socketcan_header(uint16_t protocol, u_int caplen, u_int length,
 			/* Not enough data to have the priority_vcid field */
 			return;
 		}
-		xl_hdrp->priority_vcid = SWAPLONG(xl_hdrp->priority_vcid);
+		xl_hdrp->priority_vcid = PCAP_BSWAP_32(xl_hdrp->priority_vcid);
 		if (caplen < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, payload_length) + sizeof xl_hdrp->payload_length) ||
 		    length < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, payload_length) + sizeof xl_hdrp->payload_length)) {
 			/* Not enough data to have the payload_length field */
 			return;
 		}
-		xl_hdrp->payload_length = SWAPSHORT(xl_hdrp->payload_length);
+		xl_hdrp->payload_length = PCAP_BSWAP_16(xl_hdrp->payload_length);
 		if (caplen < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, acceptance_field) + sizeof xl_hdrp->acceptance_field) ||
 		    length < (u_int) (offsetof(pcap_can_socketcan_xl_hdr, acceptance_field) + sizeof xl_hdrp->acceptance_field)) {
 			/* Not enough data to have the acceptance_field field */
 			return;
 		}
-		xl_hdrp->acceptance_field = SWAPLONG(xl_hdrp->acceptance_field);
+		xl_hdrp->acceptance_field = PCAP_BSWAP_32(xl_hdrp->acceptance_field);
 		break;
 
 	default:
@@ -269,7 +269,7 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 	offset += 2;			/* skip past bus_id */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->bus_id = SWAPSHORT(uhdr->bus_id);
+	uhdr->bus_id = PCAP_BSWAP_16(uhdr->bus_id);
 
 	offset += 2;			/* skip past various 1-byte fields */
 
@@ -281,33 +281,33 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 	offset += 4;			/* skip past ts_usec */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->ts_usec = SWAPLONG(uhdr->ts_usec);
+	uhdr->ts_usec = PCAP_BSWAP_32(uhdr->ts_usec);
 
 	offset += 4;			/* skip past status */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->status = SWAPLONG(uhdr->status);
+	uhdr->status = PCAP_BSWAP_32(uhdr->status);
 
 	offset += 4;			/* skip past urb_len */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->urb_len = SWAPLONG(uhdr->urb_len);
+	uhdr->urb_len = PCAP_BSWAP_32(uhdr->urb_len);
 
 	offset += 4;			/* skip past data_len */
 	if (hdr->caplen < offset)
 		return;
-	uhdr->data_len = SWAPLONG(uhdr->data_len);
+	uhdr->data_len = PCAP_BSWAP_32(uhdr->data_len);
 
 	if (uhdr->transfer_type == URB_ISOCHRONOUS) {
 		offset += 4;			/* skip past s.iso.error_count */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->s.iso.error_count = SWAPLONG(uhdr->s.iso.error_count);
+		uhdr->s.iso.error_count = PCAP_BSWAP_32(uhdr->s.iso.error_count);
 
 		offset += 4;			/* skip past s.iso.numdesc */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->s.iso.numdesc = SWAPLONG(uhdr->s.iso.numdesc);
+		uhdr->s.iso.numdesc = PCAP_BSWAP_32(uhdr->s.iso.numdesc);
 	} else
 		offset += 8;			/* skip USB setup header */
 
@@ -334,22 +334,22 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 		offset += 4;			/* skip past interval */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->interval = SWAPLONG(uhdr->interval);
+		uhdr->interval = PCAP_BSWAP_32(uhdr->interval);
 
 		offset += 4;			/* skip past start_frame */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->start_frame = SWAPLONG(uhdr->start_frame);
+		uhdr->start_frame = PCAP_BSWAP_32(uhdr->start_frame);
 
 		offset += 4;			/* skip past xfer_flags */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->xfer_flags = SWAPLONG(uhdr->xfer_flags);
+		uhdr->xfer_flags = PCAP_BSWAP_32(uhdr->xfer_flags);
 
 		offset += 4;			/* skip past ndesc */
 		if (hdr->caplen < offset)
 			return;
-		uhdr->ndesc = SWAPLONG(uhdr->ndesc);
+		uhdr->ndesc = PCAP_BSWAP_32(uhdr->ndesc);
 
 		if (uhdr->transfer_type == URB_ISOCHRONOUS) {
 			/* swap the values in struct linux_usb_isodesc */
@@ -361,17 +361,17 @@ swap_linux_usb_header(const struct pcap_pkthdr *hdr, u_char *buf,
 				offset += 4;		/* skip past status */
 				if (hdr->caplen < offset)
 					return;
-				pisodesc->status = SWAPLONG(pisodesc->status);
+				pisodesc->status = PCAP_BSWAP_32(pisodesc->status);
 
 				offset += 4;		/* skip past offset */
 				if (hdr->caplen < offset)
 					return;
-				pisodesc->offset = SWAPLONG(pisodesc->offset);
+				pisodesc->offset = PCAP_BSWAP_32(pisodesc->offset);
 
 				offset += 4;		/* skip past len */
 				if (hdr->caplen < offset)
 					return;
-				pisodesc->len = SWAPLONG(pisodesc->len);
+				pisodesc->len = PCAP_BSWAP_32(pisodesc->len);
 
 				offset += 4;		/* skip past padding */
 
@@ -421,8 +421,8 @@ swap_nflog_header(const struct pcap_pkthdr *hdr, u_char *buf)
 		tlv = (nflog_tlv_t *) p;
 
 		/* Swap the type and length. */
-		tlv->tlv_type = SWAPSHORT(tlv->tlv_type);
-		tlv->tlv_length = SWAPSHORT(tlv->tlv_length);
+		tlv->tlv_type = PCAP_BSWAP_16(tlv->tlv_type);
+		tlv->tlv_length = PCAP_BSWAP_16(tlv->tlv_length);
 
 		/* Get the length of the TLV. */
 		size = tlv->tlv_length;

--- a/pcap-util.h
+++ b/pcap-util.h
@@ -42,20 +42,21 @@
  * ntoh[ls] aren't sufficient because we might need to swap on a big-endian
  * machine (if the file was written in little-end order).
  */
-#define SWAPLL(y)  ((((uint64_t)(y) & 0xff00000000000000ULL) >> 56) | \
-                      (((uint64_t)(y) & 0x00ff000000000000ULL) >> 40) | \
-                      (((uint64_t)(y) & 0x0000ff0000000000ULL) >> 24) | \
-                      (((uint64_t)(y) & 0x000000ff00000000ULL) >> 8)  | \
-                      (((uint64_t)(y) & 0x00000000ff000000ULL) << 8)  | \
-                      (((uint64_t)(y) & 0x0000000000ff0000ULL) << 24) | \
-                      (((uint64_t)(y) & 0x000000000000ff00ULL) << 40) | \
-                      (((uint64_t)(y) & 0x00000000000000ffULL) << 56))
-#define	SWAPLONG(y) \
+#define PCAPINT_BSWAP_64(y) \
+    ((((uint64_t)(y) & 0xff00000000000000ULL) >> 56) | \
+     (((uint64_t)(y) & 0x00ff000000000000ULL) >> 40) | \
+     (((uint64_t)(y) & 0x0000ff0000000000ULL) >> 24) | \
+     (((uint64_t)(y) & 0x000000ff00000000ULL) >> 8)  | \
+     (((uint64_t)(y) & 0x00000000ff000000ULL) << 8)  | \
+     (((uint64_t)(y) & 0x0000000000ff0000ULL) << 24) | \
+     (((uint64_t)(y) & 0x000000000000ff00ULL) << 40) | \
+     (((uint64_t)(y) & 0x00000000000000ffULL) << 56))
+#define PCAPINT_BSWAP_32(y) \
     (((((u_int)(y))&0xff)<<24) | \
      ((((u_int)(y))&0xff00)<<8) | \
      ((((u_int)(y))&0xff0000)>>8) | \
      ((((u_int)(y))>>24)&0xff))
-#define	SWAPSHORT(y) \
+#define PCAPINT_BSWAP_16(y) \
      ((u_short)(((((u_int)(y))&0xff)<<8) | \
                 ((((u_int)(y))&0xff00)>>8)))
 
@@ -64,7 +65,7 @@
  */
 static inline pcap_4_byte_aligned_uint64 swap_4_byte_aligned_uint64(pcap_4_byte_aligned_uint64 val)
 {
-	return (pcap_4_byte_aligned_uint64){.halves[0] = SWAPLONG(val.halves[1]), .halves[1] = SWAPLONG(val.halves[0])};
+	return (pcap_4_byte_aligned_uint64){.halves[0] = PCAPINT_BSWAP_32(val.halves[1]), .halves[1] = PCAPINT_BSWAP_32(val.halves[0])};
 }
 
 /*
@@ -72,7 +73,7 @@ static inline pcap_4_byte_aligned_uint64 swap_4_byte_aligned_uint64(pcap_4_byte_
  */
 static inline pcap_4_byte_aligned_int64 swap_4_byte_aligned_int64(pcap_4_byte_aligned_int64 val)
 {
-	return (pcap_4_byte_aligned_int64){.halves[0] = SWAPLONG(val.halves[1]), .halves[1] = SWAPLONG(val.halves[0])};
+	return (pcap_4_byte_aligned_int64){.halves[0] = PCAPINT_BSWAP_32(val.halves[1]), .halves[1] = PCAPINT_BSWAP_32(val.halves[0])};
 }
 
 extern void pcapint_post_process(int linktype, int swapped,

--- a/pcap-util.h
+++ b/pcap-util.h
@@ -42,20 +42,21 @@
  * ntoh[ls] aren't sufficient because we might need to swap on a big-endian
  * machine (if the file was written in little-end order).
  */
-#define SWAPLL(y)  ((((uint64_t)(y) & 0xff00000000000000ULL) >> 56) | \
-                      (((uint64_t)(y) & 0x00ff000000000000ULL) >> 40) | \
-                      (((uint64_t)(y) & 0x0000ff0000000000ULL) >> 24) | \
-                      (((uint64_t)(y) & 0x000000ff00000000ULL) >> 8)  | \
-                      (((uint64_t)(y) & 0x00000000ff000000ULL) << 8)  | \
-                      (((uint64_t)(y) & 0x0000000000ff0000ULL) << 24) | \
-                      (((uint64_t)(y) & 0x000000000000ff00ULL) << 40) | \
-                      (((uint64_t)(y) & 0x00000000000000ffULL) << 56))
-#define	SWAPLONG(y) \
+#define PCAP_BSWAP_64(y) \
+    ((((uint64_t)(y) & 0xff00000000000000ULL) >> 56) | \
+     (((uint64_t)(y) & 0x00ff000000000000ULL) >> 40) | \
+     (((uint64_t)(y) & 0x0000ff0000000000ULL) >> 24) | \
+     (((uint64_t)(y) & 0x000000ff00000000ULL) >> 8)  | \
+     (((uint64_t)(y) & 0x00000000ff000000ULL) << 8)  | \
+     (((uint64_t)(y) & 0x0000000000ff0000ULL) << 24) | \
+     (((uint64_t)(y) & 0x000000000000ff00ULL) << 40) | \
+     (((uint64_t)(y) & 0x00000000000000ffULL) << 56))
+#define PCAP_BSWAP_32(y) \
     (((((u_int)(y))&0xff)<<24) | \
      ((((u_int)(y))&0xff00)<<8) | \
      ((((u_int)(y))&0xff0000)>>8) | \
      ((((u_int)(y))>>24)&0xff))
-#define	SWAPSHORT(y) \
+#define PCAP_BSWAP_16(y) \
      ((u_short)(((((u_int)(y))&0xff)<<8) | \
                 ((((u_int)(y))&0xff00)>>8)))
 
@@ -64,7 +65,7 @@
  */
 static inline pcap_4_byte_aligned_uint64 swap_4_byte_aligned_uint64(pcap_4_byte_aligned_uint64 val)
 {
-	return (pcap_4_byte_aligned_uint64){.halves[0] = SWAPLONG(val.halves[1]), .halves[1] = SWAPLONG(val.halves[0])};
+	return (pcap_4_byte_aligned_uint64){.halves[0] = PCAP_BSWAP_32(val.halves[1]), .halves[1] = PCAP_BSWAP_32(val.halves[0])};
 }
 
 /*
@@ -72,7 +73,7 @@ static inline pcap_4_byte_aligned_uint64 swap_4_byte_aligned_uint64(pcap_4_byte_
  */
 static inline pcap_4_byte_aligned_int64 swap_4_byte_aligned_int64(pcap_4_byte_aligned_int64 val)
 {
-	return (pcap_4_byte_aligned_int64){.halves[0] = SWAPLONG(val.halves[1]), .halves[1] = SWAPLONG(val.halves[0])};
+	return (pcap_4_byte_aligned_int64){.halves[0] = PCAP_BSWAP_32(val.halves[1]), .halves[1] = PCAP_BSWAP_32(val.halves[0])};
 }
 
 extern void pcapint_post_process(int linktype, int swapped,

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -239,7 +239,7 @@ pcap_check_header(const uint8_t *magic, FILE *fp, u_int precision, char *errbuf,
 	if (magic_int != TCPDUMP_MAGIC &&
 	    magic_int != KUZNETZOV_TCPDUMP_MAGIC &&
 	    magic_int != NSEC_TCPDUMP_MAGIC) {
-		magic_int = SWAPLONG(magic_int);
+		magic_int = PCAPINT_BSWAP_32(magic_int);
 		if (magic_int != TCPDUMP_MAGIC &&
 		    magic_int != KUZNETZOV_TCPDUMP_MAGIC &&
 		    magic_int != NSEC_TCPDUMP_MAGIC)
@@ -271,12 +271,12 @@ pcap_check_header(const uint8_t *magic, FILE *fp, u_int precision, char *errbuf,
 	 * If it's a byte-swapped capture file, byte-swap the header.
 	 */
 	if (swapped) {
-		hdr.version_major = SWAPSHORT(hdr.version_major);
-		hdr.version_minor = SWAPSHORT(hdr.version_minor);
-		hdr.thiszone = SWAPLONG(hdr.thiszone);
-		hdr.sigfigs = SWAPLONG(hdr.sigfigs);
-		hdr.snaplen = SWAPLONG(hdr.snaplen);
-		hdr.linktype = SWAPLONG(hdr.linktype);
+		hdr.version_major = PCAPINT_BSWAP_16(hdr.version_major);
+		hdr.version_minor = PCAPINT_BSWAP_16(hdr.version_minor);
+		hdr.thiszone = PCAPINT_BSWAP_32(hdr.thiszone);
+		hdr.sigfigs = PCAPINT_BSWAP_32(hdr.sigfigs);
+		hdr.snaplen = PCAPINT_BSWAP_32(hdr.snaplen);
+		hdr.linktype = PCAPINT_BSWAP_32(hdr.linktype);
 	}
 
 	/*
@@ -542,10 +542,10 @@ pcap_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 
 	if (p->swapped) {
 		/* these were written in opposite byte order */
-		hdr->caplen = SWAPLONG(sf_hdr.caplen);
-		hdr->len = SWAPLONG(sf_hdr.len);
-		hdr->ts.tv_sec = SWAPLONG(sf_hdr.ts.tv_sec);
-		hdr->ts.tv_usec = SWAPLONG(sf_hdr.ts.tv_usec);
+		hdr->caplen = PCAPINT_BSWAP_32(sf_hdr.caplen);
+		hdr->len = PCAPINT_BSWAP_32(sf_hdr.len);
+		hdr->ts.tv_sec = PCAPINT_BSWAP_32(sf_hdr.ts.tv_sec);
+		hdr->ts.tv_usec = PCAPINT_BSWAP_32(sf_hdr.ts.tv_usec);
 	} else {
 		hdr->caplen = sf_hdr.caplen;
 		hdr->len = sf_hdr.len;
@@ -1116,17 +1116,17 @@ pcap_dump_open_append(pcap_t *p, const char *fname)
 			}
 			break;
 
-		case SWAPLONG(TCPDUMP_MAGIC):
-		case SWAPLONG(NSEC_TCPDUMP_MAGIC):
+		case PCAPINT_BSWAP_32(TCPDUMP_MAGIC):
+		case PCAPINT_BSWAP_32(NSEC_TCPDUMP_MAGIC):
 			snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 			    "%s: different byte order, cannot append to file", fname);
 			(void)fclose(f);
 			return (NULL);
 
 		case KUZNETZOV_TCPDUMP_MAGIC:
-		case SWAPLONG(KUZNETZOV_TCPDUMP_MAGIC):
+		case PCAPINT_BSWAP_32(KUZNETZOV_TCPDUMP_MAGIC):
 		case NAVTEL_TCPDUMP_MAGIC:
-		case SWAPLONG(NAVTEL_TCPDUMP_MAGIC):
+		case PCAPINT_BSWAP_32(NAVTEL_TCPDUMP_MAGIC):
 			snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 			    "%s: not a pcap file to which we can append", fname);
 			(void)fclose(f);

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -239,7 +239,7 @@ pcap_check_header(const uint8_t *magic, FILE *fp, u_int precision, char *errbuf,
 	if (magic_int != TCPDUMP_MAGIC &&
 	    magic_int != KUZNETZOV_TCPDUMP_MAGIC &&
 	    magic_int != NSEC_TCPDUMP_MAGIC) {
-		magic_int = SWAPLONG(magic_int);
+		magic_int = PCAP_BSWAP_32(magic_int);
 		if (magic_int != TCPDUMP_MAGIC &&
 		    magic_int != KUZNETZOV_TCPDUMP_MAGIC &&
 		    magic_int != NSEC_TCPDUMP_MAGIC)
@@ -271,12 +271,12 @@ pcap_check_header(const uint8_t *magic, FILE *fp, u_int precision, char *errbuf,
 	 * If it's a byte-swapped capture file, byte-swap the header.
 	 */
 	if (swapped) {
-		hdr.version_major = SWAPSHORT(hdr.version_major);
-		hdr.version_minor = SWAPSHORT(hdr.version_minor);
-		hdr.thiszone = SWAPLONG(hdr.thiszone);
-		hdr.sigfigs = SWAPLONG(hdr.sigfigs);
-		hdr.snaplen = SWAPLONG(hdr.snaplen);
-		hdr.linktype = SWAPLONG(hdr.linktype);
+		hdr.version_major = PCAP_BSWAP_16(hdr.version_major);
+		hdr.version_minor = PCAP_BSWAP_16(hdr.version_minor);
+		hdr.thiszone = PCAP_BSWAP_32(hdr.thiszone);
+		hdr.sigfigs = PCAP_BSWAP_32(hdr.sigfigs);
+		hdr.snaplen = PCAP_BSWAP_32(hdr.snaplen);
+		hdr.linktype = PCAP_BSWAP_32(hdr.linktype);
 	}
 
 	/*
@@ -542,10 +542,10 @@ pcap_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 
 	if (p->swapped) {
 		/* these were written in opposite byte order */
-		hdr->caplen = SWAPLONG(sf_hdr.caplen);
-		hdr->len = SWAPLONG(sf_hdr.len);
-		hdr->ts.tv_sec = SWAPLONG(sf_hdr.ts.tv_sec);
-		hdr->ts.tv_usec = SWAPLONG(sf_hdr.ts.tv_usec);
+		hdr->caplen = PCAP_BSWAP_32(sf_hdr.caplen);
+		hdr->len = PCAP_BSWAP_32(sf_hdr.len);
+		hdr->ts.tv_sec = PCAP_BSWAP_32(sf_hdr.ts.tv_sec);
+		hdr->ts.tv_usec = PCAP_BSWAP_32(sf_hdr.ts.tv_usec);
 	} else {
 		hdr->caplen = sf_hdr.caplen;
 		hdr->len = sf_hdr.len;
@@ -1116,17 +1116,17 @@ pcap_dump_open_append(pcap_t *p, const char *fname)
 			}
 			break;
 
-		case SWAPLONG(TCPDUMP_MAGIC):
-		case SWAPLONG(NSEC_TCPDUMP_MAGIC):
+		case PCAP_BSWAP_32(TCPDUMP_MAGIC):
+		case PCAP_BSWAP_32(NSEC_TCPDUMP_MAGIC):
 			snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 			    "%s: different byte order, cannot append to file", fname);
 			(void)fclose(f);
 			return (NULL);
 
 		case KUZNETZOV_TCPDUMP_MAGIC:
-		case SWAPLONG(KUZNETZOV_TCPDUMP_MAGIC):
+		case PCAP_BSWAP_32(KUZNETZOV_TCPDUMP_MAGIC):
 		case NAVTEL_TCPDUMP_MAGIC:
-		case SWAPLONG(NAVTEL_TCPDUMP_MAGIC):
+		case PCAP_BSWAP_32(NAVTEL_TCPDUMP_MAGIC):
 			snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
 			    "%s: not a pcap file to which we can append", fname);
 			(void)fclose(f);

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -292,8 +292,8 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 		return (status);	/* error or EOF */
 
 	if (p->swapped) {
-		bhdr.block_type = SWAPLONG(bhdr.block_type);
-		bhdr.total_length = SWAPLONG(bhdr.total_length);
+		bhdr.block_type = PCAPINT_BSWAP_32(bhdr.block_type);
+		bhdr.total_length = PCAPINT_BSWAP_32(bhdr.total_length);
 	}
 
 	/*
@@ -360,7 +360,7 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 	 */
 	btrlr = (struct block_trailer *)(bdata + data_remaining - sizeof (struct block_trailer));
 	if (p->swapped)
-		btrlr->total_length = SWAPLONG(btrlr->total_length);
+		btrlr->total_length = PCAPINT_BSWAP_32(btrlr->total_length);
 
 	/*
 	 * Is the total length from the trailer the same as the total
@@ -428,8 +428,8 @@ get_opthdr_from_block_data(pcap_t *p, struct block_cursor *cursor, char *errbuf)
 	 * Byte-swap it if necessary.
 	 */
 	if (p->swapped) {
-		opthdr->option_code = SWAPSHORT(opthdr->option_code);
-		opthdr->option_length = SWAPSHORT(opthdr->option_length);
+		opthdr->option_code = PCAPINT_BSWAP_16(opthdr->option_code);
+		opthdr->option_length = PCAPINT_BSWAP_16(opthdr->option_length);
 	}
 
 	return (opthdr);
@@ -576,7 +576,7 @@ process_idb_options(pcap_t *p, struct block_cursor *cursor, uint64_t *tsresol,
 			saw_tsoffset = 1;
 			memcpy(tsoffset, optvalue, sizeof(*tsoffset));
 			if (p->swapped)
-				*tsoffset = SWAPLL(*tsoffset);
+				*tsoffset = PCAPINT_BSWAP_64(*tsoffset);
 			break;
 
 		default:
@@ -847,7 +847,7 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 		return (NULL);
 	}
 	if (byte_order_magic != BYTE_ORDER_MAGIC) {
-		byte_order_magic = SWAPLONG(byte_order_magic);
+		byte_order_magic = PCAPINT_BSWAP_32(byte_order_magic);
 		if (byte_order_magic != BYTE_ORDER_MAGIC) {
 			/*
 			 * Not a pcapng file.
@@ -855,7 +855,7 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 			return (NULL);
 		}
 		swapped = 1;
-		total_length = SWAPLONG(total_length);
+		total_length = PCAPINT_BSWAP_32(total_length);
 	}
 
 	/*
@@ -956,8 +956,8 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 		/*
 		 * Byte-swap the fields we've read.
 		 */
-		shbp->major_version = SWAPSHORT(shbp->major_version);
-		shbp->minor_version = SWAPSHORT(shbp->minor_version);
+		shbp->major_version = PCAPINT_BSWAP_16(shbp->major_version);
+		shbp->minor_version = PCAPINT_BSWAP_16(shbp->minor_version);
 
 		/*
 		 * XXX - we don't care about the section length.
@@ -1025,8 +1025,8 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 			 * Byte-swap it if necessary.
 			 */
 			if (p->swapped) {
-				idbp->linktype = SWAPSHORT(idbp->linktype);
-				idbp->snaplen = SWAPLONG(idbp->snaplen);
+				idbp->linktype = PCAPINT_BSWAP_16(idbp->linktype);
+				idbp->snaplen = PCAPINT_BSWAP_32(idbp->snaplen);
 			}
 
 			/*
@@ -1143,11 +1143,11 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				/* these were written in opposite byte order */
-				interface_id = SWAPLONG(epbp->interface_id);
-				hdr->caplen = SWAPLONG(epbp->caplen);
-				hdr->len = SWAPLONG(epbp->len);
-				t = ((uint64_t)SWAPLONG(epbp->timestamp_high)) << 32 |
-				    SWAPLONG(epbp->timestamp_low);
+				interface_id = PCAPINT_BSWAP_32(epbp->interface_id);
+				hdr->caplen = PCAPINT_BSWAP_32(epbp->caplen);
+				hdr->len = PCAPINT_BSWAP_32(epbp->len);
+				t = ((uint64_t)PCAPINT_BSWAP_32(epbp->timestamp_high)) << 32 |
+				    PCAPINT_BSWAP_32(epbp->timestamp_low);
 			} else {
 				interface_id = epbp->interface_id;
 				hdr->caplen = epbp->caplen;
@@ -1178,7 +1178,7 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				/* these were written in opposite byte order */
-				hdr->len = SWAPLONG(spbp->len);
+				hdr->len = PCAPINT_BSWAP_32(spbp->len);
 			} else
 				hdr->len = spbp->len;
 
@@ -1208,11 +1208,11 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				/* these were written in opposite byte order */
-				interface_id = SWAPSHORT(pbp->interface_id);
-				hdr->caplen = SWAPLONG(pbp->caplen);
-				hdr->len = SWAPLONG(pbp->len);
-				t = ((uint64_t)SWAPLONG(pbp->timestamp_high)) << 32 |
-				    SWAPLONG(pbp->timestamp_low);
+				interface_id = PCAPINT_BSWAP_16(pbp->interface_id);
+				hdr->caplen = PCAPINT_BSWAP_32(pbp->caplen);
+				hdr->len = PCAPINT_BSWAP_32(pbp->len);
+				t = ((uint64_t)PCAPINT_BSWAP_32(pbp->timestamp_high)) << 32 |
+				    PCAPINT_BSWAP_32(pbp->timestamp_low);
 			} else {
 				interface_id = pbp->interface_id;
 				hdr->caplen = pbp->caplen;
@@ -1236,8 +1236,8 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 * Byte-swap it if necessary.
 			 */
 			if (p->swapped) {
-				idbp->linktype = SWAPSHORT(idbp->linktype);
-				idbp->snaplen = SWAPLONG(idbp->snaplen);
+				idbp->linktype = PCAPINT_BSWAP_16(idbp->linktype);
+				idbp->snaplen = PCAPINT_BSWAP_32(idbp->snaplen);
 			}
 
 			/*
@@ -1291,9 +1291,9 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				shbp->byte_order_magic =
-				    SWAPLONG(shbp->byte_order_magic);
+				    PCAPINT_BSWAP_32(shbp->byte_order_magic);
 				shbp->major_version =
-				    SWAPSHORT(shbp->major_version);
+				    PCAPINT_BSWAP_16(shbp->major_version);
 			}
 
 			/*
@@ -1309,7 +1309,7 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 				 */
 				break;
 
-			case SWAPLONG(BYTE_ORDER_MAGIC):
+			case PCAPINT_BSWAP_32(BYTE_ORDER_MAGIC):
 				/*
 				 * Byte order changes.
 				 */

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -292,8 +292,8 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 		return (status);	/* error or EOF */
 
 	if (p->swapped) {
-		bhdr.block_type = SWAPLONG(bhdr.block_type);
-		bhdr.total_length = SWAPLONG(bhdr.total_length);
+		bhdr.block_type = PCAP_BSWAP_32(bhdr.block_type);
+		bhdr.total_length = PCAP_BSWAP_32(bhdr.total_length);
 	}
 
 	/*
@@ -360,7 +360,7 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 	 */
 	btrlr = (struct block_trailer *)(bdata + data_remaining - sizeof (struct block_trailer));
 	if (p->swapped)
-		btrlr->total_length = SWAPLONG(btrlr->total_length);
+		btrlr->total_length = PCAP_BSWAP_32(btrlr->total_length);
 
 	/*
 	 * Is the total length from the trailer the same as the total
@@ -428,8 +428,8 @@ get_opthdr_from_block_data(pcap_t *p, struct block_cursor *cursor, char *errbuf)
 	 * Byte-swap it if necessary.
 	 */
 	if (p->swapped) {
-		opthdr->option_code = SWAPSHORT(opthdr->option_code);
-		opthdr->option_length = SWAPSHORT(opthdr->option_length);
+		opthdr->option_code = PCAP_BSWAP_16(opthdr->option_code);
+		opthdr->option_length = PCAP_BSWAP_16(opthdr->option_length);
 	}
 
 	return (opthdr);
@@ -576,7 +576,7 @@ process_idb_options(pcap_t *p, struct block_cursor *cursor, uint64_t *tsresol,
 			saw_tsoffset = 1;
 			memcpy(tsoffset, optvalue, sizeof(*tsoffset));
 			if (p->swapped)
-				*tsoffset = SWAPLL(*tsoffset);
+				*tsoffset = PCAP_BSWAP_64(*tsoffset);
 			break;
 
 		default:
@@ -847,7 +847,7 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 		return (NULL);
 	}
 	if (byte_order_magic != BYTE_ORDER_MAGIC) {
-		byte_order_magic = SWAPLONG(byte_order_magic);
+		byte_order_magic = PCAP_BSWAP_32(byte_order_magic);
 		if (byte_order_magic != BYTE_ORDER_MAGIC) {
 			/*
 			 * Not a pcapng file.
@@ -855,7 +855,7 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 			return (NULL);
 		}
 		swapped = 1;
-		total_length = SWAPLONG(total_length);
+		total_length = PCAP_BSWAP_32(total_length);
 	}
 
 	/*
@@ -956,8 +956,8 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 		/*
 		 * Byte-swap the fields we've read.
 		 */
-		shbp->major_version = SWAPSHORT(shbp->major_version);
-		shbp->minor_version = SWAPSHORT(shbp->minor_version);
+		shbp->major_version = PCAP_BSWAP_16(shbp->major_version);
+		shbp->minor_version = PCAP_BSWAP_16(shbp->minor_version);
 
 		/*
 		 * XXX - we don't care about the section length.
@@ -1025,8 +1025,8 @@ pcap_ng_check_header(const uint8_t *magic, FILE *fp, u_int precision,
 			 * Byte-swap it if necessary.
 			 */
 			if (p->swapped) {
-				idbp->linktype = SWAPSHORT(idbp->linktype);
-				idbp->snaplen = SWAPLONG(idbp->snaplen);
+				idbp->linktype = PCAP_BSWAP_16(idbp->linktype);
+				idbp->snaplen = PCAP_BSWAP_32(idbp->snaplen);
 			}
 
 			/*
@@ -1143,11 +1143,11 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				/* these were written in opposite byte order */
-				interface_id = SWAPLONG(epbp->interface_id);
-				hdr->caplen = SWAPLONG(epbp->caplen);
-				hdr->len = SWAPLONG(epbp->len);
-				t = ((uint64_t)SWAPLONG(epbp->timestamp_high)) << 32 |
-				    SWAPLONG(epbp->timestamp_low);
+				interface_id = PCAP_BSWAP_32(epbp->interface_id);
+				hdr->caplen = PCAP_BSWAP_32(epbp->caplen);
+				hdr->len = PCAP_BSWAP_32(epbp->len);
+				t = ((uint64_t)PCAP_BSWAP_32(epbp->timestamp_high)) << 32 |
+				    PCAP_BSWAP_32(epbp->timestamp_low);
 			} else {
 				interface_id = epbp->interface_id;
 				hdr->caplen = epbp->caplen;
@@ -1178,7 +1178,7 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				/* these were written in opposite byte order */
-				hdr->len = SWAPLONG(spbp->len);
+				hdr->len = PCAP_BSWAP_32(spbp->len);
 			} else
 				hdr->len = spbp->len;
 
@@ -1208,11 +1208,11 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				/* these were written in opposite byte order */
-				interface_id = SWAPSHORT(pbp->interface_id);
-				hdr->caplen = SWAPLONG(pbp->caplen);
-				hdr->len = SWAPLONG(pbp->len);
-				t = ((uint64_t)SWAPLONG(pbp->timestamp_high)) << 32 |
-				    SWAPLONG(pbp->timestamp_low);
+				interface_id = PCAP_BSWAP_16(pbp->interface_id);
+				hdr->caplen = PCAP_BSWAP_32(pbp->caplen);
+				hdr->len = PCAP_BSWAP_32(pbp->len);
+				t = ((uint64_t)PCAP_BSWAP_32(pbp->timestamp_high)) << 32 |
+				    PCAP_BSWAP_32(pbp->timestamp_low);
 			} else {
 				interface_id = pbp->interface_id;
 				hdr->caplen = pbp->caplen;
@@ -1236,8 +1236,8 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 * Byte-swap it if necessary.
 			 */
 			if (p->swapped) {
-				idbp->linktype = SWAPSHORT(idbp->linktype);
-				idbp->snaplen = SWAPLONG(idbp->snaplen);
+				idbp->linktype = PCAP_BSWAP_16(idbp->linktype);
+				idbp->snaplen = PCAP_BSWAP_32(idbp->snaplen);
 			}
 
 			/*
@@ -1291,9 +1291,9 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 			 */
 			if (p->swapped) {
 				shbp->byte_order_magic =
-				    SWAPLONG(shbp->byte_order_magic);
+				    PCAP_BSWAP_32(shbp->byte_order_magic);
 				shbp->major_version =
-				    SWAPSHORT(shbp->major_version);
+				    PCAP_BSWAP_16(shbp->major_version);
 			}
 
 			/*
@@ -1309,7 +1309,7 @@ pcap_ng_next_packet(pcap_t *p, struct pcap_pkthdr *hdr, u_char **data)
 				 */
 				break;
 
-			case SWAPLONG(BYTE_ORDER_MAGIC):
+			case PCAP_BSWAP_32(BYTE_ORDER_MAGIC):
 				/*
 				 * Byte order changes.
 				 */


### PR DESCRIPTION
In particular, 'LONG' was ambiguous because it is 4 bytes in a 32-bit build and 8 bytes in a 64-bit build.

Don't use BSWAP_({16,32,64}) to avoid redefine on Solaris/illumos.