### PR TITLE
rpcap: compare against the new authentication reply size

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -2107,7 +2107,7 @@ static int rpcap_doauth(PCAP_SOCKET sockctrl, SSL *ssl, uint8_t *ver,
 			has_byte_order = 0;
 			reply_len = sizeof(struct rpcap_authreply_old);
 		}
-		else if (plen >= sizeof(struct rpcap_authreply_old))
+		else if (plen >= sizeof(struct rpcap_authreply))
 		{
 			/* Yes - read it all. */
 			has_byte_order = 1;


### PR DESCRIPTION
rpcap_doauth() validates the payload length of an authentication reply against the two possible reply layouts:

    struct rpcap_authreply_old  - 2 bytes (minvers, maxvers)
    struct rpcap_authreply      - 8 bytes (adds padding and byte_order_magic)

The chain of tests is:

    if (plen < sizeof(struct rpcap_authreply_old))        /* < 2  */
            ... too short, fail
    if (plen == sizeof(struct rpcap_authreply_old))       /* == 2 */
            reply_len = sizeof(struct rpcap_authreply_old);
    else if (plen >= sizeof(struct rpcap_authreply_old))  /* >= 2 */
            reply_len = sizeof(struct rpcap_authreply);
    else
            ... "Too long for old reply, too short for new reply", fail

By the time the third test is reached, plen > sizeof(struct rpcap_authreply_old) is already known, so the test is always true and the final else is unreachable. Its comment describes the case it was meant to catch - a reply longer than the old layout but shorter than the new one, i.e. 3 to 7 bytes - which currently takes the "read the full new reply" branch instead.

Comparing against sizeof(struct rpcap_authreply) makes the last branch reachable and restores the intended check.

No security impact: rpcap_recv() already refuses to read more than the declared payload (if (toread > *plen)), so a 3..7 byte reply is rejected either way, currently with "Message payload is too short" rather than the more specific message. This is a correctness and diagnostics fix, which is why it is sent as an ordinary pull request rather than through the private security reporting process.