### PR TITLE
Speak of null pointers, not NULL, in man pages.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -83,6 +83,8 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Add a README.qnx.md file.
       Improve documentation of TLS support in rpcapd man page.
       Produce cleaner DOT in the optimizer debugging code.
+      man: Use "null pointer" rather than "NULL" and fix some other
+        issues.
     Building and testing:
       Apply GNU Hurd support patch from the Debian package.
       CI: Introduce and use LIBPCAP_CMAKE_TAINTED.

--- a/pcap.3pcap.in
+++ b/pcap.3pcap.in
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP 3PCAP "18 September 2024"
+.TH PCAP 3PCAP "6 September 2026"
 .SH NAME
 pcap \- Packet Capture library
 .SH SYNOPSIS
@@ -171,7 +171,7 @@ adapter could well be in promiscuous mode for some other reason.
 .IP
 For now, this doesn't work on the "any" device; if an argument of "any"
 or
-.B NULL
+a null pointer
 is supplied, the setting of promiscuous mode is ignored.
 .IP
 Promiscuous mode is set with
@@ -626,7 +626,7 @@ packet.  It returns a
 to the first
 .B caplen
 bytes of the packet on success, and
-.B NULL
+a null pointer
 on error.
 .PP
 .BR pcap_next_ex ()
@@ -702,7 +702,10 @@ routine returns, an attempt should be made to read packets from the
 device.  If
 .BR pcap_get_required_select_timeout ()
 returns
-.BR NULL ,
+a null timeout pointer for a device for which
+.BR pcap_get_selectable_fd ()
+returned
+.BR \-1 ,
 no such timeout is available, and those routines cannot be
 used with the device.
 .PP

--- a/pcap_create.3pcap
+++ b/pcap_create.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_CREATE 3PCAP "11 March 2025"
+.TH PCAP_CREATE 3PCAP "6 September 2026"
 .SH NAME
 pcap_create \- create a live capture handle
 .SH SYNOPSIS
@@ -42,8 +42,8 @@ is used to create a packet capture handle to capture packets on a device
 .BR \%pcap_findalldevs (3PCAP)
 for a more detailed explanation).
 .I source
-is a string that specifies the capture device to open, in this function
-.B NULL
+is a string that specifies the capture device to open; in this function,
+a null pointer
 means the same as the string "any".
 .I errbuf
 is a buffer large enough to hold at least
@@ -60,10 +60,10 @@ on the handle before activating it.
 returns a
 .B pcap_t *
 on success and
-.B NULL
+a null pointer
 on failure.
 If
-.B NULL
+a null pointer
 is returned,
 .I errbuf
 is filled in with an appropriate error message.

--- a/pcap_datalink_val_to_name.3pcap
+++ b/pcap_datalink_val_to_name.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_DATALINK_VAL_TO_NAME 3PCAP "4 May 2022"
+.TH PCAP_DATALINK_VAL_TO_NAME 3PCAP "6 September 2026"
 .SH NAME
 pcap_datalink_val_to_name, pcap_datalink_val_to_description,
 pcap_datalink_val_to_description_or_dlt \- get a
@@ -42,7 +42,7 @@ link-layer header type name, which is the
 name for the link-layer header type value with the
 .B DLT_
 removed.
-.B NULL
+A null pointer
 is returned if the type value does not correspond to a known
 .B DLT_
 value.
@@ -50,7 +50,7 @@ value.
 .BR pcap_datalink_val_to_description ()
 translates a link-layer header type value to a short description of that
 link-layer header type.
-.B NULL
+A null pointer
 is returned if the type value does not correspond to a known
 .B DLT_
 value.
@@ -70,7 +70,7 @@ function first became available in libpcap release 1.9.1.  In previous
 releases,
 .BR pcap_datalink_val_to_description ()
 would have to be called and, if it returned
-.BR NULL ,
+a null pointer,
 a default string would have to be constructed.
 .SH SEE ALSO
 .BR pcap (3PCAP),

--- a/pcap_dump_open.3pcap.in
+++ b/pcap_dump_open.3pcap.in
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_DUMP_OPEN 3PCAP "3 July 2020"
+.TH PCAP_DUMP_OPEN 3PCAP "6 September 2026"
 .SH NAME
 pcap_dump_open, pcap_dump_open_append, pcap_dump_fopen \- open a file to
 which to write packets
@@ -89,10 +89,10 @@ structure to use in subsequent
 and
 .BR pcap_dump_close (3PCAP)
 calls is returned on success.
