### PR TITLE
Preserve statements when collapsing root branch chains

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -2157,14 +2157,23 @@ opt_root(struct block **b)
 {
 	struct slist *tmp, *s;
 
-	s = (*b)->stmts;
-	(*b)->stmts = 0;
-	while (BPF_CLASS((*b)->s.code) == BPF_JMP && JT(*b) == JF(*b))
-		*b = JT(*b);
+	/*
+	 * A block with identical successors still executes its statements.
+	 * Preserve each statement list in order while collapsing the chain.
+	 */
+	s = 0;
+	for (;;) {
+		tmp = (*b)->stmts;
+		(*b)->stmts = 0;
+		if (s == 0)
+			s = tmp;
+		else if (tmp != 0)
+			sappend(s, tmp);
 
-	tmp = (*b)->stmts;
-	if (tmp != 0)
-		sappend(s, tmp);
+		if (BPF_CLASS((*b)->s.code) != BPF_JMP || JT(*b) != JF(*b))
+			break;
+		*b = JT(*b);
+	}
 	(*b)->stmts = s;
 
 	/*

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -25810,6 +25810,18 @@ my @filter_accept_blocks = (
 # * results (mandatory, array): the list of program filter results to expect
 my @filter_apply_blocks = (
 	{
+		name => 'constant_true_subexpressions_on_pppoed',
+		savefile => 'pppoe.pcap',
+		expr => '1/2=1/3&&1>4/5&&1>6/7',
+		results => [1508],
+	},
+	{
+		name => 'constant_false_subexpressions_on_pppoed',
+		savefile => 'pppoe.pcap',
+		expr => '1/2=1/3&&1>4/5&&1=6/7',
+		results => [0],
+	},
+	{
 		name => 'pppoed_nullary_on_ctp',
 		savefile => 'loopback.pcap',
 		expr => 'pppoed',


### PR DESCRIPTION
Fixes #1699.

`opt_root()` follows chains of jump blocks whose true and false successors are identical. Each block still executes its statements, but the old loop retained statements only from the first and final blocks. Statements on intermediate blocks were discarded, so the surviving comparison could run with stale BPF register values.

This change preserves every traversed statement list in execution order and adds one-packet execution regressions for both undercapture and overcapture.

On unmodified current master, the optimized true case returns 0 instead of 1508 and the optimized false case returns 1508 instead of 0. Both unoptimized controls pass. With optimizer debugging enabled, the graph after `opt_root()` shows that the old code drops the intermediate `ld #0x1`; the patched graph preserves it immediately before the final `jgt x`.

Testing: `TESTRUN_JOBS=4 make check` (14,613 passed, 6,585 platform skips, 0 failed).