### PR TITLE
pcap-util: clean up the byte-swapping macros.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2843,6 +2843,48 @@ endif()
 # To get a correct builtin test result, the source must be compiled and linked,
 # which in CMake means check_c_source_compiles().
 #
+# Different builtins require different methods of testing, see the comments
+# about HAVE_BUILTIN_BSWAPnn in pcap-util.h and HAVE_BUILTIN_CTZ in optimize.c.
+#
+check_c_source_compiles(
+"int main(int argc, char **argv)
+{
+	switch (argc) {
+	case __builtin_bswap16(0):
+		return 0;
+	default:
+		return 1;
+	}
+}
+"
+    HAVE_BUILTIN_BSWAP16)
+
+check_c_source_compiles(
+"int main(int argc, char **argv)
+{
+	switch (argc) {
+	case __builtin_bswap32(0):
+		return 0;
+	default:
+		return 1;
+	}
+}
+"
+    HAVE_BUILTIN_BSWAP32)
+
+check_c_source_compiles(
+"int main(int argc, char **argv)
+{
+	switch (argc) {
+	case __builtin_bswap64(0):
+		return 0;
+	default:
+		return 1;
+	}
+}
+"
+    HAVE_BUILTIN_BSWAP64)
+
 check_c_source_compiles("int main(void) {return __builtin_ctz(1);}" HAVE_BUILTIN_CTZ)
 
 #

--- a/cmakeconfig.h.in
+++ b/cmakeconfig.h.in
@@ -18,6 +18,15 @@
 /* Define to 1 if you have the `asprintf' function. */
 #cmakedefine HAVE_ASPRINTF 1
 
+/* Define to 1 if you have the '__builtin_bswap16' compiler builtin. */
+#cmakedefine HAVE_BUILTIN_BSWAP16
+
+/* Define to 1 if you have the '__builtin_bswap32' compiler builtin. */
+#cmakedefine HAVE_BUILTIN_BSWAP32
+
+/* Define to 1 if you have the '__builtin_bswap64' compiler builtin. */
+#cmakedefine HAVE_BUILTIN_BSWAP64
+
 /* Define to 1 if you have the '__builtin_ctz' compiler builtin. */
 #cmakedefine HAVE_BUILTIN_CTZ
 

--- a/configure.ac
+++ b/configure.ac
@@ -2350,6 +2350,72 @@ AC_LBL_DEVEL(V_CCOPT)
 # To get a correct builtin test result, the source must be compiled and linked,
 # which in Autoconf means AC_LINK_IFELSE().
 #