-.B NULL
+A null pointer
 is returned on failure.
 If
-.B NULL
+a null pointer
 is returned,
 .BR pcap_geterr (3PCAP)
 can be used to get the error text.

--- a/pcap_file.3pcap
+++ b/pcap_file.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_FILE 3PCAP "3 January 2014"
+.TH PCAP_FILE 3PCAP "6 September 2026"
 .SH NAME
 pcap_file \- get the standard I/O stream for a savefile being read
 .SH SYNOPSIS
@@ -36,7 +36,7 @@ returns the standard I/O stream of the ``savefile'', if a ``savefile''
 was opened with
 .BR pcap_open_offline (3PCAP),
 or
-.BR NULL ,
+a null pointer,
 if a network device was opened with
 .BR pcap_create (3PCAP)
 and

--- a/pcap_findalldevs.3pcap
+++ b/pcap_findalldevs.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_FINDALLDEVS 3PCAP "1 February 2026"
+.TH PCAP_FINDALLDEVS 3PCAP "6 September 2026"
 .SH NAME
 pcap_findalldevs, pcap_freealldevs \- get a list of capture devices, and
 free that list
@@ -85,7 +85,7 @@ If
 succeeds, the pointer pointed to by
 .I alldevsp
 is set to point to the first element of the list, or to
-.B NULL
+a null pointer
 if no devices were found (this is considered success).
 Each element of the list is of type
 .BR pcap_if_t ,
@@ -94,9 +94,9 @@ and has the following members:
 .TP
 .B next
 if not
-.BR NULL ,
+a null pointer,
 a pointer to the next element in the list;
-.B NULL
+a null pointer
 for the last element of the list
 .TP
 .B name
@@ -107,14 +107,14 @@ or
 .TP
 .B description
 if not
-.BR NULL ,
+a null pointer,
 a pointer to a string giving a human-readable description of the device
 .TP
 .B addresses
 a pointer to the first element of a list of network addresses for the
 device,
 or
-.B NULL
+a null pointer
 if the device has no addresses
 .TP
 .B flags
@@ -163,9 +163,9 @@ and has the following members:
 .TP
 .B next
 if not
-.BR NULL ,
+a null pointer,
 a pointer to the next element in the list;
-.B NULL
+a null pointer
 for the last element of the list
 .TP
 .B addr
@@ -175,7 +175,7 @@ containing an address
 .TP
 .B netmask
 if not
-.BR NULL ,
+a null pointer,
 a pointer to a
 .B "struct sockaddr"
 that contains the netmask corresponding to the address pointed to by
@@ -183,26 +183,26 @@ that contains the netmask corresponding to the address pointed to by
 .TP
 .B broadaddr
 if not
-.BR NULL ,
+a null pointer,
 a pointer to a
 .B "struct sockaddr"
 that contains the broadcast address corresponding to the address pointed
 to by
 .BR addr ;
 may be
-.B NULL
+a null pointer
 if the device doesn't support broadcasts
 .TP
 .B dstaddr
 if not
-.BR NULL ,
+a null pointer,
 a pointer to a
 .B "struct sockaddr"
 that contains the destination address corresponding to the address pointed
 to by
 .BR addr ;
 may be
-.B NULL
+a null pointer
 if the device isn't a point-to-point interface
 .RE
 .PP
@@ -267,7 +267,7 @@ is filled in with an appropriate error message,
 and the pointer pointed to by
 .I alldevsp
 is set to
-.BR NULL .
+a null pointer.
 .SH BACKWARD COMPATIBILITY
 .PP
 The

--- a/pcap_get_required_select_timeout.3pcap
+++ b/pcap_get_required_select_timeout.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_GET_REQUIRED_SELECT_TIMEOUT 3PCAP "29 January 2020"
+.TH PCAP_GET_REQUIRED_SELECT_TIMEOUT 3PCAP "6 September 2026"
 .SH NAME
 pcap_get_required_select_timeout \- get a timeout to be used when doing
 select() for a live capture
@@ -42,11 +42,11 @@ containing a value that must be used as the minimum timeout in
 and
 .BR kevent (2)
 calls, or
-.B NULL
+a null pointer
 if there is no such timeout.
 If a
-.RB non- NULL
-value is returned, it must be used regardless of whether
+non-null
+timeout pointer is returned, it must be used regardless of whether
 .BR pcap_get_selectable_fd (3PCAP)
 returns
 .B \-1
