### PR TITLE
Validate both named services in portrange filters

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -7114,12 +7114,11 @@ stringtoport(compiler_state_t *cstate, const char *string, size_t string_size,
  */
 static void
 stringtoportrange(compiler_state_t *cstate, const char *string,
-    bpf_u_int32 *port1, bpf_u_int32 *port2, int *proto)
+    bpf_u_int32 *port1, bpf_u_int32 *port2, int *proto1, int *proto2)
 {
 	const char *hyphen_off;
 	const char *first, *second;
 	size_t first_size, second_size;
-	int save_proto;
 
 	if ((hyphen_off = strchr(string, '-')) == NULL)
 		bpf_error(cstate, "port range '%s' contains no hyphen", string);
@@ -7148,8 +7147,7 @@ stringtoportrange(compiler_state_t *cstate, const char *string,
 	/*
 	 * Try to convert it to a port.
 	 */
-	*port1 = stringtoport(cstate, first, first_size, proto);
-	save_proto = *proto;
+	*port1 = stringtoport(cstate, first, first_size, proto1);
 
 	/*
 	 * Get the length of the second port.
@@ -7164,9 +7162,7 @@ stringtoportrange(compiler_state_t *cstate, const char *string,
 	/*
 	 * Try to convert it to a port.
 	 */
-	*port2 = stringtoport(cstate, second, second_size, proto);
-	if (*proto != save_proto)
-		*proto = PROTO_UNDEF;
+	*port2 = stringtoport(cstate, second, second_size, proto2);
 }
 
 struct block *
@@ -7175,7 +7171,7 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 	int proto = q.proto;
 	int dir = q.dir;
 	bpf_u_int32 mask, addr;
-	int port, real_proto;
+	int port, real_proto, real_proto1, real_proto2;
 	bpf_u_int32 port1, port2;
 
 	/*
@@ -7275,33 +7271,41 @@ gen_scode(compiler_state_t *cstate, const char *name, struct qual q)
 
 	case Q_PORTRANGE:
 		(void)port_pq_to_ipproto(cstate, proto, "portrange"); // validate only
-		stringtoportrange(cstate, name, &port1, &port2, &real_proto);
+		stringtoportrange(cstate, name, &port1, &port2,
+		    &real_proto1, &real_proto2);
 		if (proto == Q_UDP) {
-			if (real_proto == IPPROTO_TCP)
+			if (real_proto1 == IPPROTO_TCP ||
+			    real_proto2 == IPPROTO_TCP)
 				bpf_error(cstate, "port in range '%s' is tcp", name);
-			else if (real_proto == IPPROTO_SCTP)
+			else if (real_proto1 == IPPROTO_SCTP ||
+			    real_proto2 == IPPROTO_SCTP)
 				bpf_error(cstate, "port in range '%s' is sctp", name);
 			else
-				/* override PROTO_UNDEF */
 				real_proto = IPPROTO_UDP;
 		}
 		if (proto == Q_TCP) {
-			if (real_proto == IPPROTO_UDP)
+			if (real_proto1 == IPPROTO_UDP ||
+			    real_proto2 == IPPROTO_UDP)
 				bpf_error(cstate, "port in range '%s' is udp", name);
-			else if (real_proto == IPPROTO_SCTP)
+			else if (real_proto1 == IPPROTO_SCTP ||
+			    real_proto2 == IPPROTO_SCTP)
 				bpf_error(cstate, "port in range '%s' is sctp", name);
 			else
-				/* override PROTO_UNDEF */
 				real_proto = IPPROTO_TCP;
 		}
 		if (proto == Q_SCTP) {
-			if (real_proto == IPPROTO_UDP)
+			if (real_proto1 == IPPROTO_UDP ||
+			    real_proto2 == IPPROTO_UDP)
 				bpf_error(cstate, "port in range '%s' is udp", name);
-			else if (real_proto == IPPROTO_TCP)
+			else if (real_proto1 == IPPROTO_TCP ||
+			    real_proto2 == IPPROTO_TCP)
 				bpf_error(cstate, "port in range '%s' is tcp", name);
 			else
-				/* override PROTO_UNDEF */
 				real_proto = IPPROTO_SCTP;
+		}
+		if (proto == Q_DEFAULT) {
+			real_proto = real_proto1 == real_proto2 ?
+			    real_proto1 : PROTO_UNDEF;
 		}
 
 		/*

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -380,6 +380,17 @@ sub skip_no_translatetest {
 	return skip_os ('msys');
 }
 
+sub skip_unless_service_uses_only {
+	my ($service, $proto) = @_;
+	my $other_proto = $proto eq 'tcp' ? 'udp' : 'tcp';
+
+	return "service '$service' is unavailable for $proto" unless
+		defined getservbyname ($service, $proto);
+	return "service '$service' is also available for $other_proto" if
+		defined getservbyname ($service, $other_proto);
+	return '';
+}
+
 sub skip_big_endian {
 	return pack ('S', 0x4245) eq 'BE' ? 'big-endian' : '';
 }
@@ -27597,6 +27608,34 @@ my @filter_reject_tests = (
 		DLT => 'IPV4',
 		expr => 'sctp portrange 70000-80000',
 		errstr => errstr_invport (70000),
+	},
+	{
+		name => 'udp_portrange_tcp_service_first',
+		skip => skip_unless_service_uses_only ('smtp', 'tcp'),
+		DLT => 'IPV4',
+		expr => 'udp portrange smtp-25',
+		errstr => 'port in range \'smtp-25\' is tcp',
+	},
+	{
+		name => 'udp_portrange_tcp_service_second',
+		skip => skip_unless_service_uses_only ('smtp', 'tcp'),
+		DLT => 'IPV4',
+		expr => 'udp portrange 25-smtp',
+		errstr => 'port in range \'25-smtp\' is tcp',
+	},
+	{
+		name => 'tcp_portrange_udp_service_first',
+		skip => skip_unless_service_uses_only ('tftp', 'udp'),
+		DLT => 'IPV4',
+		expr => 'tcp portrange tftp-69',
+		errstr => 'port in range \'tftp-69\' is udp',
+	},
+	{
+		name => 'tcp_portrange_udp_service_second',
+		skip => skip_unless_service_uses_only ('tftp', 'udp'),
+		DLT => 'IPV4',
+		expr => 'tcp portrange 69-tftp',
+		errstr => 'port in range \'69-tftp\' is udp',
 	},
 	{
 		name => 'pppoes_and_vlan',


### PR DESCRIPTION
## Summary

Preserve the resolved protocol for each endpoint of a named `portrange`, then validate both endpoints against an explicit `tcp`, `udp`, or `sctp` qualifier.

Previously, resolving the second endpoint overwrote the first endpoint's protocol. If the two endpoints differed, the result became unspecified, so expressions such as `udp portrange smtp-25` and `udp portrange 25-smtp` compiled even though `udp port smtp` was rejected on systems where `smtp` is TCP-only.

Numeric endpoints and service names available for both TCP and UDP keep their existing behavior. Unqualified ranges also keep the previous combined-protocol behavior.

The regression tests use `getservbyname()` to run only when the host service database exposes an unambiguous service name.

Fixes #1440.

## Validation

- Linux Autotools build
- Full Linux `make check`: 14,629 passed, 6,569 skipped, 0 failed
- macOS CMake build
- Focused Linux regressions for mismatched services in both endpoint positions
- Focused valid-range smoke tests for numeric, dual-protocol service, and unqualified ranges
- `perl -c testprogs/TESTrun`