### PR TITLE
Harden libpcap against integer overflow and bounds errors

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -7031,6 +7031,10 @@ stringtoport(compiler_state_t *cstate, const char *string, size_t string_size,
 		 * Not a valid number; try looking it up as a port.
 		 */
 		cpy = malloc(string_size + 1);	/* +1 for terminating '\0' */
+		if (cpy == NULL) {
+			longjmp(cstate->top_ctx, 1);
+			/*NOTREACHED*/
+		}
 		memcpy(cpy, string, string_size);
 		cpy[string_size] = '\0';
 		tcp_port = nametoport(cstate, cpy, IPPROTO_TCP);

--- a/instrument-functions.c
+++ b/instrument-functions.c
@@ -159,6 +159,10 @@ static void print_debug(void *this_fn, void *call_site, action_type action)
 		}
 
 		symtab = (asymbol **)malloc((size_t)symsize);
+		if (symtab == NULL) {
+			bfd_perror("malloc");
+			return;
+		}
 		symcount = bfd_canonicalize_symtab(abfd, symtab);
 		if (symcount < 0) {
 			free(symtab);

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -2017,8 +2017,8 @@ pcap_activate_bpf(pcap_t *p)
 					status = PCAP_ERROR;
 					goto bad;
 				}
-				strcpy(wltdev, "wlt");
-				strcat(wltdev, p->opt.device + 2);
+				pcapint_strlcpy(wltdev, "wlt", strlen(p->opt.device) + 2);
+				pcapint_strlcat(wltdev, p->opt.device + 2, strlen(p->opt.device) + 2);
 				free(p->opt.device);
 				p->opt.device = wltdev;
 			}
@@ -2800,8 +2800,8 @@ check_bpf_bindable(const char *name)
 			    errno, "malloc");
 			return (-1);
 		}
-		strcpy(en_name, "en");
-		strcat(en_name, name + 3);
+		pcapint_strlcpy(en_name, "en", en_name_len + 1);
+		pcapint_strlcat(en_name, name + 3, en_name_len + 1);
 		fd = bpf_open_and_bind(en_name, errbuf);
 		free(en_name);
 	} else

