### PR TITLE
pcap-bpf: have device_exists() own the socket descriptor.

### DIFF
--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -866,8 +866,9 @@ bpf_open_and_bind(const char *name, char *errbuf)
 
 #ifdef __APPLE__
 static int
-device_exists(int fd, const char *name, char *errbuf)
+device_exists(const char *name, char *errbuf)
 {
+	int fd;
 	int status;
 	struct ifreq ifr;
 
@@ -875,32 +876,44 @@ device_exists(int fd, const char *name, char *errbuf)
 		/* The name is too long, so it can't possibly exist. */
 		return (PCAP_ERROR_NO_SUCH_DEVICE);
 	}
-	(void)pcapint_strlcpy(ifr.ifr_name, name, sizeof(ifr.ifr_name));
-	status = ioctl(fd, SIOCGIFFLAGS, (caddr_t)&ifr);
 
-	if (status < 0) {
-		if (errno == ENXIO || errno == EINVAL) {
-			/*
-			 * macOS and *BSD return one of those two
-			 * errors if the device doesn't exist.
-			 * Don't fill in an error, as this is
-			 * an "expected" condition.
-			 */
-			return (PCAP_ERROR_NO_SUCH_DEVICE);
-		}
-
-		/*
-		 * Some other error - provide a message for it, as
-		 * it's "unexpected".
-		 */
-		pcapint_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE, errno,
-		    "Can't get interface flags on %s", name);
+	/*
+	 * Attempt to pen a socket on which we can do an ioctl to
+	 * check whether the device exists.
+	 */
+	fd = socket(AF_INET, SOCK_DGRAM, 0);
+	if (fd == -1) {
+		/* That failed; report that as the error. */
+		pcapint_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "Can't open socket to check whether a device exists");
 		return (PCAP_ERROR);
 	}
 
+	(void)pcapint_strlcpy(ifr.ifr_name, name, sizeof(ifr.ifr_name));
+	status = ioctl(fd, SIOCGIFFLAGS, (caddr_t)&ifr);
+
+	if (status < 0 && (errno == ENXIO || errno == EINVAL)) {
+		/*
+		 * macOS and *BSD return one of those two errors if
+		 * the device doesn't exist.
+		 *
+		 * Don't fill in an error, as this is an "expected"
+		 * condition; this routine's purpose is to test
+		 * whether a device exists, and "it doesn't exist"
+		 * is an answer, not an indication that we couldn't
+		 * determine whether it exists.
+		 */
+		close(fd);
+		return (PCAP_ERROR_NO_SUCH_DEVICE);
+	}
+
 	/*
-	 * The device exists.
+	 * Either we were able to fetch the interface flags, indicating
+	 * that it exists, or we weren't able to fetch them but got an
+	 * error *other* than "there is no such device", which we
+	 * treat as an indication that the device exists.
 	 */
+	close(fd);
 	return (0);
 }
 #endif
@@ -1045,21 +1058,14 @@ pcap_can_set_rfmon_bpf(pcap_t *p)
 			 */
 			return (0);
 		}
-		fd = socket(AF_INET, SOCK_DGRAM, 0);
-		if (fd == -1) {
-			pcapint_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
-			    errno, "socket");
-			return (PCAP_ERROR);
-		}
 		if (pcapint_asprintf(&wlt_name, "wlt%s", p->opt.device + 2) == -1) {
 			pcapint_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
 			    errno, "malloc");
 			close(fd);
 			return (PCAP_ERROR);
 		}
-		status = device_exists(fd, wlt_name, p->errbuf);
+		status = device_exists(wlt_name, p->errbuf);
 		free(wlt_name);
