### PR TITLE
gencode: Quiet a sanitizer warning in gen_ncode

### DIFF
--- a/gencode.c
+++ b/gencode.c
@@ -7457,11 +7457,14 @@ gen_ncode(compiler_state_t *cstate, const char *s, bpf_u_int32 v, struct qual q)
 		} else {
 			mask = 0xffffffff;
 			if (s == NULL && q.addr == Q_NET) {
+				uint64_t mask64 = mask;
+
 				/* Promote short net number */
 				while (v && (v & 0xff000000) == 0) {
 					v <<= 8;
-					mask <<= 8;
+					mask64 <<= 8;
 				}
+				mask = (bpf_u_int32)mask64;
 			} else {
 				/* Promote short ipaddr */
 				v <<= 32 - vlen;


### PR DESCRIPTION
Use a temporary 64-bit variable for the shift result.

The error was like:

$ testprogs/filtertest RAW 'net 10 mask 255'
gencode.c:7463:11: runtime error: left shift of 4294967295 by 8 places
  cannot be represented in type 'bpf_u_int32' (aka 'unsigned int')

SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior gencode.c:7463:11