@@ -100,13 +100,13 @@ when the call returns,
 should be called for all
 .BR pcap_t s
 for which a
-.RB non- NULL
-timeout was returned, regardless of whether it's indicated as having
+non-null
+timeout pointer was returned, regardless of whether it's indicated as having
 anything to read from it or not.
 .PP
 All devices with a
-.RB non- NULL
-timeout must be put in non-blocking mode with
+non-null
+timeout pointer must be put in non-blocking mode with
 .BR pcap_setnonblock (3PCAP).
 .PP
 Note that a device on which a read can be done without blocking may,
@@ -125,7 +125,7 @@ is not available on Windows.
 A pointer to a
 .B struct timeval
 is returned if the timeout is required; otherwise
-.B NULL
+a null pointer
 is returned.
 .SH BACKWARD COMPATIBILITY
 This function became available in libpcap release 1.9.0.  In previous

--- a/pcap_get_selectable_fd.3pcap
+++ b/pcap_get_selectable_fd.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_GET_SELECTABLE_FD 3PCAP "29 January 2020"
+.TH PCAP_GET_SELECTABLE_FD 3PCAP "6 September 2026"
 .SH NAME
 pcap_get_selectable_fd \- get a file descriptor on which a select() can
 be done for a live capture
@@ -69,7 +69,10 @@ and an attempt must always be made to read packets from the device
 when the call returns.  If
 .BR \%pcap_get_required_select_timeout ()
 returns
-.BR NULL ,
+a null timeout pointer for a device for which
+.BR pcap_get_selectable_fd ()
+returned
+.BR \-1 ,
 it is not possible to wait for packets to arrive on the device in an
 event loop.
 .PP

--- a/pcap_lookupdev.3pcap
+++ b/pcap_lookupdev.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_LOOKUPDEV 3PCAP "30 November 2023"
+.TH PCAP_LOOKUPDEV 3PCAP "6 September 2026"
 .SH NAME
 pcap_lookupdev \- find the default device on which to capture
 .SH SYNOPSIS
@@ -51,7 +51,7 @@ chars.
 .B If
 .BR pcap_init (3PCAP)
 .B has been called, this interface always returns
-.BR NULL .
+a null pointer.
 .LP
 .BR pcap_lookupdev ()
 returns a pointer to a string giving the name of a network device
@@ -67,7 +67,7 @@ If there is an error,
 or if
 .BR pcap_init (3PCAP)
 has been called,
-.B NULL
+a null pointer
 is returned and
 .I errbuf
 is filled in with an appropriate error message.

--- a/pcap_next_ex.3pcap
+++ b/pcap_next_ex.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_NEXT_EX 3PCAP "26 March 2026"
+.TH PCAP_NEXT_EX 3PCAP "6 September 2026"
 .SH NAME
 pcap_next_ex, pcap_next \- read the next packet from a pcap_t
 .SH SYNOPSIS
@@ -141,7 +141,7 @@ as an argument to fetch or display the error text.
 .PP
 .BR pcap_next ()
 returns a pointer to the packet data on success, and returns
-.B NULL
+a null pointer
 if an error occurred, or if no packets were read from a live capture
 (if, for example, they were discarded because they didn't pass the
 packet filter, or if, on platforms that support a packet buffer timeout

--- a/pcap_offline_filter.3pcap
+++ b/pcap_offline_filter.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_OFFLINE_FILTER 3PCAP "12 March 2026"
+.TH PCAP_OFFLINE_FILTER 3PCAP "6 September 2026"
 .SH NAME
 pcap_offline_filter \- check whether a filter matches a packet
 .SH SYNOPSIS
@@ -51,7 +51,7 @@ In the
 structure the
 .B \%bf_insns
 member is either
-.B NULL
+a null pointer
 (which means to reject all packets) or points to an array of one or more
 .B \%struct bpf_insn
 elements, in which case the

--- a/pcap_open_live.3pcap
+++ b/pcap_open_live.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_OPEN_LIVE 3PCAP "11 March 2025"
+.TH PCAP_OPEN_LIVE 3PCAP "6 September 2026"
 .SH NAME
 pcap_open_live \- open a device for capturing
 .SH SYNOPSIS
@@ -43,8 +43,8 @@ is used to obtain a packet capture handle to capture packets on a device
 .BR \%pcap_findalldevs (3PCAP)
 for a more detailed explanation).
 .I device
