### PR TITLE
rpcap: Allocate a sockaddr_storage for deserialized addresses.

### DIFF
--- a/pcap-rpcap.c
+++ b/pcap-rpcap.c
@@ -308,7 +308,7 @@ rpcap_deseraddr(struct rpcap_sockaddr *sockaddrin, struct sockaddr **sockaddrout
 		struct rpcap_sockaddr_in *sockaddrin_ipv4;
 		struct sockaddr_in *sockaddrout_ipv4;
 
-		(*sockaddrout) = (struct sockaddr *) malloc(sizeof(struct sockaddr_in));
+		(*sockaddrout) = (struct sockaddr *) malloc(sizeof(struct sockaddr_storage));
 		if ((*sockaddrout) == NULL)
 		{
 			pcapint_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,
@@ -337,7 +337,7 @@ rpcap_deseraddr(struct rpcap_sockaddr *sockaddrin, struct sockaddr **sockaddrout
 		struct rpcap_sockaddr_in6 *sockaddrin_ipv6;
 		struct sockaddr_in6 *sockaddrout_ipv6;
 
-		(*sockaddrout) = (struct sockaddr *) malloc(sizeof(struct sockaddr_in6));
+		(*sockaddrout) = (struct sockaddr *) malloc(sizeof(struct sockaddr_storage));
 		if ((*sockaddrout) == NULL)
 		{
 			pcapint_fmt_errmsg_for_errno(errbuf, PCAP_ERRBUF_SIZE,


### PR DESCRIPTION
Fixes #1738.

`rpcap_deseraddr()` allocates `sizeof(struct sockaddr_in)` or `sizeof(struct sockaddr_in6)` and returns the result through a `struct sockaddr *`. Where `struct sockaddr` is larger than the address structure allocated, the object is smaller than the type it is used as. On Haiku (`struct sockaddr` 32 bytes, `struct sockaddr_in6` 28) Clang 22 reports:

```
pcap-rpcap.c:340:35: warning: allocation of insufficient size '28' for type 'struct sockaddr' with size '32' [-Walloc-size]
```

This allocates a `struct sockaddr_storage` in both branches. It is defined to be large enough for any supported address family, and libpcap already uses it for this purpose in `sockutils.c`, `fad-getad.c`, `rpcapd/daemon.c` and others. The IPv4 branch has the same pattern as the IPv6 one the warning names, so both are changed.

The callers (`pcap_findalldevs_ex()` in the same file) only store these pointers in a `struct pcap_addr` and later free them, so nothing depends on the allocation size.

### Testing

Built on macOS 26 (arm64, Apple clang 21) with `cmake -DENABLE_REMOTE=ON`: builds clean, with no new warnings.

I could not reproduce the original diagnostic locally: Apple clang 21 does not support `-Walloc-size`, and on macOS `struct sockaddr` is 16 bytes (`sockaddr_in` 16, `sockaddr_in6` 28, `sockaddr_storage` 128), so an allocation is never smaller than `struct sockaddr`. The change is therefore argued from the sizes rather than from a reproduced warning.