-		close(fd);
 		if (status != 0) {
 			if (status == PCAP_ERROR_NO_SUCH_DEVICE)
 				return (0);
@@ -1795,7 +1801,6 @@ pcap_cleanup_bpf(pcap_t *p)
 static int
 check_setif_failure(pcap_t *p, int error)
 {
-	int fd;
 	int err;
 
 	if (error == PCAP_ERROR_NO_SUCH_DEVICE) {
@@ -1810,52 +1815,32 @@ check_setif_failure(pcap_t *p, int error)
 			 * "enN" device; if that device exists, return
 			 * "monitor mode not supported on the device".
 			 */
-			fd = socket(AF_INET, SOCK_DGRAM, 0);
-			if (fd != -1) {
-				char *en_name;
+			char *en_name;
 
-				if (pcapint_asprintf(&en_name, "en%s",
-				    p->opt.device + 3) == -1) {
-					/*
-					 * We can't find out whether there's
-					 * an underlying "enN" device, so
-					 * just report "no such device".
-					 */
-					pcapint_fmt_errmsg_for_errno(p->errbuf,
-					    PCAP_ERRBUF_SIZE, errno,
-					    "malloc");
-					close(fd);
-					return (PCAP_ERROR_NO_SUCH_DEVICE);
-				}
-				err = device_exists(fd, en_name, p->errbuf);
-				free(en_name);
-				if (err != 0) {
-					if (err == PCAP_ERROR_NO_SUCH_DEVICE) {
-						/*
-						 * The underlying "enN" device
-						 * exists, but there's no
-						 * corresponding "wltN" device;
-						 * that means that the "enN"
-						 * device doesn't support
-						 * monitor mode, probably
-						 * because it's an Ethernet
-						 * device rather than a
-						 * wireless device.
-						 */
-						err = PCAP_ERROR_RFMON_NOTSUP;
-					}
-				}
-				close(fd);
-			} else {
+			if (pcapint_asprintf(&en_name, "en%s",
+			    p->opt.device + 3) == -1) {
 				/*
-				 * We can't find out whether there's
-				 * an underlying "enN" device, so
-				 * just report "no such device".
+				 * We don't have enough memory to
+				 * construct a string for the name of
+				 * the "enN" device.
 				 */
-				err = PCAP_ERROR_NO_SUCH_DEVICE;
 				pcapint_fmt_errmsg_for_errno(p->errbuf,
-				    errno, PCAP_ERRBUF_SIZE,
-				    "socket() failed");
+				    PCAP_ERRBUF_SIZE, errno,
+				    "malloc");
+				return (PCAP_ERROR);
+			}
+			err = device_exists(en_name, p->errbuf);
+			free(en_name);
+			if (err == PCAP_ERROR_NO_SUCH_DEVICE) {
+				/*
+				 * The underlying "enN" device exists,
+				 * but there's no corresponding "wltN"
+				 * device; that means that the "enN"
+				 * device doesn't support monitor mode,
+				 * probably because it's an Ethernet
+				 * device rather than a wireless device.
+				 */
+				err = PCAP_ERROR_RFMON_NOTSUP;
 			}
 			return (err);
 		}
@@ -2005,32 +1990,16 @@ pcap_activate_bpf(pcap_t *p)
 					 * Not an enN device; check
 					 * whether the device even exists.
 					 */
-					sockfd = socket(AF_INET, SOCK_DGRAM, 0);
-					if (sockfd != -1) {
-						status = device_exists(sockfd,
-						    p->opt.device, p->errbuf);
-						if (status == 0) {
-							/*
-							 * The device exists,
-							 * but it's not an
-							 * enN device; that
-							 * means it doesn't
-							 * support monitor
-							 * mode.
-							 */
-							status = PCAP_ERROR_RFMON_NOTSUP;
-						}
-						close(sockfd);
-					} else {
+					status = device_exists(p->opt.device,
+					    p->errbuf);
+					if (status == 0) {
 						/*
-						 * We can't find out whether
-						 * the device exists, so just
-						 * report "no such device".
+						 * The device exists, but
+						 * it's not an "enN" device;
+						 * that means it doesn't
+						 * support monitor mode.
 						 */
-						status = PCAP_ERROR_NO_SUCH_DEVICE;
-						pcapint_fmt_errmsg_for_errno(p->errbuf,
-						    PCAP_ERRBUF_SIZE, errno,
-						    "socket() failed");
+						status = PCAP_ERROR_RFMON_NOTSUP;
 					}
 					goto bad;
 				}


### PR DESCRIPTION
That means that its caller doesn't need to open and close the descriptor itself.

Also, treat a failure to open the socket as an error to be reported as such, treat an error from SIOCGIFFLAGS *other* than "there is no such device" as implying that there *is* such a device, and treat a failure to allocate a string to hold the name of the device to test as an error to be reported as such.

(This code is currently used only on old versions of macOS - "old" as in "Mac OS X Tiger", which came out over 25 years ago - but it'll be useful for fixing the "report 'no such device', not 'permission denied', if the user doesn't have permission to capture on any device and the device doesn't exist" issue.)