### PR TITLE
pcap: add optional -fbounds-safety annotation for pcap_t.buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -492,6 +492,16 @@ else()
     set(NO_PROTOCHAIN ON)
 endif()
 
+# Optional Clang -fbounds-safety. Default OFF: PCAP_*COUNTED_BY* macros in
+# pcap_bounds_safety.h are inert and the ABI/build is unchanged. When ON,
+# requires a Clang that provides -fbounds-safety / <ptrcheck.h>.
+option(ENABLE_FBOUNDS_SAFETY
+       "Enable Clang -fbounds-safety annotations (experimental toolchain)" OFF)
+if(ENABLE_FBOUNDS_SAFETY)
+  add_definitions(-DPCAP_SUPPORT_FBOUNDS_SAFETY)
+  add_compile_options(-fbounds-safety)
+endif()
+
 #
 # Start out with the capture mechanism type unspecified; the user
 # can explicitly specify it and, if they don't, we'll pick an

--- a/Makefile.in
+++ b/Makefile.in
@@ -53,12 +53,22 @@ MKDEP = @MKDEP@
 CCOPT = @V_CCOPT@
 SHLIB_CCOPT = @V_SHLIB_CCOPT@
 INCLS = -I. @V_INCLS@
-DEFS = -DBUILDING_PCAP -Dpcap_EXPORTS @DEFS@ @V_DEFS@
+# Optional Clang -fbounds-safety (default off). make ENABLE_FBOUNDS_SAFETY=1
+ENABLE_FBOUNDS_SAFETY ?= 0
+ifeq ($(ENABLE_FBOUNDS_SAFETY),1)
+FBOUNDS_DEFS = -DPCAP_SUPPORT_FBOUNDS_SAFETY
+FBOUNDS_CFLAGS = -fbounds-safety
+else
+FBOUNDS_DEFS =
+FBOUNDS_CFLAGS =
+endif
+
+DEFS = -DBUILDING_PCAP -Dpcap_EXPORTS @DEFS@ @V_DEFS@ $(FBOUNDS_DEFS)
 ADDLOBJS = @ADDLOBJS@
 ADDLARCHIVEOBJS = @ADDLARCHIVEOBJS@
 LIBS = @LIBS@
 CROSSFLAGS=
-CFLAGS = @CFLAGS@   ${CROSSFLAGS}
+CFLAGS = @CFLAGS@   ${CROSSFLAGS} $(FBOUNDS_CFLAGS)
 LDFLAGS = @LDFLAGS@ ${CROSSFLAGS}
 DYEXT = @DYEXT@
 RPATH = @RPATH@
@@ -133,6 +143,7 @@ HDR = $(PUBHDR) \
 	optimize.h \
 	pcap-common.h \
 	pcap-int.h \
+	pcap_bounds_safety.h \
 	pcap-rpcap.h \
 	pcap-types.h \
 	pcap-usb-linux-common.h \

