### PR TITLE
pcap_fileno, pcap_get_selectable_fd man pages: various fixes.

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -87,6 +87,9 @@ DayOfTheWeek, Month DD, YYYY / The Tcpdump Group
       Produce cleaner DOT in the optimizer debugging code.
       man: Use "null pointer" rather than "NULL" and fix some other
         issues.
+      Note in pcap_fileno(3PCAP) and pcap_get_selectable_fd(3PCAP) that
+        the descriptors returned by those routinesmust not be closed.
+        (Issue #1722)
     Building and testing:
       Apply GNU Hurd support patch from the Debian package.
       CI: Introduce and use LIBPCAP_CMAKE_TAINTED.

--- a/pcap_fileno.3pcap
+++ b/pcap_fileno.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_FILENO 3PCAP "25 July 2018"
+.TH PCAP_FILENO 3PCAP "10 September 2026"
 .SH NAME
 pcap_fileno \- get the file descriptor for a live capture
 .SH SYNOPSIS
@@ -33,7 +33,7 @@ int pcap_fileno(pcap_t *p);
 .SH DESCRIPTION
 If
 .I p
-refers to a network device that was opened for a live capture using
+refers to a capture device that was opened for a live capture using
 a combination of
 .BR pcap_create (3PCAP)
 and
@@ -42,6 +42,10 @@ or using
 .BR pcap_open_live (3PCAP),
 .BR pcap_fileno ()
 returns the file descriptor from which captured packets are read.
+.LP
+A
+.BR close (2)
+must not be performed on the file descriptor.
 .LP
 If
 .I p

--- a/pcap_get_selectable_fd.3pcap
+++ b/pcap_get_selectable_fd.3pcap
@@ -17,7 +17,7 @@
 .\" WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF
 .\" MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
 .\"
-.TH PCAP_GET_SELECTABLE_FD 3PCAP "6 September 2026"
+.TH PCAP_GET_SELECTABLE_FD 3PCAP "10 September 2026"
 .SH NAME
 pcap_get_selectable_fd \- get a file descriptor on which a select() can
 be done for a live capture
@@ -32,19 +32,34 @@ int pcap_get_selectable_fd(pcap_t *p);
 .ft
 .fi
 .SH DESCRIPTION
+If
+.I p
+refers to a network device that was opened for a live capture using
+a combination of
+.BR pcap_create (3PCAP)
+and
+.BR pcap_activate (3PCAP),
+or using
+.BR pcap_open_live (3PCAP),
 .BR pcap_get_selectable_fd ()
-returns, on UNIX, a file descriptor number for a file descriptor on
-which one can
+returns, on Unix-like systems, a file descriptor number for a
+file descriptor on which one can
 do a
 .BR select (2),
 .BR poll (2),
 .BR epoll_wait (2),
 .BR kevent (2),
 or other such call
-to wait for it to be possible to read packets without blocking, if such
-a descriptor exists, or
+to wait for it to be possible to read or inject packets without
+blocking, if such a descriptor exists, or
 .BR \-1 ,
 if no such descriptor exists.
+.PP
+The returned file descriptor must only be used for detecting
+whether reading or injecting packets can be done without blocking.
+No other operations, including
+.BR close (2),
+should be performed on the file descriptor.
 .PP
 Some network devices opened with
 .BR pcap_create (3PCAP)
@@ -152,4 +167,7 @@ A selectable file descriptor is returned if one exists; otherwise,
 is returned.
 .SH SEE ALSO
 .BR pcap (3PCAP),
+.BR select (2),
+.BR poll (2),
+.BR epoll_wait (2),
 .BR kqueue (2)


### PR DESCRIPTION
Fix #1722 by warning that you must *not* close either of those file descriptors out from under libpcap.

Add the "if p refers to..." clause from the pcap_fileno page to the pcap_get_selectable_fd page.

Make some other improvements to the pcap_get_selectable_fd page.