### PR TITLE
optimize.c: bound count_blocks() recursion depth (fixes #27)

### DIFF
--- a/optimize.c
+++ b/optimize.c
@@ -2498,16 +2498,29 @@ slength(struct slist *s)
 }
 
 /*
+ * Bound on how deep count_blocks() is allowed to recurse. A filter
+ * expression with this many chained terms (e.g. that many "and"ed
+ * "not host X" clauses) is already unreasonable, and letting the
+ * recursion go deeper than this risks exhausting the stack on a
+ * pathological or maliciously crafted filter before we ever get to
+ * do anything useful with it.
+ */
+#define MAX_BLOCK_NESTING	10000
+
+/*
  * Return the number of nodes reachable by 'p'.
  * All nodes should be initially unmarked.
  */
 static int
-count_blocks(struct icode *ic, struct block *p)
+count_blocks(opt_state_t *opt_state, struct icode *ic, struct block *p, u_int depth)
 {
 	if (p == 0 || isMarked(ic, p))
 		return 0;
+	if (depth > MAX_BLOCK_NESTING)
+		opt_error(opt_state, "filter is too complex to optimize");
 	Mark(ic, p);
-	return count_blocks(ic, JT(p)) + count_blocks(ic, JF(p)) + 1;
+	return count_blocks(opt_state, ic, JT(p), depth + 1) +
+	    count_blocks(opt_state, ic, JF(p), depth + 1) + 1;
 }
 
 /*
@@ -2585,7 +2598,7 @@ opt_init(opt_state_t *opt_state, struct icode *ic)
 	 * block number to block.  Then, put the blocks into the array.
 	 */
 	unMarkAll(ic);
-	n = count_blocks(ic, ic->root);
+	n = count_blocks(opt_state, ic, ic->root, 0);
 	opt_state->blocks = (struct block **)calloc(n, sizeof(*opt_state->blocks));
 	if (opt_state->blocks == NULL)
 		opt_error(opt_state, "calloc");


### PR DESCRIPTION
count_blocks() walks the flow graph built from a compiled filter by recursing into each block's true and false branches. Given enough chained terms in the filter (a long run of "not host X and not host Y and ...") the graph gets deep enough that the walk exhausts the stack before it finishes. That's the crash reported in #27 back in 2013, rediscovered independently by OSS-Fuzz in 2020, and the reachability through rpcapd was written up again in a comment on the issue this year.

count_blocks() is the very first thing opt_init() does, ahead of number_blks_r() and any of the other recursive graph walks in this file, so bounding the depth here is enough on its own: the other walks never get a chance to run on the same oversized tree. I added a depth counter threaded through the recursive calls and a bail-out through opt_error() once it passes a fixed limit, reusing the same longjmp-based mechanism this file already relies on for "filter is too complex" and the like, rather than adding a new error path.

A quick honesty note on verification: I wasn't able to reproduce the original crash end to end through pcap_compile() in the sandbox I did this work in. Building a filter string long enough to hit this recursion limit runs into gencode.c's own 16-chunk memory allocator cap well before the block graph gets deep enough, at least for the "chained not host" shape the original report and the OSS-Fuzz case both used, so I couldn't get a clean crash-then-fix comparison out of that exact approach here. The bug itself isn't in question, it's independently confirmed with ASan/UBSan in the issue thread, and the fix is a plain bounds check using the file's existing bail-out convention, but I want to be upfront that I'm not the one who reproduced the crash personally this time around. I did confirm a normal 300-term filter still compiles to the identical program with this change in place, so nothing about ordinary usage should be affected.