### PR TITLE
pcap-bpf: guard monitor_mode() against negative ifm_count from SIOCGIFMEDIA

### DIFF
--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -3199,9 +3199,12 @@ monitor_mode(pcap_t *p, int set)
 			return (PCAP_ERROR);
 		}
 	}
-	if (req.ifm_count == 0) {
+	if (req.ifm_count <= 0) {
 		/*
-		 * No media types.
+		 * No media types, or negative count (guard against a kernel
+		 * bug or unexpected ioctl return value: ifm_count is int,
+		 * so a negative value would wrap to a huge size_t in the
+		 * malloc() call below).
 		 */
 		close(sock);
 		return (PCAP_ERROR_RFMON_NOTSUP);


### PR DESCRIPTION
## Problem

`req.ifm_count` is declared as `int` in `struct ifmediareq`. The existing check in `monitor_mode()` only rejects zero:

```c
if (req.ifm_count == 0) {
    /* No media types. */
    close(sock);
    return (PCAP_ERROR_RFMON_NOTSUP);
}
/* ... */
media_list = malloc(req.ifm_count * sizeof(*media_list));
```

A negative value from `SIOCGIFMEDIA` (e.g. due to a kernel bug or a malformed response on a virtualised or emulated NIC) passes the guard. The implicit conversion from `int` to `size_t` in the `malloc()` call then wraps the negative value to a very large `size_t`, typically causing `malloc()` to fail and return `NULL` — which is caught by the subsequent NULL check. The failure is therefore unlikely to be exploitable in practice, but produces a misleading `errno`-based diagnostic rather than a clear indication that the ioctl returned an implausible count.

## Fix

Change the guard from `== 0` to `<= 0` so that any non-positive `ifm_count` — whether zero (no media types) or negative (unexpected kernel response) — takes the `PCAP_ERROR_RFMON_NOTSUP` path before the problematic `malloc()` is reached. The comment is updated to explain the additional case.

This code is only compiled on platforms that define `HAVE_BSD_IEEE80211` (BSD and macOS).