--- a/pcap-bt-linux.c
+++ b/pcap-bt-linux.c
@@ -347,9 +347,13 @@ bt_read_linux(pcap_t *handle, int max_packets _U_, pcap_handler callback, u_char
 	while (cmsg) {
 		switch (cmsg->cmsg_type) {
 			case HCI_CMSG_DIR:
+				if (cmsg->cmsg_len < CMSG_LEN(sizeof(in)))
+					break;
 				memcpy(&in, CMSG_DATA(cmsg), sizeof in);
 				break;
 			case HCI_CMSG_TSTAMP:
+				if (cmsg->cmsg_len < CMSG_LEN(sizeof(pkth.ts)))
+					break;
 				memcpy(&pkth.ts, CMSG_DATA(cmsg),
 					sizeof pkth.ts);
 				break;

--- a/pcap-bt-monitor-linux.c
+++ b/pcap-bt-monitor-linux.c
@@ -145,7 +145,8 @@ DIAG_ON_SIGN_COMPARE
         if (cmsg->cmsg_level != SOL_SOCKET) continue;
 
         if (cmsg->cmsg_type == SCM_TIMESTAMP) {
-            memcpy(&pkth.ts, CMSG_DATA(cmsg), sizeof(pkth.ts));
+            if (cmsg->cmsg_len >= CMSG_LEN(sizeof(pkth.ts)))
+                memcpy(&pkth.ts, CMSG_DATA(cmsg), sizeof(pkth.ts));
         }
     }
 

--- a/pcap-dag.c
+++ b/pcap-dag.c
@@ -626,6 +626,9 @@ dag_read(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 					caplen += MTP2_HDR_LEN;
 					packet_len += MTP2_HDR_LEN;
 
+					if (caplen > sizeof(TempPkt) - MTP2_HDR_LEN) {
+						caplen = sizeof(TempPkt) - MTP2_HDR_LEN;
+					}
 					TempPkt[MTP2_SENT_OFFSET] = 0;
 					TempPkt[MTP2_ANNEX_A_USED_OFFSET] = MTP2_ANNEX_A_USED_UNKNOWN;
 					*(TempPkt+MTP2_LINK_NUMBER_OFFSET) = ((header->rec.mc_hdlc.mc_header>>16)&0x01);

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -3427,12 +3427,14 @@ retry:
 
 	/* allocate a ring for each frame header pointer*/
 	handle->cc = req.tp_frame_nr;
-	if ((size_t)req.tp_frame_nr > SIZE_MAX / sizeof(union thdr *)) {
-		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
-		    errno, "frame header ring size overflow");
-		destroy_ring(handle);
-		return PCAP_ERROR;
-	}
+#if SIZE_MAX < UINT_MAX
+   if (req.tp_frame_nr > SIZE_MAX / sizeof(union thdr *)) {
+           pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
+               errno, "frame header ring size overflow");
+           destroy_ring(handle);
+           return PCAP_ERROR;
+   }
+#endif
 	handle->buffer = malloc(handle->cc * sizeof(union thdr *));
 	if (!handle->buffer) {
 		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
@@ -5942,11 +5944,13 @@ fix_program(pcap_t *handle, struct sock_fprog *fcode)
 	 * Make a copy of the filter, and modify that copy if
 	 * necessary.
 	 */
-	if ((size_t)handle->fcode.bf_len > SIZE_MAX / sizeof(*handle->fcode.bf_insns)) {
-		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
-		    errno, "BPF filter too large");
-		return -1;
-	}
+#if SIZE_MAX < UINT_MAX
+   if (handle->fcode.bf_len > SIZE_MAX / sizeof(*handle->fcode.bf_insns)) {
+           pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
+               errno, "BPF filter too large");
+           return -1;
+   }
+#endif
 	prog_size = sizeof(*handle->fcode.bf_insns) * handle->fcode.bf_len;
 	len = handle->fcode.bf_len;
 	f = (struct bpf_insn *)malloc(prog_size);

--- a/pcap-linux.c
+++ b/pcap-linux.c
@@ -3405,6 +3405,12 @@ retry:
 	}
 
 	/* memory map the rx ring */
+	if (req.tp_block_nr != 0 && req.tp_block_size > SIZE_MAX / req.tp_block_nr) {
+		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "rx ring size overflow");
+		destroy_ring(handle);
+		return PCAP_ERROR;
+	}
 	handlep->mmapbuflen = req.tp_block_nr * req.tp_block_size;
 #ifdef MAP_32BIT
 	if (pcapint_mmap_32bit) flags |= MAP_32BIT;
@@ -3421,6 +3427,12 @@ retry:
 
 	/* allocate a ring for each frame header pointer*/
 	handle->cc = req.tp_frame_nr;
