### PR TITLE
libpcap-1.10: Backport two BPF code-generation fixes from master

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,10 @@
+Monday, September 7, 2026 / The Tcpdump Group
+  Summary for 1.10.8 libpcap release (so far!)
+    Packet filtering:
+      Fix optimization of "jset #0xffffffff".
+      BPF_X is not valid for BPF_RET; remove the always-false test for
+        it in atomuse().
+
 Saturday, September 5, 2026 / The Tcpdump Group
   Summary for 1.10.7 libpcap release
     General:

--- a/optimize.c
+++ b/optimize.c
@@ -1106,14 +1106,33 @@ opt_peep(opt_state_t *opt_state, struct block *b)
 		}
 	}
 	/*
-	 * jset #0        ->   never
-	 * jset #ffffffff ->   always
+	 * jset #0x0         ->  never
+	 * jset #0xffffffff  ->  iff A != 0
 	 */
 	if (b->s.code == (BPF_JMP|BPF_K|BPF_JSET)) {
+		/*
+		 * This can be, but not necessarily is a result of the folding
+		 * into "jset #k" above.
+		 */
 		if (b->s.k == 0)
 			JT(b) = JF(b);
-		if (b->s.k == 0xffffffffU)
-			JF(b) = JT(b);
+		else if (b->s.k == 0xffffffffU) {
+			/*
+			 * For any A: "A has at least one bit set" means the
+			 * same as "A != 0".  Test the latter condition, which
+			 * executes slightly faster and is easier to read.
+			 * This is not meant to be the inverse of the folding,
+			 * hence do not prepend a [no-op] "and #0xffffffff".
+			 */
+			b->s.code = BPF_JMP|BPF_JEQ|BPF_K;
+			b->s.k = 0;
+			opt_not(b);
+			opt_state->done = 0;
+			/*
+			 * XXX - optimizer loop detection.
+			 */
+			opt_state->non_branch_movement_performed = 1;
+		}
 	}
 	/*
 	 * If we're comparing against the index register, and the index

--- a/optimize.c
+++ b/optimize.c
@@ -544,8 +544,7 @@ atomuse(struct stmt *s)
 	switch (BPF_CLASS(c)) {
 
 	case BPF_RET:
-		return (BPF_RVAL(c) == BPF_A) ? A_ATOM :
-			(BPF_RVAL(c) == BPF_X) ? X_ATOM : -1;
+		return BPF_RVAL(c) == BPF_A ? A_ATOM : -1;
 
 	case BPF_LD:
 	case BPF_LDX:

--- a/pcap/bpf.h
+++ b/pcap/bpf.h
@@ -197,7 +197,7 @@ struct bpf_program {
 #define		BPF_K		0x00
 #define		BPF_X		0x08
 
-/* ret - BPF_K and BPF_X also apply */
+/* ret - BPF_K also applies */
 #define BPF_RVAL(code)	((code) & 0x18)
 #define		BPF_A		0x10
 /*				0x18	reserved */


### PR DESCRIPTION
Backport two BPF code-generation fixes from master to the libpcap-1.10 maintenance branch.

Both are clean cherry-picks of upstream commits (provenance lines in the commit messages); the only adjustment is a CHANGES entry in 1.10 style (the master commits also update testprogs/TESTrun, which does not exist on this branch — that test runner is new on master).

1. **Fix optimization of "jset #0xffffffff"** (upstream `f283b98e`, Denis Ovsienko, 2026-07-12)
   A `jset #0xffffffff` branch means "A is not zero"; the optimizer treated it as "always true" since 2001 (commit cae0540). Affected filters are miscompiled: one that should match only some packets silently matches everything (and its negation is optimized to "rejects all packets"). This is the kind of wrong-codegen bug that can turn a capture/selection filter into a filter bypass.

   Verified locally against the 1.10.7 tag (DLT_RAW, `pcap_compile` + `bpf_image` dump):

   ```
   filter: link[0:1] & 0xffffffff != 0
   1.10.7 (before): (000) ret #65535        <- accepts EVERY packet
   patched (after): (000) ldb [0]
                    (001) jeq #0x0   jt 2  jf 3
                    (002) ret #0
                    (003) ret #65535        <- accepts iff byte != 0
   ```
   Same for the `ldh`/`ld` variants and the `== 0` negation (which previously failed to compile at all with "expression rejects all packets").

2. **BPF_X is not valid for BPF_RET** (upstream `9db8ee21`, 2026-07-27)
   Documentation fix in pcap/bpf.h plus removal of an always-false test in `atomuse()` — keeps the optimizer's atom analysis consistent with the BPF ISA.

Note for maintainers: a further backport candidate on this branch is `6154294` ("Don't assume Linux USB headers are 64-bit aligned", 2026-03-02, issue #1634) — it is not in any 1.10.x release either, but it is larger (header re-typing across pcap/usb.h, pcap-inttypes.h, pcap-usb-linux.c, pcap-util.c), so I left it out of this PR. Happy to prepare it separately if wanted.