### PR TITLE
Restore the Clang pragma pop helper for uninitialized const pointer warnings

### DIFF
--- a/diag-control.h
+++ b/diag-control.h
@@ -154,7 +154,7 @@
     #define DIAG_OFF_UNINITIALIZED_CONST_POINTER \
       PCAP_DO_PRAGMA(clang diagnostic push) \
       PCAP_DO_PRAGMA(clang diagnostic ignored "-Wuninitialized-const-pointer")
-    #define and DIAG_ON_UNINITIALIZED_CONST_POINTER \
+    #define DIAG_ON_UNINITIALIZED_CONST_POINTER \
       PCAP_DO_PRAGMA(clang diagnostic pop)
   #endif
 


### PR DESCRIPTION
I hit this while tracing the new Clang 21.1 diagnostic helper.

`DIAG_ON_UNINITIALIZED_CONST_POINTER` was accidentally declared as `#define and ...`, so the intended helper macro never existed. With Clang 22 the `DIAG_OFF_*` side expands to a diagnostic push and ignore, but the matching `DIAG_ON_*` side falls back to the empty default instead of restoring the diagnostic state.

This change only fixes that macro definition.

Validation:
- `clang -I . -E -x c` on a tiny snippet including `diag-control.h`
- before this change the expansion stopped after `#pragma clang diagnostic ignored "-Wuninitialized-const-pointer"`
- after this change the expansion includes the matching `#pragma clang diagnostic pop`