+# Different builtins require different methods of testing, see the comments
+# about HAVE_BUILTIN_BSWAPnn in pcap-util.h and HAVE_BUILTIN_CTZ in optimize.c.
+#
+AC_MSG_CHECKING([whether the compiler implements __builtin_bswap16()])
+AC_LINK_IFELSE(
+	[AC_LANG_SOURCE([[
+int main(int argc, char **argv)
+{
+	switch (argc) {
+	case __builtin_bswap16(0):
+		return 0;
+	default:
+		return 1;
+	}
+}
+	]])],
+	[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_BUILTIN_BSWAP16, 1,
+			[Define to 1 if you have the '__builtin_bswap16' compiler builtin.])
+	],
+	[AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING([whether the compiler implements __builtin_bswap32()])
+AC_LINK_IFELSE(
+	[AC_LANG_SOURCE([[
+int main(int argc, char **argv)
+{
+	switch (argc) {
+	case __builtin_bswap32(0):
+		return 0;
+	default:
+		return 1;
+	}
+}
+	]])],
+	[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_BUILTIN_BSWAP32, 1,
+			[Define to 1 if you have the '__builtin_bswap32' compiler builtin.])
+	],
+	[AC_MSG_RESULT(no)]
+)
+
+AC_MSG_CHECKING([whether the compiler implements __builtin_bswap64()])
+AC_LINK_IFELSE(
+	[AC_LANG_SOURCE([[
+int main(int argc, char **argv)
+{
+	switch (argc) {
+	case __builtin_bswap64(0):
+		return 0;
+	default:
+		return 1;
+	}
+}
+	]])],
+	[
+		AC_MSG_RESULT(yes)
+		AC_DEFINE(HAVE_BUILTIN_BSWAP64, 1,
+			[Define to 1 if you have the '__builtin_bswap64' compiler builtin.])
+	],
+	[AC_MSG_RESULT(no)]
+)
+
 AC_MSG_CHECKING([whether the compiler implements __builtin_ctz()])
 AC_LINK_IFELSE(
 	[AC_LANG_PROGRAM([],[[return __builtin_ctz(1);]])],

--- a/optimize.c
+++ b/optimize.c
@@ -109,6 +109,10 @@ pcap_set_print_dot_graph(int value)
  * after midnight, and don't pass zero to it.
  *
  * This is the same as the count of trailing zeroes in the word.
+ *
+ * Because lowest_set_bit() is intended to be used as a function, to define
+ * HAVE_BUILTIN_CTZ it is sufficient to verify that __builtin_ctz() can return
+ * a value (the builtin does not have to evaluate to a compile-time constant).
  */
 #ifdef HAVE_BUILTIN_CTZ
   #define lowest_set_bit(mask) ((u_int)__builtin_ctz(mask))

--- a/pcap-util.h
+++ b/pcap-util.h
@@ -41,24 +41,38 @@
  *
  * ntoh[ls] aren't sufficient because we might need to swap on a big-endian
  * machine (if the file was written in little-end order).
+ *
+ * These macros are used to generate case labels in switch statements,
+ * so they can't be done as inline functions, and, when passed a
+ * compile-time constant argument, must produce a compile-time constant
+ * result.  This means that they must either use builtin functions that
+ * are recognized by the compiler as producing constant results when
+ * passed a constant argument, or must be done with expressions that
+ * evaluate to compile-time constants when passed a compile-time
+ * constant.
+ *
+ * Newer versions of GCC, Clang, Visual Studio C/C++, and possibly
+ * some other compilers recognize the expressions as byte-swapping
+ * idioms and generate optimized machine-specific code for architectures
+ * that include instructions that can be used to swap bytes.
  */
 #define PCAP_BSWAP_64(y) \
-    ((((uint64_t)(y) & 0xff00000000000000ULL) >> 56) | \
-     (((uint64_t)(y) & 0x00ff000000000000ULL) >> 40) | \
-     (((uint64_t)(y) & 0x0000ff0000000000ULL) >> 24) | \
-     (((uint64_t)(y) & 0x000000ff00000000ULL) >> 8)  | \
-     (((uint64_t)(y) & 0x00000000ff000000ULL) << 8)  | \
-     (((uint64_t)(y) & 0x0000000000ff0000ULL) << 24) | \
-     (((uint64_t)(y) & 0x000000000000ff00ULL) << 40) | \
-     (((uint64_t)(y) & 0x00000000000000ffULL) << 56))
+    ((uint64_t)(((((uint64_t)(y)) & UINT64_C(0xff00000000000000)) >> 56) | \
+                ((((uint64_t)(y)) & UINT64_C(0x00ff000000000000)) >> 40) | \
+                ((((uint64_t)(y)) & UINT64_C(0x0000ff0000000000)) >> 24) | \
+                ((((uint64_t)(y)) & UINT64_C(0x000000ff00000000)) >> 8)  | \
+                ((((uint64_t)(y)) & UINT64_C(0x00000000ff000000)) << 8)  | \
+                ((((uint64_t)(y)) & UINT64_C(0x0000000000ff0000)) << 24) | \
+                ((((uint64_t)(y)) & UINT64_C(0x000000000000ff00)) << 40) | \
+                ((((uint64_t)(y)) & UINT64_C(0x00000000000000ff)) << 56)))
 #define PCAP_BSWAP_32(y) \
-    (((((u_int)(y))&0xff)<<24) | \
-     ((((u_int)(y))&0xff00)<<8) | \
-     ((((u_int)(y))&0xff0000)>>8) | \
-     ((((u_int)(y))>>24)&0xff))
+    ((uint32_t)(((((uint32_t)(y)) & UINT32_C(0xff000000)) >> 24) | \
+                ((((uint32_t)(y)) & UINT32_C(0x00ff0000)) >> 8)  | \
+                ((((uint32_t)(y)) & UINT32_C(0x0000ff00)) << 8)  | \
+                ((((uint32_t)(y)) & UINT32_C(0x000000ff)) << 24)))
 #define PCAP_BSWAP_16(y) \
-     ((u_short)(((((u_int)(y))&0xff)<<8) | \
-                ((((u_int)(y))&0xff00)>>8)))
+    ((uint16_t)(((((uint16_t)(y)) & UINT16_C(0x00ff)) << 8) | \
+                ((((uint16_t)(y)) & UINT16_C(0xff00)) >> 8)))
 
 /*
  * Byte-swap a pcap_4_byte_aligned_uint64;

--- a/pcap-util.h
+++ b/pcap-util.h
@@ -51,11 +51,18 @@
  * evaluate to compile-time constants when passed a compile-time
  * constant.
  *
+ * (In practical terms, to define HAVE_BUILTIN_BSWAPnn it is sufficient to
+ * verify that respective builtin can be used as a case label in a switch
+ * statement.)
+ *
  * Newer versions of GCC, Clang, Visual Studio C/C++, and possibly
  * some other compilers recognize the expressions as byte-swapping
  * idioms and generate optimized machine-specific code for architectures
  * that include instructions that can be used to swap bytes.
  */
+#ifdef HAVE_BUILTIN_BSWAP64
+#define PCAP_BSWAP_64(y) __builtin_bswap64((uint64_t)(y))
+#else
 #define PCAP_BSWAP_64(y) \
     ((uint64_t)(((((uint64_t)(y)) & UINT64_C(0xff00000000000000)) >> 56) | \
                 ((((uint64_t)(y)) & UINT64_C(0x00ff000000000000)) >> 40) | \
@@ -65,14 +72,25 @@
                 ((((uint64_t)(y)) & UINT64_C(0x0000000000ff0000)) << 24) | \
                 ((((uint64_t)(y)) & UINT64_C(0x000000000000ff00)) << 40) | \
                 ((((uint64_t)(y)) & UINT64_C(0x00000000000000ff)) << 56)))
+#endif // 64-bit
+
+#ifdef HAVE_BUILTIN_BSWAP32
+#define PCAP_BSWAP_32(y) __builtin_bswap32((uint32_t)(y))
+#else
 #define PCAP_BSWAP_32(y) \
     ((uint32_t)(((((uint32_t)(y)) & UINT32_C(0xff000000)) >> 24) | \
                 ((((uint32_t)(y)) & UINT32_C(0x00ff0000)) >> 8)  | \
                 ((((uint32_t)(y)) & UINT32_C(0x0000ff00)) << 8)  | \
                 ((((uint32_t)(y)) & UINT32_C(0x000000ff)) << 24)))
+#endif // 32-bit
+
+#ifdef HAVE_BUILTIN_BSWAP16
+#define PCAP_BSWAP_16(y) __builtin_bswap16((uint16_t)(y))
+#else
 #define PCAP_BSWAP_16(y) \
     ((uint16_t)(((((uint16_t)(y)) & UINT16_C(0x00ff)) << 8) | \
                 ((((uint16_t)(y)) & UINT16_C(0xff00)) >> 8)))
+#endif // 16-bit
 
 /*
  * Byte-swap a pcap_4_byte_aligned_uint64;

--- a/testprogs/translatetest.c
+++ b/testprogs/translatetest.c
@@ -286,12 +286,7 @@ test_PCAP_BSWAP_64(const char *arg)
 	snprintf(buf, sizeof(buf), "0x%016" PRIx64, i);
 	if (pcapint_strcasecmp(buf, arg))
 		goto fail;
-	/*
-	 * The current definition of PCAP_BSWAP_64() is an unsigned long long,
-	 * which does not match PRIx64 on 64-bit architectures, so cast it to
-	 * an uint64_t, which does match, to avoid a -Wformat.
-	 */
-	printf("OK: 0x%016" PRIx64 "\n", (uint64_t)PCAP_BSWAP_64(i));
+	printf("OK: 0x%016" PRIx64 "\n", PCAP_BSWAP_64(i));
 	return EX_OK;
 fail:
 	fprintf(stderr, "ERROR: failed parsing \"%s\"\n", arg);


### PR DESCRIPTION
Use the same code style as PCAP_BSWAP_64() for PCAP_BSWAP_32() and PCAP_BSWAP_16().

For all of them:

- use uintNN_t types rather than u_short or u_int;
- use UINTnn_C macros for the byte masks, so that the appropriate suffix is added (for example, if uint64_t is unsigned long, it will append UL rather than ULL to the constant if necessary);
- put the (uintNN_t)(y) in parentheses;
- put a final cast to the desired type around the entire expression, just as we were already doing for PCAP_BSWAP_16().

Remove a no-longer-applies comment and and a now-unnecessary cast from testprogs/translatetest.c.