+	if ((size_t)req.tp_frame_nr > SIZE_MAX / sizeof(union thdr *)) {
+		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "frame header ring size overflow");
+		destroy_ring(handle);
+		return PCAP_ERROR;
+	}
 	handle->buffer = malloc(handle->cc * sizeof(union thdr *));
 	if (!handle->buffer) {
 		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
@@ -3496,7 +3508,12 @@ pcapint_oneshot_linux(u_char *user, const struct pcap_pkthdr *h,
 	struct pcap_linux *handlep = handle->priv;
 
 	*sp->hdr = *h;
-	memcpy(handlep->oneshot_buffer, bytes, h->caplen);
+	{
+		size_t copylen = h->caplen;
+		if (copylen > (size_t)handle->snapshot)
+			copylen = (size_t)handle->snapshot;
+		memcpy(handlep->oneshot_buffer, bytes, copylen);
+	}
 	*sp->pkt = handlep->oneshot_buffer;
 }
 
@@ -4344,7 +4361,7 @@ static int pcap_handle_packet_mmap(
 	 * the memory-mapped buffer.
 	 */
 	if (pcaphdr.caplen > (bpf_u_int32)handle->snapshot)
-		pcaphdr.caplen = handle->snapshot;
+		pcaphdr.caplen = (bpf_u_int32)handle->snapshot;
 
 	/* pass the packet to the user */
 	callback(user, &pcaphdr, bp);
@@ -5925,6 +5942,11 @@ fix_program(pcap_t *handle, struct sock_fprog *fcode)
 	 * Make a copy of the filter, and modify that copy if
 	 * necessary.
 	 */
+	if ((size_t)handle->fcode.bf_len > SIZE_MAX / sizeof(*handle->fcode.bf_insns)) {
+		pcapint_fmt_errmsg_for_errno(handle->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "BPF filter too large");
+		return -1;
+	}
 	prog_size = sizeof(*handle->fcode.bf_insns) * handle->fcode.bf_len;
 	len = handle->fcode.bf_len;
 	f = (struct bpf_insn *)malloc(prog_size);

--- a/pcap-netfilter-linux.c
+++ b/pcap-netfilter-linux.c
@@ -369,12 +369,27 @@ DIAG_ON_NARROWING
 	nfg->res_id = htons(res_id);
 
 	if (mynfa) {
-		struct nfattr *nfa = (struct nfattr *) (buf + NLMSG_ALIGN(nlh->nlmsg_len));
+		size_t offset;
+		size_t attr_len;
+		size_t needed;
 
+		offset = NLMSG_ALIGN(nlh->nlmsg_len);
+		if (offset > sizeof(buf))
+			return -1;
+
+		attr_len = NFA_LENGTH(mynfa->nfa_len);
+		if (attr_len > sizeof(buf) - offset)
+			return -1;
+
+		needed = offset + NFA_ALIGN(attr_len);
+		if (needed > sizeof(buf))
+			return -1;
+
+		struct nfattr *nfa = (struct nfattr *)(buf + offset);
 		nfa->nfa_type = mynfa->nfa_type;
 		nfa->nfa_len = NFA_LENGTH(mynfa->nfa_len);
 		memcpy(NFA_DATA(nfa), mynfa->data, mynfa->nfa_len);
-		nlh->nlmsg_len = NLMSG_ALIGN(nlh->nlmsg_len) + NFA_ALIGN(nfa->nfa_len);
+		nlh->nlmsg_len = needed;
 	}
 
 	memset(&snl, 0, sizeof(snl));

--- a/pcap-npf.c
+++ b/pcap-npf.c
@@ -189,6 +189,7 @@ PacketGetMonitorMode(PCHAR AdapterName _U_)
 #define PACKET_OID_DATA_LENGTH(_DataLength) \
 	(offsetof(PACKET_OID_DATA, Data) + _DataLength)
 #endif
+#define PACKET_OID_DATA_LENGTH_MAX (1024 * 1024)
 static int
 oid_get_request(ADAPTER *adapter, bpf_u_int32 oid, void *data, size_t *lenp,
     char *errbuf)
@@ -199,6 +200,16 @@ oid_get_request(ADAPTER *adapter, bpf_u_int32 oid, void *data, size_t *lenp,
 	 * Allocate a PACKET_OID_DATA structure to hand to PacketRequest().
 	 * It should be big enough to hold "*lenp" bytes of data;
 	 */
+	if (*lenp > PACKET_OID_DATA_LENGTH_MAX) {
+		snprintf(errbuf, PCAP_ERRBUF_SIZE,
+		    "OID data length too large");
+		return (PCAP_ERROR);
+	}
+	if (*lenp > SIZE_MAX - offsetof(PACKET_OID_DATA, Data)) {
+		snprintf(errbuf, PCAP_ERRBUF_SIZE,
+		    "OID data length too large");
+		return (PCAP_ERROR);
+	}
 	oid_data_arg = malloc(PACKET_OID_DATA_LENGTH(*lenp));
 	if (oid_data_arg == NULL) {
 		snprintf(errbuf, PCAP_ERRBUF_SIZE,
@@ -210,7 +221,7 @@ oid_get_request(ADAPTER *adapter, bpf_u_int32 oid, void *data, size_t *lenp,
 	 * No need to copy the data - we're doing a fetch.
 	 */
 	oid_data_arg->Oid = oid;
-	oid_data_arg->Length = (ULONG)(*lenp);	/* XXX - check for ridiculously large value? */
+	oid_data_arg->Length = (ULONG)(*lenp);
 	if (!PacketRequest(adapter, FALSE, oid_data_arg)) {
 		pcapint_fmt_errmsg_for_win32_err(errbuf, PCAP_ERRBUF_SIZE,
 		    GetLastError(), "Error calling PacketRequest");
@@ -219,8 +230,12 @@ oid_get_request(ADAPTER *adapter, bpf_u_int32 oid, void *data, size_t *lenp,
 	}
 
 	/*
-	 * Get the length actually supplied.
+	 * Get the length actually supplied; clamp to the original
+	 * buffer size to prevent overflow if the driver returns a
+	 * larger value.
 	 */
+	if (oid_data_arg->Length > *lenp)
+		oid_data_arg->Length = (ULONG)(*lenp);
 	*lenp = oid_data_arg->Length;
 
 	/*
@@ -396,6 +411,16 @@ pcap_oid_set_request_npf(pcap_t *p, bpf_u_int32 oid, const void *data,
 	 * Allocate a PACKET_OID_DATA structure to hand to PacketRequest().
 	 * It should be big enough to hold "*lenp" bytes of data;
 	 */
+	if (*lenp > PACKET_OID_DATA_LENGTH_MAX) {
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		    "OID data length too large");
+		return (PCAP_ERROR);
+	}
+	if (*lenp > SIZE_MAX - offsetof(PACKET_OID_DATA, Data)) {
+		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
+		    "OID data length too large");
+		return (PCAP_ERROR);
+	}
 	oid_data_arg = malloc(PACKET_OID_DATA_LENGTH(*lenp));
 	if (oid_data_arg == NULL) {
 		snprintf(p->errbuf, PCAP_ERRBUF_SIZE,
@@ -404,7 +429,7 @@ pcap_oid_set_request_npf(pcap_t *p, bpf_u_int32 oid, const void *data,
 	}
 
 	oid_data_arg->Oid = oid;
-	oid_data_arg->Length = (ULONG)(*lenp);	/* XXX - check for ridiculously large value? */
+	oid_data_arg->Length = (ULONG)(*lenp);
 	memcpy(oid_data_arg->Data, data, *lenp);
 	if (!PacketRequest(pw->adapter, TRUE, oid_data_arg)) {
 		pcapint_fmt_errmsg_for_win32_err(p->errbuf, PCAP_ERRBUF_SIZE,
@@ -1940,6 +1965,8 @@ get_if_flags(const char *name, bpf_u_int32 *flags, char *errbuf)
 	 * pass that to it.
 	 */
 	name_copy = strdup(name);
+	if (name_copy == NULL)
+		return (0);
 	adapter = PacketOpenAdapter(name_copy);
 	free(name_copy);
 	if (adapter == NULL) {

--- a/pcap-options.c
+++ b/pcap-options.c
@@ -47,8 +47,10 @@ struct pcap_options {
 pcap_options *pcap_alloc_option(void)
 {
         pcap_options *po = malloc(sizeof(struct pcap_options));
+        if (po == NULL)
+                return NULL;
         memset(po, 0, sizeof(struct pcap_options));
-        return po;  // caller has to check for NULL anyway.
+        return po;
 }
 
 void pcap_free_option(pcap_options *po)
@@ -66,6 +68,8 @@ int pcap_set_option_string(pcap_options *po,
                            const char *value)
 {
         const char *saved = strdup(value);
+        if (saved == NULL)
+                return -1;
         switch(pon) {
         case PON_TSTAMP_PRECISION:
                 free((void *)saved);

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1233,13 +1233,14 @@ static int pcap_startcapture_remote(pcap_t *fp)
 
 	{
 		size_t filter_size;
-
-		if (fp->fcode.bf_len >
-		    SIZE_MAX / sizeof(struct rpcap_filterbpf_insn)) {
-			snprintf(fp->errbuf, PCAP_ERRBUF_SIZE,
-			    "BPF filter too large");
-			goto error_nodiscard;
-		}
+#if SIZE_MAX < UINT_MAX
+        if (fp->fcode.bf_len >
+            SIZE_MAX / sizeof(struct rpcap_filterbpf_insn)) {
+                snprintf(fp->errbuf, PCAP_ERRBUF_SIZE,
+                    "BPF filter too large");
+                goto error_nodiscard;
+        }
+#endif
 
 		filter_size =
 		    fp->fcode.bf_len * sizeof(struct rpcap_filterbpf_insn);
@@ -1454,7 +1455,7 @@ static int pcap_startcapture_remote(pcap_t *fp)
 	 * namely the length of the message header plus the length
 	 * of the packet header plus the snapshot length.
 	 */
-	if (fp->snapshot > SIZE_MAX - sizeof(struct rpcap_header) - sizeof(struct rpcap_pkthdr)) {
+	if ((size_t)fp->snapshot > SIZE_MAX - sizeof(struct rpcap_header) - sizeof(struct rpcap_pkthdr)) {
 		pcapint_fmt_errmsg_for_errno(fp->errbuf, PCAP_ERRBUF_SIZE,
 		    errno, "snapshot length too large");
 		goto error;

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1270,7 +1270,7 @@ static int pcap_startcapture_remote(pcap_t *fp)
 
 		rpcap_createhdr((struct rpcap_header *) sendbuf,
 		    pr->protocol_version, RPCAP_MSG_STARTCAP_REQ, 0,
-		    filter_size);
+		    (uint32_t)filter_size);
 	}
 
 	/* Fill the structure needed to open an adapter remotely */

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1231,9 +1231,39 @@ static int pcap_startcapture_remote(pcap_t *fp)
 		&sendbufidx, RPCAP_NETBUF_SIZE, SOCKBUF_CHECKONLY, fp->errbuf, PCAP_ERRBUF_SIZE))
 		goto error_nodiscard;
 
-	rpcap_createhdr((struct rpcap_header *) sendbuf,
-	    pr->protocol_version, RPCAP_MSG_STARTCAP_REQ, 0,
-	    sizeof(struct rpcap_startcapreq) + sizeof(struct rpcap_filter) + fp->fcode.bf_len * sizeof(struct rpcap_filterbpf_insn));
+	{
+		size_t filter_size;
+
+		if (fp->fcode.bf_len >
+		    SIZE_MAX / sizeof(struct rpcap_filterbpf_insn)) {
+			snprintf(fp->errbuf, PCAP_ERRBUF_SIZE,
+			    "BPF filter too large");
+			goto error_nodiscard;
+		}
+
+		filter_size =
+		    fp->fcode.bf_len * sizeof(struct rpcap_filterbpf_insn);
+
+		if (filter_size > SIZE_MAX - sizeof(struct rpcap_filter)) {
+			snprintf(fp->errbuf, PCAP_ERRBUF_SIZE,
+			    "BPF filter too large");
+			goto error_nodiscard;
+		}
+
+		filter_size += sizeof(struct rpcap_filter);
+
+		if (filter_size > SIZE_MAX - sizeof(struct rpcap_startcapreq)) {
+			snprintf(fp->errbuf, PCAP_ERRBUF_SIZE,
+			    "BPF filter too large");
+			goto error_nodiscard;
+		}
+
+		filter_size += sizeof(struct rpcap_startcapreq);
+
+		rpcap_createhdr((struct rpcap_header *) sendbuf,
+		    pr->protocol_version, RPCAP_MSG_STARTCAP_REQ, 0,
+		    filter_size);
+	}
 
 	/* Fill the structure needed to open an adapter remotely */
 	startcapreq = (struct rpcap_startcapreq *) &sendbuf[sendbufidx];
@@ -1424,6 +1454,11 @@ static int pcap_startcapture_remote(pcap_t *fp)
 	 * namely the length of the message header plus the length
 	 * of the packet header plus the snapshot length.
 	 */
+	if (fp->snapshot > SIZE_MAX - sizeof(struct rpcap_header) - sizeof(struct rpcap_pkthdr)) {
+		pcapint_fmt_errmsg_for_errno(fp->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "snapshot length too large");
+		goto error;
+	}
 	fp->bufsize = sizeof(struct rpcap_header) + sizeof(struct rpcap_pkthdr) + fp->snapshot;
 
 	fp->buffer = (u_char *)malloc(fp->bufsize);
@@ -1684,6 +1719,8 @@ pcap_save_current_filter_rpcap(pcap_t *fp, const char *filter)
 			filter = "";
 
 		pr->currentfilter = strdup(filter);
+		if (pr->currentfilter == NULL)
+			return;
 	}
 }
 

--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -1261,6 +1261,13 @@ static int pcap_startcapture_remote(pcap_t *fp)
 
 		filter_size += sizeof(struct rpcap_startcapreq);
 
+
+        if (filter_size > UINT32_MAX) {
+                snprintf(fp->errbuf, PCAP_ERRBUF_SIZE,
+                    "BPF filter too large");
+                goto error_nodiscard;
+        }
+
 		rpcap_createhdr((struct rpcap_header *) sendbuf,
 		    pr->protocol_version, RPCAP_MSG_STARTCAP_REQ, 0,
 		    filter_size);

--- a/pcap.c
+++ b/pcap.c
@@ -4062,7 +4062,10 @@ pcap_sendqueue_destroy(pcap_send_queue *queue)
 int
 pcap_sendqueue_queue(pcap_send_queue *queue, const struct pcap_pkthdr *pkt_header, const u_char *pkt_data)
 {
-	if (queue->len + sizeof(struct pcap_pkthdr) + pkt_header->caplen > queue->maxlen){
+	if (queue->len > queue->maxlen ||
+	    queue->maxlen - queue->len < sizeof(struct pcap_pkthdr) ||
+	    pkt_header->caplen >
+	        queue->maxlen - queue->len - sizeof(struct pcap_pkthdr)){
 		return (-1);
 	}
 

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -857,7 +857,7 @@ pcap_dump(u_char *user, const struct pcap_pkthdr *h, const u_char *sp)
 	 * attempted, but it is better than nothing.
 	 */
 	if (fwrite(&sf_hdr, sizeof(sf_hdr), 1, f) == 1) {
-		(void)fwrite(sp, h->caplen, 1, f);
+		fwrite(sp, h->caplen, 1, f);
 	}
 }
 

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -349,6 +349,12 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 	 * Copy the stuff we've read to the buffer, and read the rest
 	 * of the block.
 	 */
+	if (bhdr.total_length < sizeof(bhdr)) {
+		snprintf(errbuf, PCAP_ERRBUF_SIZE,
+		    "block total length %u < minimum %lu",
+		    bhdr.total_length, (unsigned long)sizeof(bhdr));
+		return (-1);
+	}
 	memcpy(p->buffer, &bhdr, sizeof(bhdr));
 	bdata = p->buffer + sizeof(bhdr);
 	data_remaining = bhdr.total_length - sizeof(bhdr);


### PR DESCRIPTION
Here is the description in English for your Pull Request:

Title:
Harden libpcap against integer overflow and bounds errors

Description:

This pull request hardens multiple code paths across libpcap against integer overflow, buffer overflow, and bounds-validation issues to improve security and overall stability.

Key Changes:

Allocation Checks: Added NULL checks following memory allocations (malloc, strdup) to safely handle failure cases and prevent null pointer dereferences.

Integer Overflow Safeguards: Introduced explicit bounds checks on size calculations—such as for ring buffer allocations, BPF filter calculations, and OID structures—to prevent arithmetic overflows before allocation.

Buffer & String Safety:

Replaced unsafe string functions like strcpy and strcat with bounded alternatives (pcapint_strlcpy, pcapint_strlcat).

Added validation for control message lengths (cmsg_len) and netfilter attribute offsets (nfattr) to prevent out-of-bounds reads and writes.

Clamped copy operations (memcpy) against maximum allowed snapshot limits to protect against memory overru