--- a/NOTES.md
+++ b/NOTES.md
@@ -1,0 +1,90 @@
+# Google Patch Rewards — libpcap local draft notes
+
+**Date:** 2026-09-11 (America/Chicago)  
+**Do not claim yet:** need upstream merge + ≥30 days, then https://bughunters.google.com/report/patch_rewards
+
+## Chosen target + why
+
+- **Project:** libpcap (the-tcpdump-group/libpcap, branch `master`)
+- **Upstream:** https://github.com/the-tcpdump-group/libpcap (GitHub PR)
+- **Local clone:** `/workspace/google-patch-libpcap`
+- **Branch:** `local/buffer-fbounds-safety`
+- **Why this target:**
+  1. Tier-1 **Core infrastructure data parsers** (3× memory-safety multiplier through end-2026).
+  2. Clear, mergeable first-CL scope: one struct field pair (`buffer` / `bufsize`) on `pcap_t` — savefile/live read buffer path — not a whole-library sweep.
+  3. Same pattern as libpng / libwebp / libjpeg-turbo / libtiff: **inert macros** when the flag is off; experimental Clang `-fbounds-safety` only when explicitly enabled.
+  4. `bufsize` is already declared before `buffer` (no field reorder / ABI churn).
+  5. Not already done upstream (no `__counted_by` / `-fbounds-safety` in tree).
+  6. AI CONTRIBUTING gate clear (no AI ban in CONTRIBUTING.md).
+
+## Security benefit
+
+`pcap_t.buffer` holds bytes for packet/savefile block parsing on offline and many live backends. The library already tracks capacity in `bufsize`, but the compiler cannot see that relationship.
+
+This draft:
+
+1. Introduces `pcap_bounds_safety.h` with `PCAP_COUNTED_BY` / `PCAP_COUNTED_BY_OR_NULL` (empty by default).
+2. Annotates `buffer` with `PCAP_COUNTED_BY_OR_NULL(bufsize)` (nullable; size may be 0).
+3. Keeps `bufsize` **before** `buffer` (already true) so the named count is in scope for the attribute.
+4. Makes key update sites **capacity-then-pointer** (and clear sites **pointer-null then size 0**) so counted-by invariants hold under a real `-fbounds-safety` build; also records grown capacity in the pcapng block-grow path.
+5. Wires optional CMake `ENABLE_FBOUNDS_SAFETY` (OFF by default) and Makefile `ENABLE_FBOUNDS_SAFETY=1` → `-DPCAP_SUPPORT_FBOUNDS_SAFETY` + `-fbounds-safety`.
+
+**Default builds are unchanged:** macros expand to nothing; no new runtime checks without the experimental flag.
+
+## Files changed
+
+| File | Change |
+|------|--------|
+| `pcap_bounds_safety.h` | **New** — inert / Clang bounds macros |
+| `pcap-int.h` | Include header; annotate `pcap_t.buffer` |
+| `sf-pcap.c` | Capacity-first `grow_buffer` |
+| `sf-pcapng.c` | Capacity-first grow; set `bufsize` on realloc |
+| `savefile.c` | Null pointer then zero size on cleanup |
+| `pcap.c` | Null pointer then zero size in live cleanup |
+| `CMakeLists.txt` | `ENABLE_FBOUNDS_SAFETY` option OFF |
+| `Makefile.in` | Header in `HDR`; `ENABLE_FBOUNDS_SAFETY` hook |
+| `NOTES.md` | This file |
+
+## How to build / test
+
+Default (macros inert — must stay green):
+
+```sh
+cmake -S . -B build-draft -DBUILD_SHARED_LIBS=OFF
+cmake --build build-draft -j
+# optional: ctest / testprogs if configured
+```
+
+Or autoconf:
+
+```sh
+./autogen.sh && ./configure && make -j
+```
+
+With experimental bounds-safety toolchain (maintainers / CI; **not** available on this box — no Clang/`ptrcheck.h`):
+
+```sh
+cmake -S . -B build-fbs -DENABLE_FBOUNDS_SAFETY=ON \
+  -DCMAKE_C_COMPILER=<clang-with-fbounds-safety> \
+  -DBUILD_SHARED_LIBS=OFF
+cmake --build build-fbs -j
+```
+
+## Upstream submit plan
+
+1. Open a focused GitHub PR against `the-tcpdump-group/libpcap` branch `master`.
+2. Proposed title: `pcap: add optional -fbounds-safety annotation for pcap_t.buffer`
+3. Frame as secure-by-design / Safe Buffers-style systematization of an existing size+pointer pair; cite libwebp/libpng prior art and Google Patch Rewards Tier-1 parser goals.
+4. Emphasize: default build behavior unchanged; flag OFF; no PoC / no CVE claim.
+5. Do **not** claim on https://bughunters.google.com/report/patch_rewards until **merge + ≥30 days**.
+
+## Follow-ups (separate CLs)
+
+- Linux TPACKET path: `buffer` is a frame-pointer ring sized by `cc`, while `bufsize` is frame size — needs a dedicated capacity field or backend-local annotation before enabling `-fbounds-safety` there.
+- BPF zerocopy paths that alias `buffer` into mmapped regions (null without size clear).
+- `bp` / `cc` cursor pair (pointer-into-buffer; different annotation shape).
+- Other live backends’ allocate sites (most already capacity-then-pointer).
+
+## Status
+
+**IN PROGRESS — local draft only; no GitHub upload, no push, no claim.**

--- a/pcap-int.h
+++ b/pcap-int.h
@@ -48,6 +48,7 @@
 #include <stdarg.h>
 
 #include "portability.h"
+#include "pcap_bounds_safety.h"
 
 #define PCAP_DEBUG {printf(" [%s:%d %s] ", __FILE__, __LINE__, __func__); fflush(stdout);}
 
