### PR TITLE
Eliminate wraparound when computing BPF ja jump targets

### DIFF
--- a/bpf_filter.c
+++ b/bpf_filter.c
@@ -398,6 +398,7 @@ int
 pcapint_validate_filter(const struct bpf_insn *f, int len)
 {
 	u_int i, from;
+	int64_t target;
 	const struct bpf_insn *p;
 
 	if (len < 1)
@@ -493,7 +494,17 @@ pcapint_validate_filter(const struct bpf_insn *f, int len)
 			from = i + 1;
 			switch (BPF_OP(p->code)) {
 			case BPF_JA:
-				if (from + p->k >= (u_int)len)
+				/*
+				 * The run-time evaluator sign-extends
+				 * p->k, so a value with the most
+				 * significant bit set is a backward
+				 * jump.  Compute the target in 64-bit
+				 * arithmetic to keep out-of-range jumps
+				 * from passing this check via 32-bit
+				 * wraparound.
+				 */
+				target = (int64_t)from + (bpf_int32)p->k;
+				if (target < 0 || target >= (int64_t)len)
 					return 0;
 				break;
 			case BPF_JEQ:

--- a/bpf_image.c
+++ b/bpf_image.c
@@ -243,7 +243,13 @@ bpf_image(const struct bpf_insn *p, int n)
 
 	case BPF_JMP|BPF_JA:
 		op = "ja";
-		(void)snprintf(operand_buf, sizeof operand_buf, "%d", n + 1 + p->k);
+		/*
+		 * The evaluator sign-extends p->k, so evaluate the
+		 * destination the same way here, in 64-bit arithmetic,
+		 * to avoid both wraparound and overflow.
+		 */
+		(void)snprintf(operand_buf, sizeof operand_buf, "%lld",
+		    (long long)n + 1 + (bpf_int32)p->k);
 		operand = operand_buf;
 		break;
 


### PR DESCRIPTION
Issue #1730 reports UBSan diagnostics from the BPF validator when a filter contains `ip6 protochain`, whose opcode emits backward `ja` jumps.

On current master, building with clang `-fsanitize=unsigned-integer-overflow` and running the test suite produces 38 failures; the captured output shows the two wraparound sites:

    bpf_filter.c:496:14: runtime error: unsigned integer overflow: 20 + 4294967281 cannot be represented in type 'unsigned int'
    bpf_image.c:246:63: runtime error: unsigned integer overflow: 20 + 4294967281 cannot be represented in type 'unsigned int'

### What happens

The evaluator sign-extends the K field of BPF_JA instructions (`pc += (bpf_int32)pc->k`), so K values with the most significant bit set are backward jumps; the protochain operation relies on them. The validator instead computes `from + p->k` in 32-bit unsigned arithmetic, and for those values its bounds check only comes out right through the unsigned addition wrapping modulo 2^32 — reported by UBSan and fragile to reason about. The disassembler computes the displayed `ja` destination the same wraparound-prone way and passes it to `%d` although the addition is performed in unsigned arithmetic.

### The change

- validator: compute the target as `(int64_t)from + (bpf_int32)p->k` and require `0 <= target < len`;
- disassembler: compute the destination in 64-bit signed arithmetic and print it with `%lld`.

For every program whose length fits in 31 bits this accepts exactly the same set of programs as before, backward jumps included, so validation is neither tightened nor loosened; the existing behavior is just made explicit and the wraparound is gone.

### Testing

- With `-fsanitize=unsigned-integer-overflow`, `perl testprogs/TESTrun`: 38 tests failed before this patch, 0 after (21208 tests, skips unchanged); no sanitizer output remains.
- The `ip6 protochain` filters from #1730 still validate and run identically.

Fixes #1730
