### PR TITLE
Fix BPF optimizer handling of VLAN metadata offsets

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -58,6 +58,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
         and DLT_ENC savefiles. (issue #74)
       Match all AF_INET6 values when filtering DLT_PFLOG savefiles.
       Fix optimization of "jset #0xffffffff".
+      Fix optimizer handling of Linux VLAN metadata offsets (issue #1513).
     Capture file reading:
       Fix misaligned accesses in processing Linux USB captures (issue
         #1634, reported by FuzzAnything Organization

--- a/optimize.c
+++ b/optimize.c
@@ -1929,19 +1929,17 @@ or_pullup(opt_state_t *opt_state, struct block *b, struct block *root)
 		if ((*samep)->val[A_ATOM] == val)
 			break;
 
-		/* XXX Need to check that there are no data dependencies
-		   between dp0 and dp1.  Currently, the code generator
-		   will not produce such dependencies. */
 		samep = &JF(*samep);
 	}
-#ifdef notdef
-	/* XXX This doesn't cover everything. */
-	for (i = 0; i < N_ATOMS; ++i)
-		if ((*samep)->val[i] != pred->val[i])
-			return;
-#endif
-	/* Pull up the node. */
+	/*
+	 * Pulling this block ahead of diffp makes its statements run on paths
+	 * that did not previously execute them.  Do not move definitions that
+	 * are live on any of those paths.
+	 */
 	pull = *samep;
+	if ((pull->def & (*diffp)->in_use) != 0)
+		return;
+	/* Pull up the node. */
 	*samep = JF(pull);
 	JF(pull) = *diffp;
 

--- a/testprogs/TESTrun
+++ b/testprogs/TESTrun
@@ -11675,6 +11675,58 @@ my @filter_accept_blocks = (
 			',
 	}, # vlan_eth_linuxext_nullary
 	{
+		name => 'vlan_eth_linuxext_offset_branch',
+		skip => skip_config_not_def1 ('HAVE_DECL_SKF_AD_VLAN_TAG_PRESENT'),
+		DLT => 'EN10MB',
+		linuxext => 1,
+		aliases => ['ether proto 0x8892 or (vlan and ether proto 0x8892)'],
+		opt => '
+			(000) ld       #0x0
+			(001) st       M[1]
+			(002) ldh      [12]
+			(003) jeq      #0x8892          jt 15	jf 4
+			(004) ldb      [vlanp]
+			(005) jeq      #0x1             jt 12	jf 6
+			(006) ld       #0x4
+			(007) st       M[1]
+			(008) ldh      [12]
+			(009) jeq      #0x8100          jt 12	jf 10
+			(010) jeq      #0x88a8          jt 12	jf 11
+			(011) jeq      #0x9100          jt 12	jf 16
+			(012) ldx      M[1]
+			(013) ldh      [x + 12]
+			(014) jeq      #0x8892          jt 15	jf 16
+			(015) ret      #262144
+			(016) ret      #0
+			',
+		unopt => '
+			(000) ld       #0x0
+			(001) st       M[0]
+			(002) st       M[1]
+			(003) ldh      [12]
+			(004) jeq      #0x8892          jt 22	jf 5
+			(005) ldb      [vlanp]
+			(006) jeq      #0x1             jt 19	jf 7
+			(007) ld       M[0]
+			(008) add      #4
+			(009) st       M[0]
+			(010) ld       M[1]
+			(011) add      #4
+			(012) st       M[1]
+			(013) ldh      [12]
+			(014) jeq      #0x8100          jt 19	jf 15
+			(015) ldh      [12]
+			(016) jeq      #0x88a8          jt 19	jf 17
+			(017) ldh      [12]
+			(018) jeq      #0x9100          jt 19	jf 23
+			(019) ldx      M[1]
+			(020) ldh      [x + 12]
+			(021) jeq      #0x8892          jt 22	jf 23
+			(022) ret      #262144
+			(023) ret      #0
+			',
+	}, # vlan_eth_linuxext_offset_branch
+	{
 		name => 'vlan_eth_linuxext_unary',
 		skip => skip_config_not_def1 ('HAVE_DECL_SKF_AD_VLAN_TAG_PRESENT'),
 		DLT => 'EN10MB',
@@ -25805,10 +25857,25 @@ my @filter_accept_blocks = (
 # a hash, where the keys have the following meaning:
 #
 # * name, expr and netmask: same as in filter_accept_blocks above
-# * savefile (mandatory, string): the file in tests/filter/ to use with
-#   "filtertest -r", this should not have too many packets
+# * savefile (string): the file in tests/filter/ to use with "filtertest -r",
+#   this should not have too many packets; mandatory unless aux_vlan is set
+# * aux_vlan (optional, int): if set to 1, apply the filter to filtertest's
+#   built-in packet with a VLAN tag supplied as auxiliary metadata
+# * DLT and linuxext: same as in filter_accept_blocks above; mandatory when
+#   aux_vlan is set
 # * results (mandatory, array): the list of program filter results to expect
 my @filter_apply_blocks = (
+	{
+		name => 'vlan_metadata_offset_branch',
+		skip => skip_config_not_def1 ('HAVE_DECL_SKF_AD_VLAN_TAG_PRESENT'),
+		DLT => 'EN10MB',
+		linuxext => 1,
+		aux_vlan => 1,
+		expr => 'ether proto 0x8892 or (vlan and ether proto 0x8892)',
+		# Metadata match, metadata false-positive probe, inline VLAN match,
+		# and ordinary nonmatch, in that order.
+		results => [262144, 0, 262144, 0],
+	},
 	{
 		name => 'pppoed_nullary_on_ctp',
 		savefile => 'loopback.pcap',
@@ -31020,12 +31087,12 @@ sub run_filter_apply_test {
 	my @args = common_filtertest_args $test;
 	file_put_contents mytmpfile ($filename_filter), $test->{expr};
 	file_put_contents mytmpfile ($filename_expected), $test->{expected};
-	push @args, (
-		'-F',
-		mytmpfile ($filename_filter),
-		'-r',
-		SAVEFILE_DIR . $test->{savefile},
-	);
+	push @args, ('-F', mytmpfile ($filename_filter));
+	if ($test->{aux_vlan}) {
+		push @args, ('-A', $test->{DLT});
+	} else {
+		push @args, ('-r', SAVEFILE_DIR . $test->{savefile});
+	}
 	return run_generic_accept_test @args;
 }
 
@@ -31147,7 +31214,19 @@ foreach my $test (@filter_accept_blocks) {
 foreach my $block (@filter_apply_blocks) {
 	my $descr = 'filter apply block';
 	assert_named $descr, $block;
-	assert_nonempty_strings $descr, $block, 'savefile', 'expr';
+	assert_nonempty_strings $descr, $block, 'expr';
+	if (exists $block->{aux_vlan}) {
+		if (! defined $block->{aux_vlan} || $block->{aux_vlan} ne '1') {
+			die "Internal error: $descr '$block->{name}' defines 'aux_vlan' as a value other than 1";
+		}
+		assert_nonempty_strings $descr, $block, 'DLT';
+		if (! exists $block->{linuxext} || ! defined $block->{linuxext} ||
+		    $block->{linuxext} ne '1') {
+			die "Internal error: $descr '$block->{name}' with 'aux_vlan' does not define 'linuxext' as 1";
+		}
+	} else {
+		assert_nonempty_strings $descr, $block, 'savefile';
+	}
 	assert_nonempty_array $descr, $block, 'results';
 	my $skip_reason = (defined $block->{skip} && $block->{skip} ne '') ?
 		$block->{skip} : undef;
@@ -31174,7 +31253,10 @@ foreach my $block (@filter_apply_blocks) {
 			optimize => int ($optunopt eq 'opt'),
 			expr => $block->{expr},
 			expected => $multiline,
-			savefile => 'filter/' . $block->{savefile},
+			savefile => defined $block->{savefile} ? 'filter/' . $block->{savefile} : undef,
+			aux_vlan => defined $block->{aux_vlan} && $block->{aux_vlan} == 1,
+			DLT => defined $block->{DLT} ? $block->{DLT} : undef,
+			linuxext => defined $block->{linuxext} && $block->{linuxext} == 1,
 		};
 	}
 }

--- a/testprogs/filtertest.c
+++ b/testprogs/filtertest.c
@@ -116,6 +116,56 @@ static char *cmdbuf;
 static pcap_t *pd;
 static struct bpf_program fcode;
 
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+static void
+apply_aux_vlan_packets(void)
+{
+	/*
+	 * When the VLAN tag is supplied as packet metadata, the Ethernet type
+	 * remains at bytes 12 and 13.  The second packet deliberately has the
+	 * target value at bytes 16 and 17 to detect an incorrect offset shift.
+	 */
+	static const u_char metadata_match[] = {
+		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0,
+		0x88, 0x92, 0, 0, 0, 0
+	};
+	static const u_char metadata_false_positive[] = {
+		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0,
+		0x08, 0x00, 0, 0, 0x88, 0x92
+	};
+	static const u_char inline_vlan_match[] = {
+		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0,
+		0x81, 0x00, 0, 100, 0x88, 0x92
+	};
+	static const u_char ordinary_nonmatch[] = {
+		0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0,
+		0x08, 0x00, 0, 0, 0, 0
+	};
+	struct pcap_bpf_aux_data aux_data = { 0 };
+
+	aux_data.vlan_tag_present = 1;
+	aux_data.vlan_tag = 100;
+	printf("%u\n", pcapint_filter_with_aux_data(fcode.bf_insns,
+	    metadata_match, sizeof(metadata_match), sizeof(metadata_match),
+	    &aux_data));
+	printf("%u\n", pcapint_filter_with_aux_data(fcode.bf_insns,
+	    metadata_false_positive, sizeof(metadata_false_positive),
+	    sizeof(metadata_false_positive), &aux_data));
+
+	aux_data.vlan_tag_present = 0;
+	printf("%u\n", pcapint_filter_with_aux_data(fcode.bf_insns,
+	    inline_vlan_match, sizeof(inline_vlan_match),
+	    sizeof(inline_vlan_match), &aux_data));
+	printf("%u\n", pcapint_filter_with_aux_data(fcode.bf_insns,
+	    ordinary_nonmatch, sizeof(ordinary_nonmatch),
+	    sizeof(ordinary_nonmatch), &aux_data));
+}
+#endif
+
 /*
  * atexit() is broken on Linux/ARMv7 with TinyCC, work around by calling this
  * function explicitly just before exit() if there is a possibility any of
@@ -325,6 +375,9 @@ main(int argc, char **argv)
 #ifdef __linux__
 	bool lflag = false;
 #endif
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+	bool Aflag = false;
+#endif
 	bool qflag = false;
 	int snaplen = MAXIMUM_SNAPLEN;
 	enum {
@@ -347,8 +400,16 @@ main(int argc, char **argv)
 		program_name = argv[0];
 
 	opterr = 0;
-	while ((op = getopt(argc, argv, "hdF:gm:Os:S:lqr:")) != -1) {
+	while ((op = getopt(argc, argv, "AhdF:gm:Os:S:lqr:")) != -1) {
 		switch (op) {
+
+		case 'A':
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+			Aflag = true;
+			break;
+#else
+			error(EX_USAGE, "libpcap and filtertest built without VLAN auxiliary-data support");
+#endif
 
 		case 'h':
 			usage(stdout);
@@ -445,6 +506,10 @@ main(int argc, char **argv)
 	}
 
 	if (insavefile) {
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+		if (Aflag)
+			error(EX_USAGE, "-r is not compatible with -A");
+#endif
 		if (dflag > 1)
 			error(EX_USAGE, "-r is not compatible with -d");
 #ifdef BDEBUG
@@ -485,6 +550,10 @@ main(int argc, char **argv)
 		if (pd == NULL)
 			error(EX_SOFTWARE, "Can't open fake pcap_t");
 #ifdef __linux__
+#if defined(SKF_AD_VLAN_TAG_PRESENT)
+		if (Aflag && !lflag)
+			error(EX_USAGE, "-A requires -l");
+#endif
 		if (lflag) {
 #ifdef SKF_AD_VLAN_TAG_PRESENT
 			/*
@@ -533,6 +602,11 @@ main(int argc, char **argv)
 	if (!bpf_validate(fcode.bf_insns, fcode.bf_len))
 		error(EX_SOFTWARE, "Filter doesn't pass validation");
 
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+	if (Aflag) {
+		apply_aux_vlan_packets();
+	} else
+#endif
 	if (! insavefile) {
 #ifdef BDEBUG
 		// only show machine code if BDEBUG defined, since dflag > 3
@@ -576,7 +650,11 @@ usage(FILE *f)
 	(void)fprintf(f, "%s, with %s\n", program_name,
 	    pcap_lib_version());
 	(void)fprintf(f,
-	    "Usage: %s [-d"
+	    "Usage: %s "
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+	    "[-A] "
+#endif
+	    "[-d"
 #ifdef BDEBUG
 	    "g"
 #endif
@@ -603,6 +681,9 @@ usage(FILE *f)
 #endif
 #ifdef __linux__
 	(void)fprintf(f, "  -l              allow the use of Linux BPF extensions\n");
+#endif
+#if defined(__linux__) && defined(SKF_AD_VLAN_TAG_PRESENT)
+	(void)fprintf(f, "  -A              apply the filter to a built-in packet with VLAN metadata\n");
 #endif
 	(void)fprintf(f, "  -m <netmask>    use this IPv4 netmask for pcap_compile(3PCAP),\n");
 	(void)fprintf(f, "                  e.g. 255.255.255.0\n");


### PR DESCRIPTION
Fixes #1513.

`or_pullup()` can move a block that defines scratch-memory values across a path where those values are already live. With Linux VLAN metadata, this moves the four-byte offset adjustment onto the metadata-present path, so the optimized filter reads the EtherType at byte 16 instead of byte 12 and can produce a false match.

Prevent that pull-up when the moved block defines scratch words used by the crossed block. Add bytecode and execution regressions covering metadata-stripped VLAN, inline VLAN, positive matches, the false-positive probe, and an ordinary nonmatch.

Validation:

- focused optimized and unoptimized regression tests
- `TESTRUN_JOBS=4 perl testprogs/TESTrun`
- `TESTRUN_JOBS=4 make -s check`

AI assistance was used for analysis and drafting. The issue was reproduced locally against current master, and the final patch was verified with the project test suite.