@@ -261,9 +262,15 @@ struct pcap {
 
 	/*
 	 * Read buffer.
+	 * bufsize is declared before buffer so PCAP_COUNTED_BY_OR_NULL can name
+	 * it. Capacity is assigned before the pointer at update sites.
+	 * On most capture/savefile paths, buffer holds bufsize bytes (or is NULL
+	 * with bufsize 0). Linux TPACKET uses buffer as a frame-pointer ring with
+	 * a different size relationship — follow-up before enabling
+	 * -fbounds-safety on that backend.
 	 */
 	u_int bufsize;
-	u_char *buffer;
+	u_char * PCAP_COUNTED_BY_OR_NULL(bufsize) buffer;
 	u_char *bp;
 	u_int cc;
 

--- a/pcap.c
+++ b/pcap.c
@@ -4242,7 +4242,9 @@ pcapint_cleanup_live_common(pcap_t *p)
 	 */
 	if (p->buffer != NULL) {
 		free(p->buffer);
+		/* clear: drop counted pointer then size */
 		p->buffer = NULL;
+		p->bufsize = 0;
 	}
 	if (p->dlt_list != NULL) {
 		free(p->dlt_list);

--- a/pcap_bounds_safety.h
+++ b/pcap_bounds_safety.h
@@ -1,0 +1,36 @@
+/* pcap_bounds_safety.h - portability macros for optional -fbounds-safety
+ *
+ * Copyright (c) 2026 Jeff Bindel
+ *
+ * License: BSD (same as libpcap; see LICENSE)
+ *
+ * When PCAP_SUPPORT_FBOUNDS_SAFETY is defined (typically via
+ * -DPCAP_SUPPORT_FBOUNDS_SAFETY and a Clang toolchain that implements
+ * -fbounds-safety), these macros expand to Clang bounds annotations.
+ * Otherwise they expand to nothing so default builds are unchanged.
+ *
+ * Pattern matches libwebp / libpng / libjpeg-turbo / libtiff inert-macro
+ * -fbounds-safety adoption: annotations are inert unless explicitly enabled.
+ */
+
+#ifndef PCAP_BOUNDS_SAFETY_H
+#define PCAP_BOUNDS_SAFETY_H
+
+#ifdef PCAP_SUPPORT_FBOUNDS_SAFETY
+
+#  include <ptrcheck.h>
+/* Non-ABI-breaking counted-by annotations for struct pointer members.
+ * Prefer PCAP_COUNTED_BY_OR_NULL for pointers that may be NULL while the
+ * companion size field is zero (pcap_t.buffer / bufsize pattern).
+ */
+#  define PCAP_COUNTED_BY(n) __counted_by(n)
+#  define PCAP_COUNTED_BY_OR_NULL(n) __counted_by_or_null(n)
+
+#else /* !PCAP_SUPPORT_FBOUNDS_SAFETY */
+
+#  define PCAP_COUNTED_BY(n)
+#  define PCAP_COUNTED_BY_OR_NULL(n)
+
+#endif /* PCAP_SUPPORT_FBOUNDS_SAFETY */
+
+#endif /* PCAP_BOUNDS_SAFETY_H */

--- a/savefile.c
+++ b/savefile.c
@@ -238,8 +238,12 @@ pcapint_sf_cleanup(pcap_t *p)
 {
 	if (p->rfile != stdin)
 		(void)fclose(p->rfile);
-	if (p->buffer != NULL)
+	if (p->buffer != NULL) {
 		free(p->buffer);
+		/* clear: drop counted pointer then size */
+		p->buffer = NULL;
+		p->bufsize = 0;
+	}
 	pcap_freecode(&p->fcode);
 }
 

--- a/sf-pcap.c
+++ b/sf-pcap.c
@@ -496,8 +496,9 @@ grow_buffer(pcap_t *p, u_int bufsize)
 		snprintf(p->errbuf, PCAP_ERRBUF_SIZE, "out of memory");
 		return (0);
 	}
-	p->buffer = bigger_buffer;
+	/* counted_by: set capacity before pointer */
 	p->bufsize = bufsize;
+	p->buffer = bigger_buffer;
 	return (1);
 }
 

--- a/sf-pcapng.c
+++ b/sf-pcapng.c
@@ -342,6 +342,8 @@ read_block(FILE *fp, pcap_t *p, struct block_cursor *cursor, char *errbuf)
 			snprintf(errbuf, PCAP_ERRBUF_SIZE, "out of memory");
 			return (-1);
 		}
+		/* counted_by: set capacity before pointer */
+		p->bufsize = bhdr.total_length;
 		p->buffer = bigger_buffer;
 	}
 


### PR DESCRIPTION
## Summary
Secure-by-design memory-safety hardening. Annotates `pcap_t.buffer` with optional Clang `-fbounds-safety` / counted-by-style macros bound to `bufsize`. Default builds unchanged (`ENABLE_FBOUNDS_SAFETY` OFF).

Contributor: Jeff Bindel via `LaptopsPlural`. Not a vulnerability PoC.

## Test plan
- [ ] Default build
- [ ] Existing tests
- [ ] Optional bounds-safety ON with supporting Clang (maintainers)
