### PR TITLE
small fixes for netmap and QNX

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -159,6 +159,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Fill pcap_if_t in more consistently.
     QNX:
       Use "unix.h" instead of the missing <sysexits.h>.
+      Fix promiscuous mode for netmap.
     RDMA:
       Fix some resource freeing issues. (issues #1532 and #1300)
       Improve error messages for activate and findalldevs failures.

--- a/CHANGES
+++ b/CHANGES
@@ -93,6 +93,7 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Make NetBSD build warning-free.
       Make Sun C build warning-free.
       Make FreeBSD, Linux and macOS builds warning-free.
+      Make QNX build warning-free.
       Print MAC addresses in findalldevstest.
       Parameterize the interface name in reactivatetest.
       When necessary, trust the OS to implement ffs().

--- a/build.sh
+++ b/build.sh
@@ -103,11 +103,6 @@ suncc-5.14/SunOS-5.10|suncc-5.15/SunOS-5.10)
     #   returning, might return
     LIBPCAP_TAINTED=yes
     ;;
-*/QNX-*)
-    # pcap-bpf.c:1409:28: warning: implicit conversion loses integer precision:
-    #   'long' to 'suseconds_t' (aka 'int')
-    LIBPCAP_TAINTED=yes
-    ;;
 clang-22.*/Haiku-*)
     # pcap-rpcap.c:340:40: warning: allocation of insufficient size '28' for
     #   type 'struct sockaddr' with size '32' [-Walloc-size]

--- a/build.sh
+++ b/build.sh
@@ -106,11 +106,6 @@ suncc-5.14/SunOS-5.10|suncc-5.15/SunOS-5.10)
 */QNX-*)
     # pcap-bpf.c:1409:28: warning: implicit conversion loses integer precision:
     #   'long' to 'suseconds_t' (aka 'int')
-    # pcap-netmap.c:50: warning: "IFF_PPROMISC" redefined
-    #   In file included from .../qnx803/target/qnx/usr/include/net/netmap_user.h:93,
-    #                    from ./pcap-netmap.c:38:
-    #   .../qnx803/target/qnx/usr/include/net/if.h:167: note: this is the
-    #   location of the previous definition
     LIBPCAP_TAINTED=yes
     ;;
 clang-22.*/Haiku-*)

--- a/pcap-bpf.c
+++ b/pcap-bpf.c
@@ -1419,7 +1419,14 @@ pcap_read_bpf(pcap_t *p, int cnt, pcap_handler callback, u_char *user)
 
 				bintime2timespec(&bt, &ts);
 				pkthdr.ts.tv_sec = ts.tv_sec;
-				pkthdr.ts.tv_usec = ts.tv_nsec;
+				/*
+				 * On QNX 8.0 the former (timeval.tv_usec) is
+				 * an int via suseconds_t and the latter
+				 * (timespec.tv_nsec) is a long.  The value is
+				 * supposed to be in the [0 .. 999999999]
+				 * interval.
+				 */
+				pkthdr.ts.tv_usec = (suseconds_t)ts.tv_nsec;
 			} else {
 				struct timeval tv;
 

--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -41,9 +41,16 @@
 #include "pcap-int.h"
 #include "pcap-netmap.h"
 
-#ifndef __FreeBSD__
+#if ! defined(__FreeBSD__) && ! defined(__QNX__)
   /*
    * On FreeBSD we use IFF_PPROMISC which is in ifr_flagshigh.
+   * The reason for this is the same as in ifconfig(8) and is documented in
+   * ifnet(9): IFF_PROMISC is a part of the IFF_CANTCHANGE bitmask and is
+   * reserved for kernel purposes.  ioctl(2) silently disregards requests to
+   * change IFF_PROMISC, so trying to use the latter would not even cause an
+   * obvious run-time error.  Exactly the same applies to QNX 8.0, which uses
+   * FreeBSD network stack.
+   *
    * Remap to IFF_PROMISC on other platforms.
    *
    * XXX - DragonFly BSD?
@@ -172,7 +179,7 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 		 * So we mask out the upper 16 bits.
 		 */
 		ifr.ifr_flags = *if_flags & 0xffff;
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__QNX__)
 		/*
 		 * In FreeBSD, we need to set the high-order flags,
 		 * as we're using IFF_PPROMISC, which is in those bits.
@@ -202,7 +209,7 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 			 * sign-extended value.
 			 */
 			*if_flags = ifr.ifr_flags & 0xffff;
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__QNX__)
 			/*
 			 * In FreeBSD, we need to return the
 			 * high-order flags, as we're using

--- a/pcap-netmap.c
+++ b/pcap-netmap.c
@@ -153,8 +153,13 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 	 * contain a NUL-terminated string.
 	 */
 	(void)pcapint_strlcpy(ifr.ifr_name, d->req.nr_name, sizeof(ifr.ifr_name));