-is a string that specifies the capture device to open, in this function
-.B NULL
+is a string that specifies the capture device to open; in this function,
+a null pointer
 means the same as the string "any".
 .PP
 .I snaplen
@@ -74,10 +74,10 @@ chars.
 returns a
 .B pcap_t *
 on success and
-.B NULL
+a null pointer
 on failure.
 If
-.B NULL
+a null pointer
 is returned,
 .I errbuf
 is filled in with an appropriate error message.

--- a/pcap_open_offline.3pcap.in
+++ b/pcap_open_offline.3pcap.in
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_OPEN_OFFLINE 3PCAP "12 October 2024"
+.TH PCAP_OPEN_OFFLINE 3PCAP "6 September 2026"
 .SH NAME
 pcap_open_offline, pcap_open_offline_with_tstamp_precision,
 pcap_fopen_offline, pcap_fopen_offline_with_tstamp_precision \- open a saved capture file for reading
@@ -104,10 +104,10 @@ and
 return a
 .B pcap_t *
 on success and
-.B NULL
+a null pointer
 on failure.
 If
-.B NULL
+a null pointer
 is returned,
 .I errbuf
 is filled in with an appropriate error message.

--- a/pcap_setnonblock.3pcap
+++ b/pcap_setnonblock.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_SETNONBLOCK 3PCAP "30 November 2023"
+.TH PCAP_SETNONBLOCK 3PCAP "6 September 2026"
 .SH NAME
 pcap_setnonblock, pcap_getnonblock \- set or get the state of
 non-blocking mode on a capture device
@@ -65,7 +65,7 @@ available;
 should be used instead.
 .BR pcap_next (3PCAP)
 will return
-.B NULL
+a null pointer
 if there are no packets currently available to read;
 this is indistinguishable from an error, so
 .BR pcap_next_ex ()

--- a/pcap_statustostr.3pcap
+++ b/pcap_statustostr.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_STATUSTOSTR 3PCAP "12 August 2026"
+.TH PCAP_STATUSTOSTR 3PCAP "6 September 2026"
 .SH NAME
 pcap_statustostr \- convert a PCAP_ERROR_ or PCAP_WARNING_ value to a string
 .SH SYNOPSIS
@@ -36,11 +36,14 @@ converts a
 .B PCAP_ERROR_
 or
 .B PCAP_WARNING_
-value returned by a libpcap routine to an error/warning string.
+value returned by a libpcap routine to an error or warning string.
 .SH RETURN VALUE
 The function never returns
-.BR NULL :
-for an argument that is not a known error/warning value it produces a generic
-message that quotes the argument.
+a null pointer;
+if the
+.I error
+argument
+is not a known error or warning value, it returns a generic
+message that shows the numeric value of the argument.
 .SH SEE ALSO
 .BR pcap (3PCAP)

--- a/pcap_tstamp_type_val_to_name.3pcap
+++ b/pcap_tstamp_type_val_to_name.3pcap
@@ -18,7 +18,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_TSTAMP_TYPE_VAL_TO_NAME 3PCAP "22 August 2018"
+.TH PCAP_TSTAMP_TYPE_VAL_TO_NAME 3PCAP "6 September 2026"
 .SH NAME
 pcap_tstamp_type_val_to_name, pcap_tstamp_type_val_to_description \- get
 a name or description for a time stamp type value
@@ -37,13 +37,13 @@ const char *pcap_tstamp_type_val_to_description(int tstamp_type);
 .BR pcap_tstamp_type_val_to_name ()
 translates a time stamp type value to the corresponding time stamp type
 name.
-.B NULL
+A null pointer
 is returned on failure.
 .PP
 .BR pcap_tstamp_type_val_to_description ()
 translates a time stamp type value to a short description of that time
 stamp type.
-.B NULL
+A null pointer
 is returned on failure.
 .SH BACKWARD COMPATIBILITY
 .PP


### PR DESCRIPTION
This is less ambiguous in the case of pcap_datalink_val_to_name(), which can return a null pointer for an unknown DLT_ value or a pointer to the string "NULL" for DLT_NULL.

It could also be considered more general, as there are other ways to represent a null pointer in C source, and, in newer versions of C++, you can compare the return value against nulllptr. If there are other languages that can call C functions directly so that you don't need a language wrapper, they may also have different ways of representing null pointers at the source code level.

Fix GitHub issue #1739.

While we're at it, improve the wording in some man pages to be clearer or more complete.