### PR TITLE
Fix CMake libnl fallback detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2119,7 +2119,10 @@ else(WIN32)
                 set(REQUIRES_PRIVATE "${LIBNL_PACKAGE_NAME} ${REQUIRES_PRIVATE}")
             else()
                 cmake_push_check_state()
-                set(CMAKE_REQUIRED_LIBRARIES nl-3)
+                # Both libraries are linked below, so require both here.
+                # Checking only nl-3 gives a false positive when libnl-genl
+                # is not installed.
+                set(CMAKE_REQUIRED_LIBRARIES nl-genl-3 nl-3)
                 check_function_exists(nl_socket_alloc HAVE_LIBNL)
                 cmake_pop_check_state()
                 if(HAVE_LIBNL)


### PR DESCRIPTION
## Summary

- require both `nl-genl-3` and `nl-3` in the non-pkg-config CMake probe
- avoid enabling `HAVE_LIBNL` when only `libnl-3` is installed and the final shared-library link would fail

The fallback previously checked `nl_socket_alloc` with only `nl-3`, but the enabled build path links both `nl-genl-3` and `nl-3`. Requiring the same libraries in the probe keeps detection consistent with the actual link.

## Validation

Tested in `debian:bookworm-slim` on `linux/arm64`:

1. Before the change, with `libnl-3-dev` installed and `libnl-genl-3-dev` absent, CMake found `nl_socket_alloc`, then the shared build failed with `cannot find -lnl-genl-3`.
2. With this change and the same packages, CMake reports `nl_socket_alloc - not found`, disables libnl support, and the full CMake build reaches 100%.
3. With both `libnl-3-dev` and `libnl-genl-3-dev` installed, `HAVE_LIBNL` remains enabled and the full CMake build reaches 100%.

Closes #1703