+	const char *reqstr = "bogus";
 	switch (what) {
+	case SIOCGIFFLAGS:
+		reqstr = "SIOCGIFFLAGS";
+		break;
 	case SIOCSIFFLAGS:
+		reqstr = "SIOCSIFFLAGS";
 		/*
 		 * The flags we pass in are 32-bit and unsigned.
 		 *
@@ -179,7 +184,11 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 		break;
 	}
 	error = ioctl(fd, what, &ifr);
-	if (!error) {
+	if (error) {
+		pcapint_fmt_errmsg_for_errno(p->errbuf, PCAP_ERRBUF_SIZE,
+		    errno, "ioctl() request 0x%lx (%s)", what, reqstr);
+		return PCAP_ERROR;
+	} else {
 		switch (what) {
 		case SIOCGIFFLAGS:
 			/*
@@ -208,7 +217,7 @@ pcap_netmap_ioctl(pcap_t *p, u_long what, uint32_t *if_flags)
 #ifdef __linux__
 	close(fd);
 #endif /* __linux__ */
-	return error ? -1 : 0;
+	return 0;
 }
 
 
@@ -220,8 +229,8 @@ pcap_netmap_close(pcap_t *p)
 	uint32_t if_flags = 0;
 
 	if (pn->must_clear_promisc) {
-		pcap_netmap_ioctl(p, SIOCGIFFLAGS, &if_flags); /* fetch flags */
-		if (if_flags & IFF_PPROMISC) {
+		if (! pcap_netmap_ioctl(p, SIOCGIFFLAGS, &if_flags) &&
+		    if_flags & IFF_PPROMISC) {
 			if_flags &= ~IFF_PPROMISC;
 			pcap_netmap_ioctl(p, SIOCSIFFLAGS, &if_flags);
 		}
@@ -266,11 +275,13 @@ pcap_netmap_activate(pcap_t *p)
 		p->snapshot = MAXIMUM_SNAPLEN;
 
 	if (p->opt.promisc && !(d->req.nr_ringid & NETMAP_SW_RING)) {
-		pcap_netmap_ioctl(p, SIOCGIFFLAGS, &if_flags); /* fetch flags */
+		if (pcap_netmap_ioctl(p, SIOCGIFFLAGS, &if_flags))
+			return PCAP_ERROR; // errbuf already filled
 		if (!(if_flags & IFF_PPROMISC)) {
 			pn->must_clear_promisc = 1;
 			if_flags |= IFF_PPROMISC;
-			pcap_netmap_ioctl(p, SIOCSIFFLAGS, &if_flags);
+			if (pcap_netmap_ioctl(p, SIOCSIFFLAGS, &if_flags))
+				return PCAP_ERROR; // errbuf already filled
 		}
 	}
 	p->linktype = DLT_EN10MB;


### PR DESCRIPTION
For the avoidance of doubt, this does not fix the-tcpdump-group/tcpdump#1458.